### PR TITLE
MX-170: Implement Unit Test Cases for the Self Service Plugin

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -21,14 +21,17 @@ jobs:
           distribution: 'zulu'
           cache: 'maven'
 
-      #- name: Validate Code Formatting
-        # Enforce coding style guidelines immediately.
-        # Fails fast if the code does not adhere to the project's Spotless configuration.
-        #run: mvn spotless:check --file pom.xml
+      - name: Build and Run Unit Tests
+        # Compiles, runs unit tests, and packages the JAR.
+        # Smoke/integration tests (*SmokeTest, *IntegrationTest) are excluded by surefire config.
+        run: mvn -B clean package -U -Dspotless.check.skip=true --file pom.xml
 
-      - name: Build and Package
-        # Compiles the code and packages the JAR artifacts.
-        # Tests are currently skipped (-DskipTests) as integration tests require
-        # a running Fineract backend instance (localhost:8443) which is not
-        # available in this standard runner environment.
-        run: mvn -B clean package -U -DskipTests --file pom.xml
+      - name: Upload Test Reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-reports
+          path: |
+            target/surefire-reports/
+            target/site/jacoco/
+          retention-days: 14

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,20 @@
     <lombok.version>1.18.44</lombok.version>
     <spotless.version>3.4.0</spotless.version>
     <swagger.version>2.2.46</swagger.version>
+    <testcontainers.version>1.20.6</testcontainers.version>
   </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.testcontainers</groupId>
+        <artifactId>testcontainers-bom</artifactId>
+        <version>${testcontainers.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <dependencies>      
     <dependency>
@@ -114,6 +127,22 @@
       <artifactId>truth</artifactId>
       <version>${truth.version}</version>
       <scope>compile</scope>
+    </dependency>
+    <!-- Test: Testcontainers for integration/smoke tests -->
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>postgresql</artifactId>
+      <scope>test</scope>
     </dependency>
     <!-- Apache Fineract Libraries -->
     <dependency>
@@ -435,6 +464,42 @@
   </pluginRepositories>
 
   <build>
+    <plugins>
+      <!-- Surefire: run unit tests -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <includes>
+            <include>**/*Test.java</include>
+          </includes>
+          <excludes>
+            <exclude>**/*SmokeTest.java</exclude>
+            <exclude>**/*IntegrationTest.java</exclude>
+          </excludes>
+        </configuration>
+      </plugin>
+      <!-- JaCoCo: code coverage -->
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>0.8.13</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>report</id>
+            <phase>test</phase>
+            <goals>
+              <goal>report</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
     <pluginManagement>
       <plugins>
         <plugin>

--- a/src/test/java/org/apache/fineract/selfservice/config/SelfServiceModuleIsEnabledConditionTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/config/SelfServiceModuleIsEnabledConditionTest.java
@@ -1,0 +1,25 @@
+package org.apache.fineract.selfservice.config;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.apache.fineract.infrastructure.core.config.FineractProperties;
+import org.junit.jupiter.api.Test;
+
+class SelfServiceModuleIsEnabledConditionTest {
+
+  @Test
+  void matches_shouldAlwaysReturnTrueRegardlessOfProperties() {
+    SelfServiceModuleIsEnabledCondition condition = new SelfServiceModuleIsEnabledCondition();
+    FineractProperties properties = mock(FineractProperties.class);
+    // The matches method always returns true — the module is always enabled when loaded.
+    // This documents that there is currently no configuration toggle for the module.
+    assertTrue(condition.matches(properties));
+  }
+
+  @Test
+  void matches_shouldReturnTrueEvenWithNullProperties() {
+    SelfServiceModuleIsEnabledCondition condition = new SelfServiceModuleIsEnabledCondition();
+    assertTrue(condition.matches(null));
+  }
+}

--- a/src/test/java/org/apache/fineract/selfservice/loanaccount/data/SelfLoansDataValidatorTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/loanaccount/data/SelfLoansDataValidatorTest.java
@@ -1,0 +1,89 @@
+package org.apache.fineract.selfservice.loanaccount.data;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.HashMap;
+import org.apache.fineract.infrastructure.core.exception.InvalidJsonException;
+import org.apache.fineract.infrastructure.core.exception.PlatformApiDataValidationException;
+import org.apache.fineract.infrastructure.core.serialization.FromJsonHelper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class SelfLoansDataValidatorTest {
+
+  private SelfLoansDataValidator validator;
+
+  @BeforeEach
+  void setUp() {
+    FromJsonHelper fromJsonHelper = new FromJsonHelper();
+    validator = new SelfLoansDataValidator(fromJsonHelper);
+  }
+
+  // --- validateLoanApplication ---
+
+  @Test
+  void validateLoanApplication_shouldThrowOnBlankJson() {
+    assertThrows(InvalidJsonException.class, () -> validator.validateLoanApplication(""));
+    assertThrows(InvalidJsonException.class, () -> validator.validateLoanApplication("   "));
+  }
+
+  @Test
+  void validateLoanApplication_shouldThrowOnMissingClientId() {
+    String json = "{\"loanType\": \"individual\"}";
+    assertThrows(
+        PlatformApiDataValidationException.class, () -> validator.validateLoanApplication(json));
+  }
+
+  @Test
+  void validateLoanApplication_shouldThrowOnMissingLoanType() {
+    String json = "{\"clientId\": \"1\"}";
+    assertThrows(
+        PlatformApiDataValidationException.class, () -> validator.validateLoanApplication(json));
+  }
+
+  @Test
+  void validateLoanApplication_shouldThrowOnInvalidLoanType() {
+    String json = "{\"loanType\": \"group\", \"clientId\": \"1\"}";
+    assertThrows(
+        PlatformApiDataValidationException.class, () -> validator.validateLoanApplication(json));
+  }
+
+  @Test
+  void validateLoanApplication_shouldReturnClientIdOnValidInput() {
+    String json = "{\"loanType\": \"individual\", \"clientId\": \"42\"}";
+    HashMap<String, Object> result = validator.validateLoanApplication(json);
+    assertEquals(42L, result.get("clientId"));
+  }
+
+  // --- validateModifyLoanApplication ---
+
+  @Test
+  void validateModifyLoanApplication_shouldReturnEmptyMapWhenNoParams() {
+    String json = "{}";
+    HashMap<String, Object> result = validator.validateModifyLoanApplication(json);
+    assertFalse(result.containsKey("clientId"));
+  }
+
+  @Test
+  void validateModifyLoanApplication_shouldReturnClientIdWhenPresent() {
+    String json = "{\"clientId\": \"99\"}";
+    HashMap<String, Object> result = validator.validateModifyLoanApplication(json);
+    assertEquals(99L, result.get("clientId"));
+  }
+
+  @Test
+  void validateModifyLoanApplication_shouldThrowOnInvalidLoanType() {
+    String json = "{\"loanType\": \"group\"}";
+    assertThrows(
+        PlatformApiDataValidationException.class,
+        () -> validator.validateModifyLoanApplication(json));
+  }
+
+  @Test
+  void validateModifyLoanApplication_shouldAcceptIndividualLoanType() {
+    String json = "{\"loanType\": \"individual\", \"clientId\": \"5\"}";
+    HashMap<String, Object> result = validator.validateModifyLoanApplication(json);
+    assertEquals(5L, result.get("clientId"));
+  }
+}

--- a/src/test/java/org/apache/fineract/selfservice/registration/SelfServiceApiConstantsTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/registration/SelfServiceApiConstantsTest.java
@@ -1,0 +1,57 @@
+package org.apache.fineract.selfservice.registration;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class SelfServiceApiConstantsTest {
+
+  @Test
+  void registrationRequestDataParameters_shouldContainAllRequiredFields() {
+    assertTrue(SelfServiceApiConstants.REGISTRATION_REQUEST_DATA_PARAMETERS.contains("username"));
+    assertTrue(
+        SelfServiceApiConstants.REGISTRATION_REQUEST_DATA_PARAMETERS.contains("accountNumber"));
+    assertTrue(SelfServiceApiConstants.REGISTRATION_REQUEST_DATA_PARAMETERS.contains("password"));
+    assertTrue(SelfServiceApiConstants.REGISTRATION_REQUEST_DATA_PARAMETERS.contains("firstName"));
+    assertTrue(SelfServiceApiConstants.REGISTRATION_REQUEST_DATA_PARAMETERS.contains("lastName"));
+    assertTrue(SelfServiceApiConstants.REGISTRATION_REQUEST_DATA_PARAMETERS.contains("email"));
+    assertTrue(
+        SelfServiceApiConstants.REGISTRATION_REQUEST_DATA_PARAMETERS.contains(
+            "authenticationMode"));
+    assertTrue(SelfServiceApiConstants.REGISTRATION_REQUEST_DATA_PARAMETERS.contains("middleName"));
+  }
+
+  @Test
+  void registrationRequestDataParameters_shouldBeImmutable() {
+    assertThrows(
+        UnsupportedOperationException.class,
+        () -> SelfServiceApiConstants.REGISTRATION_REQUEST_DATA_PARAMETERS.add("illegal"));
+  }
+
+  @Test
+  void createUserRequestDataParameters_shouldContainRequiredFields() {
+    assertTrue(SelfServiceApiConstants.CREATE_USER_REQUEST_DATA_PARAMETERS.contains("requestId"));
+    assertTrue(
+        SelfServiceApiConstants.CREATE_USER_REQUEST_DATA_PARAMETERS.contains(
+            "authenticationToken"));
+    assertEquals(2, SelfServiceApiConstants.CREATE_USER_REQUEST_DATA_PARAMETERS.size());
+  }
+
+  @Test
+  void createUserRequestDataParameters_shouldBeImmutable() {
+    assertThrows(
+        UnsupportedOperationException.class,
+        () -> SelfServiceApiConstants.CREATE_USER_REQUEST_DATA_PARAMETERS.add("illegal"));
+  }
+
+  @Test
+  void selfServiceUserRole_shouldBeCorrect() {
+    assertEquals("Self Service User", SelfServiceApiConstants.SELF_SERVICE_USER_ROLE);
+  }
+
+  @Test
+  void createRequestSuccessMessage_shouldBeCorrect() {
+    assertEquals(
+        "Self service request created.", SelfServiceApiConstants.createRequestSuccessMessage);
+  }
+}

--- a/src/test/java/org/apache/fineract/selfservice/registration/domain/SelfServiceRegistrationTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/registration/domain/SelfServiceRegistrationTest.java
@@ -1,0 +1,67 @@
+package org.apache.fineract.selfservice.registration.domain;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+
+import org.apache.fineract.portfolio.client.domain.Client;
+import org.junit.jupiter.api.Test;
+
+class SelfServiceRegistrationTest {
+
+  @Test
+  void instance_shouldCreateRegistrationWithAllFields() {
+    Client client = mock(Client.class);
+    SelfServiceRegistration reg =
+        SelfServiceRegistration.instance(
+            client,
+            "000000001",
+            "Pedro",
+            "Marmol",
+            "Perez",
+            "5522649498",
+            "pedro@test.com",
+            "1234",
+            "pedro.marmol",
+            "SecurePass123#");
+
+    assertEquals(client, reg.getClient());
+    assertEquals("000000001", reg.getAccountNumber());
+    assertEquals("Pedro", reg.getFirstName());
+    assertEquals("Marmol", reg.getMiddleName());
+    assertEquals("Perez", reg.getLastName());
+    assertEquals("5522649498", reg.getMobileNumber());
+    assertEquals("pedro@test.com", reg.getEmail());
+    assertEquals("1234", reg.getAuthenticationToken());
+    assertEquals("pedro.marmol", reg.getUsername());
+    assertEquals("SecurePass123#", reg.getPassword());
+    assertNotNull(reg.getCreatedDate());
+  }
+
+  @Test
+  void instance_shouldHandleNullMiddleName() {
+    Client client = mock(Client.class);
+    SelfServiceRegistration reg =
+        SelfServiceRegistration.instance(
+            client,
+            "000000002",
+            "John",
+            null,
+            "Doe",
+            null,
+            "john@test.com",
+            "5678",
+            "john.doe",
+            "Pass456#");
+
+    assertNull(reg.getMiddleName());
+    assertNull(reg.getMobileNumber());
+    assertEquals("John", reg.getFirstName());
+  }
+
+  @Test
+  void defaultConstructor_shouldCreateEmptyInstance() {
+    SelfServiceRegistration reg = new SelfServiceRegistration();
+    assertNull(reg.getClient());
+    assertNull(reg.getFirstName());
+  }
+}

--- a/src/test/java/org/apache/fineract/selfservice/savings/data/SelfSavingsDataValidatorTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/savings/data/SelfSavingsDataValidatorTest.java
@@ -1,0 +1,55 @@
+package org.apache.fineract.selfservice.savings.data;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.HashMap;
+import org.apache.fineract.infrastructure.core.exception.InvalidJsonException;
+import org.apache.fineract.infrastructure.core.exception.PlatformApiDataValidationException;
+import org.apache.fineract.infrastructure.core.serialization.FromJsonHelper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class SelfSavingsDataValidatorTest {
+
+  private SelfSavingsDataValidator validator;
+
+  @BeforeEach
+  void setUp() {
+    FromJsonHelper fromJsonHelper = new FromJsonHelper();
+    validator = new SelfSavingsDataValidator(fromJsonHelper);
+  }
+
+  @Test
+  void validateSavingsApplication_shouldThrowOnBlankJson() {
+    assertThrows(InvalidJsonException.class, () -> validator.validateSavingsApplication(""));
+    assertThrows(InvalidJsonException.class, () -> validator.validateSavingsApplication("   "));
+  }
+
+  @Test
+  void validateSavingsApplication_shouldThrowOnMissingClientId() {
+    String json = "{\"productId\": 1}";
+    assertThrows(
+        PlatformApiDataValidationException.class, () -> validator.validateSavingsApplication(json));
+  }
+
+  @Test
+  void validateSavingsApplication_shouldThrowOnNullClientId() {
+    String json = "{\"clientId\": null}";
+    assertThrows(
+        PlatformApiDataValidationException.class, () -> validator.validateSavingsApplication(json));
+  }
+
+  @Test
+  void validateSavingsApplication_shouldReturnClientIdOnValidInput() {
+    String json = "{\"clientId\": 42}";
+    HashMap<String, Object> result = validator.validateSavingsApplication(json);
+    assertEquals(42L, result.get("clientId"));
+  }
+
+  @Test
+  void validateSavingsApplication_shouldAcceptClientIdWithOtherFields() {
+    String json = "{\"clientId\": 10, \"productId\": 1, \"locale\": \"en\"}";
+    HashMap<String, Object> result = validator.validateSavingsApplication(json);
+    assertEquals(10L, result.get("clientId"));
+  }
+}

--- a/src/test/java/org/apache/fineract/selfservice/shareaccounts/data/SelfShareAccountsDataValidatorTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/shareaccounts/data/SelfShareAccountsDataValidatorTest.java
@@ -1,0 +1,43 @@
+package org.apache.fineract.selfservice.shareaccounts.data;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.HashMap;
+import org.apache.fineract.infrastructure.core.exception.InvalidJsonException;
+import org.apache.fineract.infrastructure.core.exception.PlatformApiDataValidationException;
+import org.apache.fineract.infrastructure.core.serialization.FromJsonHelper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class SelfShareAccountsDataValidatorTest {
+
+  private SelfShareAccountsDataValidator validator;
+
+  @BeforeEach
+  void setUp() {
+    FromJsonHelper fromJsonHelper = new FromJsonHelper();
+    validator = new SelfShareAccountsDataValidator(fromJsonHelper);
+  }
+
+  @Test
+  void validateShareAccountApplication_shouldThrowOnBlankJson() {
+    assertThrows(InvalidJsonException.class, () -> validator.validateShareAccountApplication(""));
+    assertThrows(
+        InvalidJsonException.class, () -> validator.validateShareAccountApplication("   "));
+  }
+
+  @Test
+  void validateShareAccountApplication_shouldThrowOnMissingClientId() {
+    String json = "{\"productId\": 1}";
+    assertThrows(
+        PlatformApiDataValidationException.class,
+        () -> validator.validateShareAccountApplication(json));
+  }
+
+  @Test
+  void validateShareAccountApplication_shouldReturnClientIdOnValidInput() {
+    String json = "{\"clientId\": \"15\"}";
+    HashMap<String, Object> result = validator.validateShareAccountApplication(json);
+    assertEquals(15L, result.get("clientId"));
+  }
+}

--- a/src/test/java/org/apache/fineract/selfservice/useradministration/domain/AppSelfServiceUserTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/useradministration/domain/AppSelfServiceUserTest.java
@@ -1,0 +1,193 @@
+package org.apache.fineract.selfservice.useradministration.domain;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
+import org.apache.fineract.infrastructure.businessdate.domain.BusinessDateType;
+import org.apache.fineract.infrastructure.core.domain.FineractPlatformTenant;
+import org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil;
+import org.apache.fineract.infrastructure.security.exception.NoAuthorizationException;
+import org.apache.fineract.organisation.office.domain.Office;
+import org.apache.fineract.portfolio.client.domain.Client;
+import org.apache.fineract.useradministration.domain.Role;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+
+class AppSelfServiceUserTest {
+
+  @BeforeEach
+  void setUp() {
+    // AppSelfServiceUser constructor calls DateUtils.getLocalDateOfTenant()
+    // which requires a tenant in ThreadLocalContextUtil
+    FineractPlatformTenant tenant =
+        new FineractPlatformTenant(1L, "default", "Default Tenant", "UTC", null);
+    ThreadLocalContextUtil.setTenant(tenant);
+    // updatePassword calls DateUtils.getBusinessLocalDate() which needs business dates
+    HashMap<BusinessDateType, LocalDate> businessDates = new HashMap<>();
+    businessDates.put(BusinessDateType.BUSINESS_DATE, LocalDate.now());
+    businessDates.put(BusinessDateType.COB_DATE, LocalDate.now().minusDays(1));
+    ThreadLocalContextUtil.setBusinessDates(businessDates);
+  }
+
+  @AfterEach
+  void tearDown() {
+    ThreadLocalContextUtil.clearTenant();
+  }
+
+  private AppSelfServiceUser createUser(Set<Role> roles) {
+    Office office = mock(Office.class);
+    Collection<SimpleGrantedAuthority> authorities = new ArrayList<>();
+    authorities.add(new SimpleGrantedAuthority("DUMMY_ROLE"));
+    User springUser = new User("testuser", "password123", authorities);
+    Collection<Client> clients = new ArrayList<>();
+    return new AppSelfServiceUser(
+        office,
+        springUser,
+        roles,
+        "test@email.com",
+        "John",
+        "Doe",
+        null,
+        true,
+        true,
+        clients,
+        false);
+  }
+
+  @Test
+  void constructor_shouldSetAllFields() {
+    AppSelfServiceUser user = createUser(new HashSet<>());
+
+    assertEquals("testuser", user.getUsername());
+    assertEquals("John", user.getFirstname());
+    assertEquals("Doe", user.getLastname());
+    assertEquals("test@email.com", user.getEmail());
+    assertTrue(user.isEnabled());
+    assertTrue(user.isAccountNonExpired());
+    assertTrue(user.isAccountNonLocked());
+    assertTrue(user.isCredentialsNonExpired());
+    assertTrue(user.isSelfServiceUser());
+    assertTrue(user.getPasswordNeverExpires());
+    assertNotNull(user.getLastTimePasswordUpdated());
+  }
+
+  @Test
+  void getDisplayName_shouldReturnFullName() {
+    AppSelfServiceUser user = createUser(new HashSet<>());
+    assertEquals("John Doe", user.getDisplayName());
+  }
+
+  @Test
+  void delete_shouldSoftDelete() {
+    AppSelfServiceUser user = createUser(new HashSet<>());
+    user.delete();
+
+    assertTrue(user.isDeleted());
+    assertFalse(user.isEnabled());
+    assertFalse(user.isAccountNonExpired());
+    assertTrue(user.getUsername().contains("DELETED"));
+  }
+
+  @Test
+  void updatePassword_shouldChangePassword() {
+    AppSelfServiceUser user = createUser(new HashSet<>());
+    user.updatePassword("newEncodedPassword");
+
+    assertEquals("newEncodedPassword", user.getPassword());
+  }
+
+  @Test
+  void updatePassword_shouldThrowWhenCannotChangePassword() {
+    Office office = mock(Office.class);
+    Collection<SimpleGrantedAuthority> authorities = new ArrayList<>();
+    authorities.add(new SimpleGrantedAuthority("DUMMY"));
+    User springUser = new User("testuser", "password123", authorities);
+    // cannotChangePassword = true
+    AppSelfServiceUser user =
+        new AppSelfServiceUser(
+            office,
+            springUser,
+            new HashSet<>(),
+            "test@email.com",
+            "John",
+            "Doe",
+            null,
+            true,
+            true,
+            new ArrayList<>(),
+            true);
+
+    assertThrows(NoAuthorizationException.class, () -> user.updatePassword("newPassword"));
+  }
+
+  @Test
+  void updateRoles_shouldReplaceRoles() {
+    AppSelfServiceUser user = createUser(new HashSet<>());
+    assertTrue(user.getRoles().isEmpty());
+
+    Set<Role> newRoles = new HashSet<>();
+    Role mockRole = mock(Role.class);
+    newRoles.add(mockRole);
+    user.updateRoles(newRoles);
+
+    assertEquals(1, user.getRoles().size());
+  }
+
+  @Test
+  void updateRoles_shouldNotReplaceWithEmptySet() {
+    Set<Role> initialRoles = new HashSet<>();
+    Role mockRole = mock(Role.class);
+    initialRoles.add(mockRole);
+    AppSelfServiceUser user = createUser(initialRoles);
+
+    user.updateRoles(new HashSet<>());
+    // Empty set should not replace
+    assertEquals(1, user.getRoles().size());
+  }
+
+  @Test
+  void changeOffice_shouldUpdateOffice() {
+    AppSelfServiceUser user = createUser(new HashSet<>());
+    Office newOffice = mock(Office.class);
+    user.changeOffice(newOffice);
+    assertSame(newOffice, user.getOffice());
+  }
+
+  @Test
+  void isNotEnabled_shouldBeInverseOfIsEnabled() {
+    AppSelfServiceUser user = createUser(new HashSet<>());
+    assertTrue(user.isEnabled());
+    assertFalse(user.isNotEnabled());
+  }
+
+  @Test
+  void hasIdOf_shouldThrowNpeWhenIdIsNull() {
+    AppSelfServiceUser user = createUser(new HashSet<>());
+    // Without JPA, id is null — the entity's hasIdOf() does not handle this gracefully.
+    // This documents a potential bug: getId().equals() throws NPE when id is null.
+    assertThrows(NullPointerException.class, () -> user.hasIdOf(999L));
+  }
+
+  @Test
+  void toString_shouldContainUsername() {
+    AppSelfServiceUser user = createUser(new HashSet<>());
+    String str = user.toString();
+    assertTrue(str.contains("testuser"));
+  }
+
+  @Test
+  void getStaffId_shouldReturnNullWhenNoStaff() {
+    AppSelfServiceUser user = createUser(new HashSet<>());
+    assertNull(user.getStaffId());
+    assertNull(user.getStaff());
+  }
+}


### PR DESCRIPTION
## What this PR does

Sets up the testing foundation for the self-service plugin — infrastructure, CI, and unit tests for stable code.

### Unit Tests (40 tests across 7 classes)

The self-service module had zero test coverage in Fineract core. This PR adds tests for code that is stable and unlikely to change as the API fix tickets (MX-176 through MX-212) are worked on:

- `AppSelfServiceUserTest` (12) — entity construction, roles, password, soft delete, display name
- `SelfLoansDataValidatorTest` (9) — loan application and modify validation
- `SelfServiceApiConstantsTest` (6) — field presence, immutability, constant values
- `SelfSavingsDataValidatorTest` (5) — savings application validation
- `SelfShareAccountsDataValidatorTest` (3) — share account validation
- `SelfServiceRegistrationTest` (3) — entity factory and field mapping
- `SelfServiceModuleIsEnabledConditionTest` (2) — config condition

> Tests for actively changing code (security context, registration service) are intentionally excluded — those will ship alongside their respective API fix PRs.

### Build & CI

- **Testcontainers** — dependencies added for future integration tests
- **JaCoCo** — code coverage reporting
- **Surefire** — configured to run `*Test.java`, exclude `*SmokeTest.java` and `*IntegrationTest.java`
- **CI pipeline** — now runs unit tests on every push/PR (previously skipped all tests with `-DskipTests`)

### Bug found during testing

`AppSelfServiceUser.hasIdOf(Long)` throws a `NullPointerException` when the entity id is null (before JPA persistence). Documented in the test, will be fixed in a follow-up PR.
