### PR TITLE
MX-212: Fix the API 07. GET LIST OF CLIENT TRANSACTION DETAIL

### DIFF
--- a/src/main/java/org/apache/fineract/selfservice/client/api/SelfClientsApiResource.java
+++ b/src/main/java/org/apache/fineract/selfservice/client/api/SelfClientsApiResource.java
@@ -68,16 +68,22 @@ import org.apache.fineract.infrastructure.documentmanagement.data.ImageCreateRes
 import org.apache.fineract.infrastructure.documentmanagement.data.ImageDeleteRequest;
 import org.apache.fineract.infrastructure.documentmanagement.data.ImageDeleteResponse;
 import org.apache.fineract.infrastructure.documentmanagement.service.ImageReadPlatformService;
-import org.apache.fineract.infrastructure.security.service.PlatformSecurityContext;
+import org.apache.fineract.infrastructure.core.api.ApiRequestParameterHelper;
+import org.apache.fineract.infrastructure.core.serialization.ApiRequestJsonSerializationSettings;
+import org.apache.fineract.infrastructure.core.serialization.DefaultToApiJsonSerializer;
+import org.apache.fineract.infrastructure.core.service.Page;
+import org.apache.fineract.infrastructure.core.service.SearchParameters;
 import org.apache.fineract.portfolio.client.api.ClientApiConstants;
 import org.apache.fineract.portfolio.client.api.ClientChargesApiResource;
-import org.apache.fineract.portfolio.client.api.ClientTransactionsApiResource;
 import org.apache.fineract.portfolio.client.api.ClientsApiResource;
+import org.apache.fineract.portfolio.client.data.ClientTransactionData;
 import org.apache.fineract.portfolio.client.exception.ClientNotFoundException;
+import org.apache.fineract.portfolio.client.service.ClientTransactionReadPlatformService;
 import org.apache.fineract.selfservice.client.data.SelfClientDataValidator;
 import org.apache.fineract.selfservice.client.service.AppuserClientMapperReadService;
 import org.apache.fineract.selfservice.config.SelfServiceModuleIsEnabledCondition;
-import org.apache.fineract.useradministration.domain.AppUser;
+import org.apache.fineract.selfservice.security.service.PlatformSelfServiceSecurityContext;
+import org.apache.fineract.selfservice.useradministration.domain.AppSelfServiceUser;
 import org.apache.fineract.util.StreamResponseUtil;
 import org.glassfish.jersey.media.multipart.FormDataBodyPart;
 import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
@@ -92,10 +98,12 @@ import org.springframework.stereotype.Component;
 @Conditional(SelfServiceModuleIsEnabledCondition.class)
 public class SelfClientsApiResource {
 
-  private final PlatformSecurityContext context;
+  private final PlatformSelfServiceSecurityContext context;
   private final ClientsApiResource clientApiResource;
   private final ClientChargesApiResource clientChargesApiResource;
-  private final ClientTransactionsApiResource clientTransactionsApiResource;
+  private final ClientTransactionReadPlatformService clientTransactionReadPlatformService;
+  private final DefaultToApiJsonSerializer<ClientTransactionData> clientTransactionSerializer;
+  private final ApiRequestParameterHelper apiRequestParameterHelper;
   private final AppuserClientMapperReadService appUserClientMapperReadService;
   private final SelfClientDataValidator dataValidator;
   private final ImageReadPlatformService imageReadPlatformService;
@@ -399,8 +407,14 @@ public class SelfClientsApiResource {
 
     validateAppuserClientsMapping(clientId);
 
-    return this.clientTransactionsApiResource.retrieveAllClientTransactions(
-        clientId, uriInfo, offset, limit);
+    final SearchParameters searchParameters =
+        SearchParameters.builder().limit(limit).offset(offset).build();
+    final Page<ClientTransactionData> clientTransactions =
+        this.clientTransactionReadPlatformService.retrieveAllTransactions(
+            clientId, searchParameters);
+    final ApiRequestJsonSerializationSettings settings =
+        this.apiRequestParameterHelper.process(uriInfo.getQueryParameters());
+    return this.clientTransactionSerializer.serialize(settings, clientTransactions);
   }
 
   @GET
@@ -435,12 +449,15 @@ public class SelfClientsApiResource {
 
     validateAppuserClientsMapping(clientId);
 
-    return this.clientTransactionsApiResource.retrieveClientTransaction(
-        clientId, transactionId, uriInfo);
+    final ClientTransactionData clientTransaction =
+        this.clientTransactionReadPlatformService.retrieveTransaction(clientId, transactionId);
+    final ApiRequestJsonSerializationSettings settings =
+        this.apiRequestParameterHelper.process(uriInfo.getQueryParameters());
+    return this.clientTransactionSerializer.serialize(settings, clientTransaction);
   }
 
   private void validateAppuserClientsMapping(final Long clientId) {
-    AppUser user = this.context.authenticatedUser();
+    AppSelfServiceUser user = this.context.authenticatedSelfServiceUser();
     final boolean mappedClientId =
         this.appUserClientMapperReadService.isClientMappedToUser(clientId, user.getId());
     if (!mappedClientId) {

--- a/src/test/java/org/apache/fineract/selfservice/client/api/SelfClientsApiResourceTransactionTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/client/api/SelfClientsApiResourceTransactionTest.java
@@ -1,0 +1,170 @@
+package org.apache.fineract.selfservice.client.api;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.UriInfo;
+import org.apache.fineract.infrastructure.core.api.ApiRequestParameterHelper;
+import org.apache.fineract.infrastructure.core.serialization.ApiRequestJsonSerializationSettings;
+import org.apache.fineract.infrastructure.core.serialization.DefaultToApiJsonSerializer;
+import org.apache.fineract.infrastructure.core.service.Page;
+import org.apache.fineract.infrastructure.core.service.SearchParameters;
+import org.apache.fineract.portfolio.client.data.ClientTransactionData;
+import org.apache.fineract.portfolio.client.exception.ClientNotFoundException;
+import org.apache.fineract.portfolio.client.service.ClientTransactionReadPlatformService;
+import org.apache.fineract.selfservice.client.service.AppuserClientMapperReadService;
+import org.apache.fineract.selfservice.security.service.PlatformSelfServiceSecurityContext;
+import org.apache.fineract.selfservice.useradministration.domain.AppSelfServiceUser;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SelfClientsApiResourceTransactionTest {
+
+  @Mock private PlatformSelfServiceSecurityContext context;
+  @Mock private ClientTransactionReadPlatformService clientTransactionReadPlatformService;
+  @Mock private DefaultToApiJsonSerializer<ClientTransactionData> clientTransactionSerializer;
+  @Mock private ApiRequestParameterHelper apiRequestParameterHelper;
+  @Mock private AppuserClientMapperReadService appUserClientMapperReadService;
+  @Mock private AppSelfServiceUser selfServiceUser;
+  @Mock private UriInfo uriInfo;
+
+  private SelfClientsApiResource resource;
+
+  @BeforeEach
+  void setUp() {
+    resource =
+        new SelfClientsApiResource(
+            context,
+            null, // clientApiResource
+            null, // clientChargesApiResource
+            clientTransactionReadPlatformService,
+            clientTransactionSerializer,
+            apiRequestParameterHelper,
+            appUserClientMapperReadService,
+            null, // dataValidator
+            null, // imageReadPlatformService
+            null, // commandPipeline
+            null, // imageResizeContentProcessor
+            null, // base64EncoderContentProcessor
+            null, // base64DecoderContentProcessor
+            null, // dataUrlEncoderContentProcessor
+            null, // dataUrlDecoderContentProcessor
+            null, // sizeContentProcessor
+            null); // contentDetectorManager
+  }
+
+  @Test
+  void retrieveClientTransaction_shouldReturnSerializedTransaction() {
+    Long clientId = 104L;
+    Long transactionId = 233L;
+    String expectedJson = "{\"id\":233}";
+
+    when(context.authenticatedSelfServiceUser()).thenReturn(selfServiceUser);
+    when(selfServiceUser.getId()).thenReturn(1L);
+    when(appUserClientMapperReadService.isClientMappedToUser(clientId, 1L)).thenReturn(true);
+    when(uriInfo.getQueryParameters()).thenReturn(new MultivaluedHashMap<>());
+
+    ApiRequestJsonSerializationSettings settings = mock(ApiRequestJsonSerializationSettings.class);
+    when(apiRequestParameterHelper.process(any())).thenReturn(settings);
+
+    ClientTransactionData transactionData = mock(ClientTransactionData.class);
+    when(clientTransactionReadPlatformService.retrieveTransaction(clientId, transactionId))
+        .thenReturn(transactionData);
+    when(clientTransactionSerializer.serialize(eq(settings), eq(transactionData)))
+        .thenReturn(expectedJson);
+
+    String result = resource.retrieveClientTransaction(clientId, transactionId, uriInfo);
+
+    assertEquals(expectedJson, result);
+    verify(clientTransactionReadPlatformService).retrieveTransaction(clientId, transactionId);
+  }
+
+  @Test
+  void retrieveClientTransaction_shouldThrowWhenClientNotMapped() {
+    Long clientId = 999L;
+    Long transactionId = 1L;
+
+    when(context.authenticatedSelfServiceUser()).thenReturn(selfServiceUser);
+    when(selfServiceUser.getId()).thenReturn(1L);
+    when(appUserClientMapperReadService.isClientMappedToUser(clientId, 1L)).thenReturn(false);
+
+    assertThrows(
+        ClientNotFoundException.class,
+        () -> resource.retrieveClientTransaction(clientId, transactionId, uriInfo));
+
+    verifyNoInteractions(clientTransactionReadPlatformService);
+  }
+
+  @Test
+  void retrieveAllClientTransactions_shouldReturnSerializedPage() {
+    Long clientId = 104L;
+    Integer offset = 0;
+    Integer limit = 10;
+    String expectedJson = "{\"totalFilteredRecords\":1}";
+
+    when(context.authenticatedSelfServiceUser()).thenReturn(selfServiceUser);
+    when(selfServiceUser.getId()).thenReturn(1L);
+    when(appUserClientMapperReadService.isClientMappedToUser(clientId, 1L)).thenReturn(true);
+    when(uriInfo.getQueryParameters()).thenReturn(new MultivaluedHashMap<>());
+
+    ApiRequestJsonSerializationSettings settings = mock(ApiRequestJsonSerializationSettings.class);
+    when(apiRequestParameterHelper.process(any())).thenReturn(settings);
+
+    @SuppressWarnings("unchecked")
+    Page<ClientTransactionData> page = mock(Page.class);
+    when(clientTransactionReadPlatformService.retrieveAllTransactions(eq(clientId), any(SearchParameters.class)))
+        .thenReturn(page);
+    when(clientTransactionSerializer.serialize(eq(settings), eq(page)))
+        .thenReturn(expectedJson);
+
+    String result = resource.retrieveAllClientTransactions(clientId, uriInfo, offset, limit);
+
+    assertEquals(expectedJson, result);
+    verify(clientTransactionReadPlatformService)
+        .retrieveAllTransactions(eq(clientId), any(SearchParameters.class));
+  }
+
+  @Test
+  void retrieveAllClientTransactions_shouldThrowWhenClientNotMapped() {
+    Long clientId = 999L;
+
+    when(context.authenticatedSelfServiceUser()).thenReturn(selfServiceUser);
+    when(selfServiceUser.getId()).thenReturn(1L);
+    when(appUserClientMapperReadService.isClientMappedToUser(clientId, 1L)).thenReturn(false);
+
+    assertThrows(
+        ClientNotFoundException.class,
+        () -> resource.retrieveAllClientTransactions(clientId, uriInfo, 0, 10));
+
+    verifyNoInteractions(clientTransactionReadPlatformService);
+  }
+
+  @Test
+  void validateAppuserClientsMapping_usesAuthenticatedSelfServiceUser() {
+    Long clientId = 104L;
+    Long transactionId = 1L;
+
+    when(context.authenticatedSelfServiceUser()).thenReturn(selfServiceUser);
+    when(selfServiceUser.getId()).thenReturn(42L);
+    when(appUserClientMapperReadService.isClientMappedToUser(clientId, 42L)).thenReturn(true);
+    when(uriInfo.getQueryParameters()).thenReturn(new MultivaluedHashMap<>());
+    when(apiRequestParameterHelper.process(any()))
+        .thenReturn(mock(ApiRequestJsonSerializationSettings.class));
+    when(clientTransactionReadPlatformService.retrieveTransaction(anyLong(), anyLong()))
+        .thenReturn(mock(ClientTransactionData.class));
+    when(clientTransactionSerializer.serialize(any(ApiRequestJsonSerializationSettings.class), any(ClientTransactionData.class)))
+        .thenReturn("{}");
+
+    resource.retrieveClientTransaction(clientId, transactionId, uriInfo);
+
+    verify(context).authenticatedSelfServiceUser();
+    verify(context, never()).authenticatedUser(any());
+    verify(appUserClientMapperReadService).isClientMappedToUser(clientId, 42L);
+  }
+}


### PR DESCRIPTION

### Problem

`SelfClientsApiResource` injected `PlatformSecurityContext` (core) instead of `PlatformSelfServiceSecurityContext`. The core's `authenticatedUser()` does an `instanceof AppUser` check that fails for `AppSelfServiceUser`, throwing `UnAuthenticatedUserException` on every request.

Additionally, the transaction endpoints delegated to core's `ClientTransactionsApiResource`, which calls `validateHasReadPermission()` — a permission self-service users don't have.

### Fix

- Changed context injection to `PlatformSelfServiceSecurityContext`
- Changed `validateAppuserClientsMapping()` to use `authenticatedSelfServiceUser()`
- Replaced `ClientTransactionsApiResource` delegation with direct `ClientTransactionReadPlatformService` calls

### Files Changed

- `SelfClientsApiResource.java` — context fix + transaction refactor
- `SelfClientsApiResourceTransactionTest.java` — 5 unit tests (new)
