### PR TITLE
MX-175: Fix bean collision in self-service auth provider and add security wiring integration tests

### DIFF
--- a/src/main/java/org/apache/fineract/selfservice/security/api/SelfAuthenticationApiResource.java
+++ b/src/main/java/org/apache/fineract/selfservice/security/api/SelfAuthenticationApiResource.java
@@ -73,7 +73,7 @@ public class SelfAuthenticationApiResource {
         public String password;
     }
 
-    @Qualifier("customAuthenticationProvider")
+    @Qualifier("selfServiceAuthenticationProvider")
     private final DaoAuthenticationProvider customAuthenticationProvider;
     private final ToApiJsonSerializer<AppSelfServiceUserData> apiJsonSerializerService;
     private final PlatformSelfServiceSecurityContext springSecurityPlatformSecurityContext;

--- a/src/main/java/org/apache/fineract/selfservice/security/starter/SelfServiceSecurityConfiguration.java
+++ b/src/main/java/org/apache/fineract/selfservice/security/starter/SelfServiceSecurityConfiguration.java
@@ -171,39 +171,36 @@ public class SelfServiceSecurityConfiguration {
     }
 
     public SelfServiceBasicAuthenticationFilter tenantAwareBasicAuthenticationFilter() throws Exception {
-        SelfServiceBasicAuthenticationFilter filter = new SelfServiceBasicAuthenticationFilter(authenticationManagerBean(),
-                basicAuthenticationEntryPoint(), toApiJsonSerializer, configurationDomainService, cacheWritePlatformService,
+        SelfServiceBasicAuthenticationFilter filter = new SelfServiceBasicAuthenticationFilter(selfServiceAuthenticationManager(),
+                selfServiceBasicAuthenticationEntryPoint(), toApiJsonSerializer, configurationDomainService, cacheWritePlatformService,
                 userNotificationService, basicAuthTenantDetailsService, businessDateReadPlatformService);
 
-        // Scope the auth filter to /api/** so it can pick up the tenant header
         filter.setRequestMatcher(API_MATCHER.matcher("/api/**"));
         return filter;
     }
 
-    @Bean
-    public BasicAuthenticationEntryPoint basicAuthenticationEntryPoint() {
-        BasicAuthenticationEntryPoint basicAuthenticationEntryPoint = new BasicAuthenticationEntryPoint();
-        basicAuthenticationEntryPoint.setRealmName("Fineract Platform API");
-        return basicAuthenticationEntryPoint;
+    @Bean(name = "selfServiceBasicAuthenticationEntryPoint")
+    public BasicAuthenticationEntryPoint selfServiceBasicAuthenticationEntryPoint() {
+        BasicAuthenticationEntryPoint entryPoint = new BasicAuthenticationEntryPoint();
+        entryPoint.setRealmName("Fineract Self Service API");
+        return entryPoint;
     }
 
-    @Bean(name = "customAuthenticationProvider")
-    public DaoAuthenticationProvider authProvider() {
+    @Bean(name = "selfServiceAuthenticationProvider")
+    public DaoAuthenticationProvider selfServiceAuthProvider() {
         DaoAuthenticationProvider authProvider = new DaoAuthenticationProvider();
         authProvider.setUserDetailsService(userDetailsService);
-        authProvider.setPasswordEncoder(passwordEncoder());
+        authProvider.setPasswordEncoder(selfServicePasswordEncoder());
         authProvider.setPostAuthenticationChecks(platformUserDetailsChecker);
         return authProvider;
     }
 
-    @Bean
-    public PasswordEncoder passwordEncoder() {
+    public PasswordEncoder selfServicePasswordEncoder() {
         return PasswordEncoderFactories.createDelegatingPasswordEncoder();
     }
 
-    @Bean
-    public AuthenticationManager authenticationManagerBean() throws Exception {
-        ProviderManager providerManager = new ProviderManager(authProvider());
+    public AuthenticationManager selfServiceAuthenticationManager() throws Exception {
+        ProviderManager providerManager = new ProviderManager(selfServiceAuthProvider());
         providerManager.setEraseCredentialsAfterAuthentication(false);
         return providerManager;
     }

--- a/src/test/java/org/apache/fineract/selfservice/security/SelfServiceSecurityTestConfig.java
+++ b/src/test/java/org/apache/fineract/selfservice/security/SelfServiceSecurityTestConfig.java
@@ -1,0 +1,139 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.fineract.selfservice.security;
+
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+
+import org.apache.fineract.infrastructure.businessdate.service.BusinessDateReadPlatformService;
+import org.apache.fineract.infrastructure.cache.service.CacheWritePlatformService;
+import org.apache.fineract.infrastructure.configuration.domain.ConfigurationDomainService;
+import org.apache.fineract.infrastructure.core.config.FineractProperties;
+import org.apache.fineract.infrastructure.core.config.SecurityConfig;
+import org.apache.fineract.infrastructure.core.domain.FineractRequestContextHolder;
+import org.apache.fineract.infrastructure.core.filters.IdempotencyStoreHelper;
+import org.apache.fineract.infrastructure.core.serialization.ToApiJsonSerializer;
+import org.apache.fineract.infrastructure.core.service.MDCWrapper;
+import org.apache.fineract.infrastructure.jobs.filter.ProgressiveLoanModelCheckerFilter;
+import org.apache.fineract.infrastructure.security.data.PlatformRequestLog;
+import org.apache.fineract.infrastructure.security.domain.PlatformUserRepository;
+import org.apache.fineract.infrastructure.security.service.AuthTenantDetailsService;
+import org.apache.fineract.infrastructure.security.service.PlatformUserDetailsChecker;
+import org.apache.fineract.infrastructure.security.service.TenantAwareJpaPlatformUserDetailsService;
+import org.apache.fineract.notification.service.UserNotificationService;
+import org.apache.fineract.selfservice.security.domain.PlatformSelfServiceUserRepository;
+import org.apache.fineract.selfservice.security.service.TenantAwareJpaPlatformSelfServiceUserDetailsService;
+import org.apache.fineract.selfservice.security.starter.SelfServiceSecurityConfiguration;
+import org.springframework.boot.autoconfigure.web.ServerProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+
+@Configuration
+@Import({
+    SecurityConfig.class,
+    SelfServiceSecurityConfiguration.class
+})
+@EnableWebSecurity
+@EnableWebMvc
+@EnableConfigurationProperties(FineractProperties.class)
+public class SelfServiceSecurityTestConfig {
+
+    @Bean
+    @Primary
+    public TenantAwareJpaPlatformUserDetailsService coreUserDetailsService() {
+        return mock(TenantAwareJpaPlatformUserDetailsService.class);
+    }
+
+    @Bean
+    public TenantAwareJpaPlatformSelfServiceUserDetailsService selfServiceUserDetailsService() {
+        return mock(TenantAwareJpaPlatformSelfServiceUserDetailsService.class);
+    }
+
+    @Bean
+    public ServerProperties serverProperties() {
+        return mock(ServerProperties.class, RETURNS_DEEP_STUBS);
+    }
+
+    @Bean
+    @SuppressWarnings("unchecked")
+    public ToApiJsonSerializer<PlatformRequestLog> toApiJsonSerializer() {
+        return mock(ToApiJsonSerializer.class);
+    }
+
+    @Bean
+    public ConfigurationDomainService configurationDomainService() {
+        return mock(ConfigurationDomainService.class);
+    }
+
+    @Bean
+    public CacheWritePlatformService cacheWritePlatformService() {
+        return mock(CacheWritePlatformService.class);
+    }
+
+    @Bean
+    public UserNotificationService userNotificationService() {
+        return mock(UserNotificationService.class);
+    }
+
+    @Bean
+    public AuthTenantDetailsService basicAuthTenantDetailsService() {
+        return mock(AuthTenantDetailsService.class);
+    }
+
+    @Bean
+    public BusinessDateReadPlatformService businessDateReadPlatformService() {
+        return mock(BusinessDateReadPlatformService.class);
+    }
+
+    @Bean
+    public MDCWrapper mdcWrapper() {
+        return mock(MDCWrapper.class);
+    }
+
+    @Bean
+    public FineractRequestContextHolder fineractRequestContextHolder() {
+        return mock(FineractRequestContextHolder.class);
+    }
+
+    @Bean
+    public IdempotencyStoreHelper idempotencyStoreHelper() {
+        return mock(IdempotencyStoreHelper.class);
+    }
+
+    @Bean
+    public PlatformUserDetailsChecker platformUserDetailsChecker() {
+        return mock(PlatformUserDetailsChecker.class);
+    }
+
+    @Bean
+    public ProgressiveLoanModelCheckerFilter progressiveLoanModelCheckerFilter() {
+        return mock(ProgressiveLoanModelCheckerFilter.class);
+    }
+
+    @Bean
+    public PlatformUserRepository platformUserRepository() {
+        return mock(PlatformUserRepository.class);
+    }
+
+    @Bean
+    public PlatformSelfServiceUserRepository platformSelfServiceUserRepository() {
+        return mock(PlatformSelfServiceUserRepository.class);
+    }
+}

--- a/src/test/java/org/apache/fineract/selfservice/security/SelfServiceSecurityWiringTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/security/SelfServiceSecurityWiringTest.java
@@ -1,0 +1,81 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.fineract.selfservice.security;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+
+import org.apache.fineract.infrastructure.security.service.TenantAwareJpaPlatformUserDetailsService;
+import org.apache.fineract.selfservice.security.service.TenantAwareJpaPlatformSelfServiceUserDetailsService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.ApplicationContext;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = SelfServiceSecurityTestConfig.class)
+@TestPropertySource("classpath:application-test.properties")
+@WebAppConfiguration
+class SelfServiceSecurityWiringTest {
+
+    @Autowired
+    private ApplicationContext ctx;
+
+    @Qualifier("selfServiceAuthenticationProvider")
+    @Autowired
+    private DaoAuthenticationProvider selfServiceProvider;
+
+    @Test
+    void selfServiceAuthProvider_usesSelfServiceUserDetailsService() {
+        UserDetailsService uds = (UserDetailsService)
+                ReflectionTestUtils.getField(selfServiceProvider, "userDetailsService");
+        assertInstanceOf(TenantAwareJpaPlatformSelfServiceUserDetailsService.class, uds);
+    }
+
+    @Test
+    void selfServiceAuthProvider_isDistinctFromCoreProvider() {
+        DaoAuthenticationProvider coreProvider =
+                ctx.getBean("customAuthenticationProvider", DaoAuthenticationProvider.class);
+        assertNotSame(coreProvider, selfServiceProvider);
+    }
+
+    @Test
+    void coreAuthProvider_usesCoreUserDetailsService() {
+        DaoAuthenticationProvider coreProvider =
+                ctx.getBean("customAuthenticationProvider", DaoAuthenticationProvider.class);
+        UserDetailsService uds = (UserDetailsService)
+                ReflectionTestUtils.getField(coreProvider, "userDetailsService");
+        assertInstanceOf(TenantAwareJpaPlatformUserDetailsService.class, uds);
+    }
+
+    @Test
+    void selfServiceEntryPoint_exists() {
+        assertNotNull(ctx.getBean("selfServiceBasicAuthenticationEntryPoint"));
+    }
+
+    @Test
+    void selfServiceFilterChain_exists() {
+        assertNotNull(ctx.getBean("selfServiceSecurityFilterChain"));
+    }
+}

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,0 +1,8 @@
+spring.main.allow-bean-definition-overriding=false
+
+fineract.security.basicauth.enabled=true
+fineract.security.2fa.enabled=false
+fineract.security.cors.enabled=false
+fineract.security.hsts.enabled=false
+fineract.ip-tracking.enabled=false
+fineract.module.selfservice.enabled=true


### PR DESCRIPTION
## Description

Fixes the self-service login endpoint returning `BadCredentialsException` due to a Spring bean name collision with core Fineract.

### Root Cause

`SelfServiceSecurityConfiguration` defined `@Bean(name = "customAuthenticationProvider")` — the **same name** as core `SecurityConfig`. Spring silently kept the core bean, so `SelfAuthenticationApiResource` was wired to `TenantAwareJpaPlatformUserDetailsService`, which queries `m_appuser` instead of `m_appselfservice_user`.

### Fix

- Renamed all colliding beans to unique self-service names (`selfServiceAuthenticationProvider`, `selfServiceBasicAuthenticationEntryPoint`)
- Removed `@Bean` from `PasswordEncoder` and `AuthenticationManager` since they are only consumed internally via method calls
- Updated `@Qualifier` in `SelfAuthenticationApiResource` to point to the renamed provider

### Spring Context Wiring Test

Added `SelfServiceSecurityWiringTest` — a lightweight Spring context test (no database, no server) that loads **both** security configurations and asserts:

- Self-service auth provider is wired to `TenantAwareJpaPlatformSelfServiceUserDetailsService`
- Core auth provider is wired to `TenantAwareJpaPlatformUserDetailsService`
- Both providers are separate beans
- `allow-bean-definition-overriding=false` in test properties ensures any future bean collision crashes the test immediately

### Verification

After this fix, the trace log should show:
cache=[selfServiceUsersByUsername] → TenantAwareJpaPlatformSelfServiceUserDetailsService SELECT ... FROM "m_appselfservice_user"

Instead of:
cache=[usersByUsername] → TenantAwareJpaPlatformUserDetailsService SELECT ... FROM "m_appuser"