### PR TITLE
MX-175: Fix the API 03 Self-Service LOGIN

### DIFF
--- a/src/main/java/org/apache/fineract/selfservice/security/filter/SelfServiceBasicAuthenticationFilter.java
+++ b/src/main/java/org/apache/fineract/selfservice/security/filter/SelfServiceBasicAuthenticationFilter.java
@@ -1,0 +1,62 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.selfservice.security.filter;
+
+import java.io.IOException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.apache.fineract.infrastructure.businessdate.service.BusinessDateReadPlatformService;
+import org.apache.fineract.infrastructure.cache.service.CacheWritePlatformService;
+import org.apache.fineract.infrastructure.configuration.domain.ConfigurationDomainService;
+import org.apache.fineract.infrastructure.core.serialization.ToApiJsonSerializer;
+import org.apache.fineract.infrastructure.security.data.PlatformRequestLog;
+import org.apache.fineract.infrastructure.security.filter.TenantAwareBasicAuthenticationFilter;
+import org.apache.fineract.infrastructure.security.service.AuthTenantDetailsService;
+import org.apache.fineract.notification.service.UserNotificationService;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
+/**
+ * Overrides the core filter to avoid a ClassCastException in onSuccessfulAuthentication,
+ * where the parent casts the principal to AppUser. Self-service authentication returns
+ * AppSelfServiceUser which is not an AppUser.
+ */
+public class SelfServiceBasicAuthenticationFilter extends TenantAwareBasicAuthenticationFilter {
+
+    public SelfServiceBasicAuthenticationFilter(AuthenticationManager authenticationManager,
+            AuthenticationEntryPoint authenticationEntryPoint,
+            ToApiJsonSerializer<PlatformRequestLog> toApiJsonSerializer,
+            ConfigurationDomainService configurationDomainService,
+            CacheWritePlatformService cacheWritePlatformService,
+            UserNotificationService userNotificationService,
+            AuthTenantDetailsService basicAuthTenantDetailsService,
+            BusinessDateReadPlatformService businessDateReadPlatformService) {
+        super(authenticationManager, authenticationEntryPoint, toApiJsonSerializer,
+                configurationDomainService, cacheWritePlatformService, userNotificationService,
+                basicAuthTenantDetailsService, businessDateReadPlatformService);
+    }
+
+    @Override
+    protected void onSuccessfulAuthentication(HttpServletRequest request,
+            HttpServletResponse response, Authentication authResult) throws IOException {
+        // No-op: skip parent's AppUser cast. Self-service users don't need
+        // the X-Notification-Refresh header that the core filter sets.
+    }
+}

--- a/src/main/java/org/apache/fineract/selfservice/security/starter/SelfServiceSecurityConfiguration.java
+++ b/src/main/java/org/apache/fineract/selfservice/security/starter/SelfServiceSecurityConfiguration.java
@@ -34,7 +34,7 @@ import org.apache.fineract.infrastructure.instancemode.filter.FineractInstanceMo
 import org.apache.fineract.infrastructure.jobs.filter.LoanCOBApiFilter;
 import org.apache.fineract.infrastructure.jobs.filter.LoanCOBFilterHelper;
 import org.apache.fineract.infrastructure.security.data.PlatformRequestLog;
-import org.apache.fineract.infrastructure.security.filter.TenantAwareBasicAuthenticationFilter;
+import org.apache.fineract.selfservice.security.filter.SelfServiceBasicAuthenticationFilter;
 import org.apache.fineract.infrastructure.security.filter.TwoFactorAuthenticationFilter;
 import org.apache.fineract.infrastructure.security.service.AuthTenantDetailsService;
 import org.apache.fineract.infrastructure.security.service.PlatformUserDetailsChecker;
@@ -170,8 +170,8 @@ public class SelfServiceSecurityConfiguration {
         return new CallerIpTrackingFilter(fineractProperties);
     }
 
-    public TenantAwareBasicAuthenticationFilter tenantAwareBasicAuthenticationFilter() throws Exception {
-        TenantAwareBasicAuthenticationFilter filter = new TenantAwareBasicAuthenticationFilter(authenticationManagerBean(),
+    public SelfServiceBasicAuthenticationFilter tenantAwareBasicAuthenticationFilter() throws Exception {
+        SelfServiceBasicAuthenticationFilter filter = new SelfServiceBasicAuthenticationFilter(authenticationManagerBean(),
                 basicAuthenticationEntryPoint(), toApiJsonSerializer, configurationDomainService, cacheWritePlatformService,
                 userNotificationService, basicAuthTenantDetailsService, businessDateReadPlatformService);
 

--- a/src/main/java/org/apache/fineract/selfservice/useradministration/domain/AppSelfServiceUser.java
+++ b/src/main/java/org/apache/fineract/selfservice/useradministration/domain/AppSelfServiceUser.java
@@ -42,6 +42,7 @@ import org.apache.fineract.infrastructure.core.data.EnumOptionData;
 import org.apache.fineract.infrastructure.core.domain.AbstractPersistableCustom;
 import org.apache.fineract.infrastructure.core.service.DateUtils;
 import org.apache.fineract.infrastructure.security.domain.PlatformUser;
+import org.apache.fineract.selfservice.security.domain.PlatformSelfServiceUser;
 import org.apache.fineract.infrastructure.security.exception.NoAuthorizationException;
 import org.apache.fineract.infrastructure.security.service.PlatformPasswordEncoder;
 import org.apache.fineract.infrastructure.security.service.RandomPasswordGenerator;
@@ -58,7 +59,7 @@ import org.springframework.security.core.userdetails.User;
 
 @Entity
 @Table(name = "m_appselfservice_user", uniqueConstraints = @UniqueConstraint(columnNames = {"username"}, name = "username_org"))
-public class AppSelfServiceUser extends AbstractPersistableCustom<Long> implements PlatformUser {
+public class AppSelfServiceUser extends AbstractPersistableCustom<Long> implements PlatformUser, PlatformSelfServiceUser {
 
     @Column(name = "email", nullable = false, length = 100)
     private String email;
@@ -102,7 +103,7 @@ public class AppSelfServiceUser extends AbstractPersistableCustom<Long> implemen
     private Staff staff;
 
     @ManyToMany(fetch = FetchType.EAGER)
-    @JoinTable(name = "m_appuser_role", joinColumns = @JoinColumn(name = "appuser_id"), inverseJoinColumns = @JoinColumn(name = "role_id"))
+    @JoinTable(name = "m_appselfservice_user_role", joinColumns = @JoinColumn(name = "appuser_id"), inverseJoinColumns = @JoinColumn(name = "role_id"))
     private Set<Role> roles;
 
     @Column(name = "last_time_password_updated")

--- a/src/main/resources/db/changelog/tenant/module/selfservice/parts/001-create-selfserviceuser-initial-schema.xml
+++ b/src/main/resources/db/changelog/tenant/module/selfservice/parts/001-create-selfserviceuser-initial-schema.xml
@@ -167,4 +167,56 @@
                                  referencedTableName="m_client" validate="true"/>
     </changeSet>
 
+    <!-- Create dedicated self-service role mapping table to prevent ID collision with m_appuser_role -->
+    <changeSet author="fineract" id="ss-0001-9">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="m_appselfservice_user_role"/>
+            </not>
+        </preConditions>
+        <createTable tableName="m_appselfservice_user_role">
+            <column name="appuser_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="role_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+        <addPrimaryKey tableName="m_appselfservice_user_role"
+                       columnNames="appuser_id, role_id"/>
+        <addForeignKeyConstraint baseTableName="m_appselfservice_user_role"
+                                 baseColumnNames="appuser_id"
+                                 constraintName="fk_ss_user_role_appuser"
+                                 referencedTableName="m_appselfservice_user"
+                                 referencedColumnNames="id"/>
+        <addForeignKeyConstraint baseTableName="m_appselfservice_user_role"
+                                 baseColumnNames="role_id"
+                                 constraintName="fk_ss_user_role_role"
+                                 referencedTableName="m_role"
+                                 referencedColumnNames="id"/>
+    </changeSet>
+
+    <!--
+        Migrate existing self-service role data.
+        SECURITY: Filter by role name to prevent privilege escalation.
+        m_appuser and m_appselfservice_user use independent auto-increment sequences,
+        so IDs collide. An unfiltered JOIN would copy back-office admin roles.
+    -->
+    <changeSet author="fineract" id="ss-0001-10">
+        <preConditions onFail="MARK_RAN">
+            <tableExists tableName="m_appselfservice_user_role"/>
+            <tableExists tableName="m_appuser_role"/>
+            <tableExists tableName="m_appselfservice_user"/>
+        </preConditions>
+        <sql>
+            INSERT INTO m_appselfservice_user_role (appuser_id, role_id)
+            SELECT ar.appuser_id, ar.role_id
+            FROM m_appuser_role ar
+            INNER JOIN m_appselfservice_user su ON su.id = ar.appuser_id
+            INNER JOIN m_role r ON r.id = ar.role_id
+            WHERE r.name = 'Self Service User'
+            ON CONFLICT DO NOTHING;
+        </sql>
+    </changeSet>
+
 </databaseChangeLog>

--- a/src/test/java/org/apache/fineract/selfservice/security/filter/SelfServiceBasicAuthenticationFilterTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/security/filter/SelfServiceBasicAuthenticationFilterTest.java
@@ -1,0 +1,50 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.selfservice.security.filter;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.apache.fineract.selfservice.useradministration.domain.AppSelfServiceUser;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
+class SelfServiceBasicAuthenticationFilterTest {
+
+    @Test
+    void onSuccessfulAuthentication_doesNotThrow_withAppSelfServiceUserPrincipal() {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        Authentication auth = mock(Authentication.class);
+        AppSelfServiceUser selfServiceUser = mock(AppSelfServiceUser.class);
+        when(auth.getPrincipal()).thenReturn(selfServiceUser);
+
+        SelfServiceBasicAuthenticationFilter filter = new SelfServiceBasicAuthenticationFilter(
+                mock(AuthenticationManager.class), mock(AuthenticationEntryPoint.class),
+                null, null, null, null, null, null);
+
+        assertThatCode(() -> filter.onSuccessfulAuthentication(request, response, auth))
+                .doesNotThrowAnyException();
+    }
+}

--- a/src/test/java/org/apache/fineract/selfservice/security/service/TenantAwareJpaPlatformSelfServiceUserDetailsServiceTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/security/service/TenantAwareJpaPlatformSelfServiceUserDetailsServiceTest.java
@@ -1,0 +1,93 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.selfservice.security.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.apache.fineract.selfservice.security.domain.PlatformSelfServiceUserRepository;
+import org.apache.fineract.selfservice.useradministration.domain.AppSelfServiceUser;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+
+@ExtendWith(MockitoExtension.class)
+class TenantAwareJpaPlatformSelfServiceUserDetailsServiceTest {
+
+    @Mock
+    private PlatformSelfServiceUserRepository platformUserRepository;
+
+    @InjectMocks
+    private TenantAwareJpaPlatformSelfServiceUserDetailsService service;
+
+    private AppSelfServiceUser activeUser;
+
+    @BeforeEach
+    void setUp() {
+        activeUser = mock(AppSelfServiceUser.class);
+    }
+
+    @Test
+    void loadUserByUsername_returnsAppSelfServiceUser_whenUserIsActiveAndNotDeleted() {
+        when(platformUserRepository.findByUsernameAndDeletedAndEnabled("roberto@gmail.com", false, true))
+                .thenReturn(activeUser);
+
+        UserDetails result = service.loadUserByUsername("roberto@gmail.com");
+
+        assertThat(result).isSameAs(activeUser);
+        assertThat(result).isInstanceOf(AppSelfServiceUser.class);
+    }
+
+    @Test
+    void loadUserByUsername_throwsUsernameNotFoundException_whenUserNotFound() {
+        when(platformUserRepository.findByUsernameAndDeletedAndEnabled("unknown@test.com", false, true))
+                .thenReturn(null);
+
+        assertThatThrownBy(() -> service.loadUserByUsername("unknown@test.com"))
+                .isInstanceOf(UsernameNotFoundException.class)
+                .hasMessageContaining("unknown@test.com");
+    }
+
+    @Test
+    void loadUserByUsername_throwsUsernameNotFoundException_whenUserIsDeleted() {
+        // deleted=false, enabled=true means we only look for active users.
+        // A deleted user won't match these criteria, so the repository returns null.
+        when(platformUserRepository.findByUsernameAndDeletedAndEnabled("deleted@test.com", false, true))
+                .thenReturn(null);
+
+        assertThatThrownBy(() -> service.loadUserByUsername("deleted@test.com"))
+                .isInstanceOf(UsernameNotFoundException.class);
+    }
+
+    @Test
+    void loadUserByUsername_throwsUsernameNotFoundException_whenUserIsDisabled() {
+        when(platformUserRepository.findByUsernameAndDeletedAndEnabled("disabled@test.com", false, true))
+                .thenReturn(null);
+
+        assertThatThrownBy(() -> service.loadUserByUsername("disabled@test.com"))
+                .isInstanceOf(UsernameNotFoundException.class);
+    }
+}


### PR DESCRIPTION
### Problem

The `POST /api/v1/self/authentication` endpoint fails because the authentication pipeline queries the wrong database table. The `DaoAuthenticationProvider` was loading users from `m_appuser` (back-office staff) instead of `m_appselfservice_user` (self-service customers), causing every login attempt to fail with "user not found."

Additionally, `AppSelfServiceUser` shared the `m_appuser_role` join table with core `AppUser`. Since both tables use independent auto-increment IDs, role mappings would collide — a self-service customer could silently inherit back-office admin privileges.

### Changes

- **`AppSelfServiceUser`** — Implemented `PlatformSelfServiceUser` interface (required by the repository contract) and switched `@JoinTable` from `m_appuser_role` → `m_appselfservice_user_role`
- **`SelfServiceBasicAuthenticationFilter`** *(new)* — Overrides `onSuccessfulAuthentication()` to prevent `ClassCastException` where the core filter casts the principal to `AppUser`
- **`SelfServiceSecurityConfiguration`** — Wired the new filter in place of the core `TenantAwareBasicAuthenticationFilter`
- **Liquibase migration** — Created `m_appselfservice_user_role` table with FK constraints and migrated existing role data filtered strictly by the `Self Service User` role name to prevent privilege escalation
- **Unit tests** — 5 new tests covering the `UserDetailsService` lookup scenarios and filter safety

### Testing

- `mvn compile` — BUILD SUCCESS
- `mvn test` — 45 tests, 0 failures
