### PR TITLE
MX-214: Decouple self-service product APIs from core API resources

### DIFF
--- a/src/main/java/org/apache/fineract/selfservice/products/api/SelfLoanProductsApiResource.java
+++ b/src/main/java/org/apache/fineract/selfservice/products/api/SelfLoanProductsApiResource.java
@@ -24,11 +24,16 @@ import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.UriInfo;
+import java.util.Collection;
 import lombok.RequiredArgsConstructor;
+import org.apache.fineract.infrastructure.core.api.ApiRequestParameterHelper;
+import org.apache.fineract.infrastructure.core.serialization.ApiRequestJsonSerializationSettings;
+import org.apache.fineract.infrastructure.core.serialization.DefaultToApiJsonSerializer;
 import org.apache.fineract.portfolio.loanaccount.api.LoanApiConstants;
-import org.apache.fineract.portfolio.loanproduct.api.LoanProductsApiResource;
-import org.springframework.stereotype.Component;
+import org.apache.fineract.portfolio.loanproduct.data.LoanProductData;
+import org.apache.fineract.portfolio.loanproduct.service.LoanProductReadPlatformService;
 import org.apache.fineract.selfservice.client.service.AppSelfServiceUserClientMapperReadService;
+import org.springframework.stereotype.Component;
 
 @Path("/v1/self/loanproducts")
 @Component
@@ -169,7 +174,9 @@ import org.apache.fineract.selfservice.client.service.AppSelfServiceUserClientMa
 @RequiredArgsConstructor
 public class SelfLoanProductsApiResource {
 
-  private final LoanProductsApiResource loanProductsApiResource;
+  private final LoanProductReadPlatformService loanProductReadPlatformService;
+  private final DefaultToApiJsonSerializer<LoanProductData> toApiJsonSerializer;
+  private final ApiRequestParameterHelper apiRequestParameterHelper;
   private final AppSelfServiceUserClientMapperReadService appUserClientMapperReadService;
 
   @GET
@@ -180,7 +187,11 @@ public class SelfLoanProductsApiResource {
       @Context final UriInfo uriInfo) {
 
     this.appUserClientMapperReadService.validateAppSelfServiceUserClientsMapping(clientId);
-    return this.loanProductsApiResource.retrieveAllLoanProducts(uriInfo);
+    final ApiRequestJsonSerializationSettings settings =
+        this.apiRequestParameterHelper.process(uriInfo.getQueryParameters());
+    final Collection<LoanProductData> products =
+        this.loanProductReadPlatformService.retrieveAllLoanProducts();
+    return this.toApiJsonSerializer.serialize(settings, products);
   }
 
   @GET
@@ -193,6 +204,10 @@ public class SelfLoanProductsApiResource {
       @Context final UriInfo uriInfo) {
 
     this.appUserClientMapperReadService.validateAppSelfServiceUserClientsMapping(clientId);
-    return this.loanProductsApiResource.retrieveLoanProductDetails(productId, uriInfo);
+    final ApiRequestJsonSerializationSettings settings =
+        this.apiRequestParameterHelper.process(uriInfo.getQueryParameters());
+    final LoanProductData loanProduct =
+        this.loanProductReadPlatformService.retrieveLoanProduct(productId);
+    return this.toApiJsonSerializer.serialize(settings, loanProduct);
   }
 }

--- a/src/main/java/org/apache/fineract/selfservice/products/api/SelfSavingsProductsApiResource.java
+++ b/src/main/java/org/apache/fineract/selfservice/products/api/SelfSavingsProductsApiResource.java
@@ -24,11 +24,16 @@ import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.UriInfo;
+import java.util.Collection;
 import lombok.RequiredArgsConstructor;
+import org.apache.fineract.infrastructure.core.api.ApiRequestParameterHelper;
+import org.apache.fineract.infrastructure.core.serialization.ApiRequestJsonSerializationSettings;
+import org.apache.fineract.infrastructure.core.serialization.DefaultToApiJsonSerializer;
 import org.apache.fineract.portfolio.savings.SavingsApiConstants;
-import org.apache.fineract.portfolio.savings.api.SavingsProductsApiResource;
-import org.springframework.stereotype.Component;
+import org.apache.fineract.portfolio.savings.data.SavingsProductData;
+import org.apache.fineract.portfolio.savings.service.SavingsProductReadPlatformService;
 import org.apache.fineract.selfservice.client.service.AppSelfServiceUserClientMapperReadService;
+import org.springframework.stereotype.Component;
 
 @Path("/v1/self/savingsproducts")
 @Component
@@ -36,7 +41,9 @@ import org.apache.fineract.selfservice.client.service.AppSelfServiceUserClientMa
 @RequiredArgsConstructor
 public class SelfSavingsProductsApiResource {
 
-  private final SavingsProductsApiResource savingsProductsApiResource;
+  private final SavingsProductReadPlatformService savingsProductReadPlatformService;
+  private final DefaultToApiJsonSerializer<SavingsProductData> toApiJsonSerializer;
+  private final ApiRequestParameterHelper apiRequestParameterHelper;
   private final AppSelfServiceUserClientMapperReadService appUserClientMapperReadService;
 
   @GET
@@ -47,7 +54,11 @@ public class SelfSavingsProductsApiResource {
       @Context final UriInfo uriInfo) {
 
     this.appUserClientMapperReadService.validateAppSelfServiceUserClientsMapping(clientId);
-    return this.savingsProductsApiResource.retrieveAll(uriInfo);
+    final ApiRequestJsonSerializationSettings settings =
+        this.apiRequestParameterHelper.process(uriInfo.getQueryParameters());
+    final Collection<SavingsProductData> products =
+        this.savingsProductReadPlatformService.retrieveAll();
+    return this.toApiJsonSerializer.serialize(settings, products);
   }
 
   @GET
@@ -60,6 +71,10 @@ public class SelfSavingsProductsApiResource {
       @Context final UriInfo uriInfo) {
 
     this.appUserClientMapperReadService.validateAppSelfServiceUserClientsMapping(clientId);
-    return this.savingsProductsApiResource.retrieveOne(productId, uriInfo);
+    final ApiRequestJsonSerializationSettings settings =
+        this.apiRequestParameterHelper.process(uriInfo.getQueryParameters());
+    final SavingsProductData savingsProduct =
+        this.savingsProductReadPlatformService.retrieveOne(productId);
+    return this.toApiJsonSerializer.serialize(settings, savingsProduct);
   }
 }

--- a/src/main/java/org/apache/fineract/selfservice/products/api/SelfShareProductsApiResource.java
+++ b/src/main/java/org/apache/fineract/selfservice/products/api/SelfShareProductsApiResource.java
@@ -25,10 +25,15 @@ import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.UriInfo;
 import lombok.RequiredArgsConstructor;
+import org.apache.fineract.infrastructure.core.api.ApiRequestParameterHelper;
+import org.apache.fineract.infrastructure.core.serialization.ApiRequestJsonSerializationSettings;
+import org.apache.fineract.infrastructure.core.serialization.DefaultToApiJsonSerializer;
+import org.apache.fineract.infrastructure.core.service.Page;
 import org.apache.fineract.portfolio.accounts.constants.ShareAccountApiConstants;
-import org.apache.fineract.portfolio.products.api.ProductsApiResource;
-import org.springframework.stereotype.Component;
+import org.apache.fineract.portfolio.products.data.ProductData;
+import org.apache.fineract.portfolio.products.service.ShareProductReadPlatformService;
 import org.apache.fineract.selfservice.client.service.AppSelfServiceUserClientMapperReadService;
+import org.springframework.stereotype.Component;
 
 @Path("/v1/self/products/share")
 @Component
@@ -36,7 +41,9 @@ import org.apache.fineract.selfservice.client.service.AppSelfServiceUserClientMa
 @RequiredArgsConstructor
 public class SelfShareProductsApiResource {
 
-  private final ProductsApiResource productsApiResource;
+  private final ShareProductReadPlatformService shareProductReadPlatformService;
+  private final DefaultToApiJsonSerializer<ProductData> toApiJsonSerializer;
+  private final ApiRequestParameterHelper apiRequestParameterHelper;
   private final AppSelfServiceUserClientMapperReadService appUserClientMapperReadService;
 
   @GET
@@ -46,11 +53,14 @@ public class SelfShareProductsApiResource {
   public String retrieveProduct(
       @QueryParam(ShareAccountApiConstants.clientid_paramname) final Long clientId,
       @PathParam("productId") final Long productId,
-      @PathParam("type") final String productType,
       @Context final UriInfo uriInfo) {
+
     this.appUserClientMapperReadService.validateAppSelfServiceUserClientsMapping(clientId);
-    return this.productsApiResource.retrieveProduct(
-        productId, ShareAccountApiConstants.shareEntityType, uriInfo);
+    final ApiRequestJsonSerializationSettings settings =
+        this.apiRequestParameterHelper.process(uriInfo.getQueryParameters());
+    final ProductData productData =
+        this.shareProductReadPlatformService.retrieveOne(productId, false);
+    return this.toApiJsonSerializer.serialize(settings, productData);
   }
 
   @GET
@@ -61,8 +71,12 @@ public class SelfShareProductsApiResource {
       @QueryParam("offset") final Integer offset,
       @QueryParam("limit") final Integer limit,
       @Context final UriInfo uriInfo) {
+
     this.appUserClientMapperReadService.validateAppSelfServiceUserClientsMapping(clientId);
-    return this.productsApiResource.retrieveAllProducts(
-        ShareAccountApiConstants.shareEntityType, offset, limit, uriInfo);
+    final ApiRequestJsonSerializationSettings settings =
+        this.apiRequestParameterHelper.process(uriInfo.getQueryParameters());
+    final Page<ProductData> products =
+        this.shareProductReadPlatformService.retrieveAllProducts(offset, limit);
+    return this.toApiJsonSerializer.serialize(settings, products);
   }
 }

--- a/src/main/java/org/apache/fineract/selfservice/security/service/AppSelfServiceUserAdapter.java
+++ b/src/main/java/org/apache/fineract/selfservice/security/service/AppSelfServiceUserAdapter.java
@@ -1,0 +1,69 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.fineract.selfservice.security.service;
+
+import java.lang.reflect.Field;
+import java.util.HashSet;
+import org.apache.fineract.selfservice.useradministration.domain.AppSelfServiceUser;
+import org.apache.fineract.useradministration.domain.AppUser;
+import org.springframework.security.core.userdetails.User;
+
+/**
+ * Creates a minimal, read-only {@link AppUser} stub from an {@link AppSelfServiceUser}.
+ *
+ * This adapter exists solely to pass the {@code context.authenticatedUser()} guard checks in core
+ * Fineract read services. The stub is NOT a persistent entity and must never be used for write
+ * operations.
+ */
+final class AppSelfServiceUserAdapter {
+
+  private AppSelfServiceUserAdapter() {}
+
+  static AppUser fromSelfServiceUser(AppSelfServiceUser selfServiceUser) {
+    User springUser = new User(
+        selfServiceUser.getUsername(),
+        selfServiceUser.getPassword(),
+        selfServiceUser.isEnabled(),
+        selfServiceUser.isAccountNonExpired(),
+        selfServiceUser.isCredentialsNonExpired(),
+        selfServiceUser.isAccountNonLocked(),
+        selfServiceUser.getAuthorities()
+    );
+
+    AppUser stub = new AppUser(
+        selfServiceUser.getOffice(),
+        springUser,
+        new HashSet<>(),
+        selfServiceUser.getEmail(),
+        selfServiceUser.getFirstname(),
+        selfServiceUser.getLastname(),
+        null,
+        true,
+        false
+    );
+    setId(stub, selfServiceUser.getId());
+    return stub;
+  }
+
+  private static void setId(AppUser stub, Long id) {
+    try {
+      Field idField = AppUser.class.getSuperclass().getDeclaredField("id");
+      idField.setAccessible(true);
+      idField.set(stub, id);
+    } catch (NoSuchFieldException | IllegalAccessException e) {
+      throw new IllegalStateException("Failed to set id on AppUser stub", e);
+    }
+  }
+}

--- a/src/main/java/org/apache/fineract/selfservice/security/service/PlatformSelfServiceSecurityContextImpl.java
+++ b/src/main/java/org/apache/fineract/selfservice/security/service/PlatformSelfServiceSecurityContextImpl.java
@@ -22,15 +22,16 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.fineract.commands.domain.CommandWrapper;
 import org.apache.fineract.commands.service.CommandWrapperBuilder;
 import org.apache.fineract.infrastructure.configuration.domain.ConfigurationDomainService;
 import org.apache.fineract.infrastructure.core.service.DateUtils;
+import org.apache.fineract.infrastructure.security.service.PlatformSecurityContext;
 import org.apache.fineract.selfservice.security.exception.SelfServiceNoAuthorizationException;
 import org.apache.fineract.selfservice.security.exception.SelfServiceResetPasswordException;
 import org.apache.fineract.selfservice.security.exception.SelfServiceUnAuthenticatedUserException;
 import org.apache.fineract.selfservice.useradministration.domain.AppSelfServiceUser;
+import org.apache.fineract.useradministration.domain.AppUser;
 import org.apache.fineract.useradministration.exception.UnAuthenticatedUserException;
 import org.springframework.context.annotation.Primary;
 import org.springframework.security.core.Authentication;
@@ -38,147 +39,158 @@ import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 
+/**
+ * Primary security context that bridges the self-service and core security models.
+ *
+ * Implements both {@link PlatformSelfServiceSecurityContext} (for self-service API resources)
+ * and {@link PlatformSecurityContext} (for core read services that call
+ * {@code context.authenticatedUser()} as a guard check).
+ *
+ * When the principal is an {@link AppSelfServiceUser}, the core {@link PlatformSecurityContext}
+ * methods return a minimal {@link AppUser} stub via {@link AppSelfServiceUserAdapter},
+ * allowing core read services to pass their guard checks without modification.
+ */
 @Component
-@Primary 
+@Primary
 @RequiredArgsConstructor
-@Slf4j
 public class PlatformSelfServiceSecurityContextImpl implements PlatformSelfServiceSecurityContext {
 
-    private final ConfigurationDomainService configurationDomainService;
+  private final ConfigurationDomainService configurationDomainService;
 
-    protected static final List<CommandWrapper> EXEMPT_FROM_PASSWORD_RESET_CHECK = new ArrayList<CommandWrapper>(
-            List.of(new CommandWrapperBuilder().changeUserPassword(null).build()));
+  protected static final List<CommandWrapper> EXEMPT_FROM_PASSWORD_RESET_CHECK =
+      new ArrayList<CommandWrapper>(
+          List.of(new CommandWrapperBuilder().changeUserPassword(null).build()));
 
-    @Override
-    public AppSelfServiceUser authenticatedSelfServiceUser() {
-        
-        log.warn("*************************************************************");
-        log.warn("*                                                           *");
-        log.warn("* public AppSelfServiceUser authenticatedSelfServiceUser()  *");
-        log.warn("*                                                           *");
-        log.warn("*************************************************************");
-
-        AppSelfServiceUser currentUser = null;
-        final SecurityContext context = SecurityContextHolder.getContext();
-        if (context != null) {
-            final Authentication auth = context.getAuthentication();
-            if (auth != null) {
-                Object principal = auth.getPrincipal();
-                if (principal instanceof AppSelfServiceUser appUser) {
-                    currentUser = appUser;
-                }
-            }
+  @Override
+  public AppSelfServiceUser authenticatedSelfServiceUser() {
+    AppSelfServiceUser currentUser = null;
+    final SecurityContext context = SecurityContextHolder.getContext();
+    if (context != null) {
+      final Authentication auth = context.getAuthentication();
+      if (auth != null) {
+        Object principal = auth.getPrincipal();
+        if (principal instanceof AppSelfServiceUser appUser) {
+          currentUser = appUser;
         }
-        if (currentUser == null) {
-            throw new UnAuthenticatedUserException();
-        }
-        if (this.doesPasswordHasToBeRenewed(currentUser)) {
-            throw new SelfServiceResetPasswordException(currentUser.getId());
-        }
-        return currentUser;
+      }
     }
-
-    @Override
-    public void isAuthenticated() {
-        authenticatedSelfServiceUser();
+    if (currentUser == null) {
+      throw new UnAuthenticatedUserException();
     }
-
-    @Override
-    public AppSelfServiceUser getAuthenticatedUserIfPresent() {
-        
-        log.warn("*************************************************************");
-        log.warn("*                                                           *");
-        log.warn("* public AppSelfServiceUser getAuthenticatedUserIfPresent() *");
-        log.warn("*                                                           *");
-        log.warn("*************************************************************");
-
-        AppSelfServiceUser currentUser = null;
-        final SecurityContext context = SecurityContextHolder.getContext();
-        if (context != null) {
-            final Authentication auth = context.getAuthentication();
-            if (auth != null) {
-                currentUser = (AppSelfServiceUser) auth.getPrincipal();
-            }
-        }
-        if (currentUser == null) {
-            return null;
-        }
-        if (this.doesPasswordHasToBeRenewed(currentUser)) {
-            throw new SelfServiceResetPasswordException(currentUser.getId());
-        }
-        return currentUser;
+    if (this.doesPasswordHasToBeRenewed(currentUser)) {
+      throw new SelfServiceResetPasswordException(currentUser.getId());
     }
+    return currentUser;
+  }
 
-    @Override
-    public AppSelfServiceUser authenticatedUser(CommandWrapper commandWrapper) {
-        
-        log.warn("******************************************************************************");
-        log.warn("*                                                                            *");
-        log.warn("* public AppSelfServiceUser authenticatedUser(CommandWrapper commandWrapper) *");
-        log.warn("*                                                                            *");
-        log.warn("******************************************************************************");
-
-        AppSelfServiceUser currentUser = null;
-        final SecurityContext context = SecurityContextHolder.getContext();
-        if (context != null) {
-            final Authentication auth = context.getAuthentication();
-            if (auth != null) {
-                currentUser = (AppSelfServiceUser) auth.getPrincipal();
-            }
-        }
-        if (currentUser == null) {
-            throw new SelfServiceUnAuthenticatedUserException();
-        }
-        if (this.shouldCheckForPasswordForceReset(commandWrapper, currentUser) && this.doesPasswordHasToBeRenewed(currentUser)) {
-            throw new SelfServiceResetPasswordException(currentUser.getId());
-        }
-        return currentUser;
+  @Override
+  public void isAuthenticated() {
+    final Object principal = extractPrincipal();
+    if (principal instanceof AppSelfServiceUser) {
+      authenticatedSelfServiceUser();
+    } else {
+      throw new UnAuthenticatedUserException();
     }
+  }
 
-    @Override
-    public void validateAccessRights(final String resourceOfficeHierarchy) {
-
-        final AppSelfServiceUser user = authenticatedSelfServiceUser();
-        final String userOfficeHierarchy = user.getOffice().getHierarchy();
-
-        if (!resourceOfficeHierarchy.startsWith(userOfficeHierarchy)) {
-            throw new SelfServiceNoAuthorizationException("The user doesn't have enough permissions to access the resource.");
+  @Override
+  public AppSelfServiceUser getAuthenticatedUserIfPresent() {
+    AppSelfServiceUser currentUser = null;
+    final SecurityContext context = SecurityContextHolder.getContext();
+    if (context != null) {
+      final Authentication auth = context.getAuthentication();
+      if (auth != null) {
+        Object principal = auth.getPrincipal();
+        if (principal instanceof AppSelfServiceUser ssUser) {
+          currentUser = ssUser;
         }
+      }
     }
-
-    @Override
-    public String officeHierarchy() {
-        return authenticatedSelfServiceUser().getOffice().getHierarchy();
+    if (currentUser == null) {
+      return null;
     }
-
-    @Override
-    public boolean doesPasswordHasToBeRenewed(AppSelfServiceUser currentUser) {
-
-        if (currentUser.isPasswordResetRequired()) {
-            return true;
-        }
-
-        if (this.configurationDomainService.isPasswordForcedResetEnable() && !currentUser.getPasswordNeverExpires()) {
-
-            Long passwordDurationDays = this.configurationDomainService.retrievePasswordLiveTime();
-            final LocalDate passWordLastUpdateDate = currentUser.getLastTimePasswordUpdated();
-
-            final LocalDate passwordExpirationDate = passWordLastUpdateDate.plusDays(passwordDurationDays);
-
-            if (DateUtils.isBeforeTenantDate(passwordExpirationDate)) {
-                return true;
-            }
-        }
-        return false;
+    if (this.doesPasswordHasToBeRenewed(currentUser)) {
+      throw new SelfServiceResetPasswordException(currentUser.getId());
     }
+    return currentUser;
+  }
 
-    private boolean shouldCheckForPasswordForceReset(CommandWrapper commandWrapper, AppSelfServiceUser currentUser) {
-        for (CommandWrapper commandItem : EXEMPT_FROM_PASSWORD_RESET_CHECK) {
-            if (commandItem.actionName().equals(commandWrapper.actionName())
-                    && commandItem.getEntityName().equals(commandWrapper.getEntityName())) {
-                return commandWrapper.getEntityId() == null || !commandWrapper.getEntityId().equals(currentUser.getId());
-            }
+  @Override
+  public AppSelfServiceUser authenticatedUser(CommandWrapper commandWrapper) {
+    AppSelfServiceUser currentUser = null;
+    final SecurityContext context = SecurityContextHolder.getContext();
+    if (context != null) {
+      final Authentication auth = context.getAuthentication();
+      if (auth != null) {
+        Object principal = auth.getPrincipal();
+        if (principal instanceof AppSelfServiceUser ssUser) {
+          currentUser = ssUser;
         }
+      }
+    }
+    if (currentUser == null) {
+      throw new SelfServiceUnAuthenticatedUserException();
+    }
+    if (this.shouldCheckForPasswordForceReset(commandWrapper, currentUser)
+        && this.doesPasswordHasToBeRenewed(currentUser)) {
+      throw new SelfServiceResetPasswordException(currentUser.getId());
+    }
+    return currentUser;
+  }
+
+  @Override
+  public void validateAccessRights(final String resourceOfficeHierarchy) {
+    final AppSelfServiceUser user = authenticatedSelfServiceUser();
+    final String userOfficeHierarchy = user.getOffice().getHierarchy();
+    if (!resourceOfficeHierarchy.startsWith(userOfficeHierarchy)) {
+      throw new SelfServiceNoAuthorizationException(
+          "The user doesn't have enough permissions to access the resource.");
+    }
+  }
+
+  @Override
+  public String officeHierarchy() {
+    return authenticatedSelfServiceUser().getOffice().getHierarchy();
+  }
+
+  @Override
+  public boolean doesPasswordHasToBeRenewed(AppSelfServiceUser currentUser) {
+    if (currentUser.isPasswordResetRequired()) {
+      return true;
+    }
+    if (this.configurationDomainService.isPasswordForcedResetEnable()
+        && !currentUser.getPasswordNeverExpires()) {
+      Long passwordDurationDays = this.configurationDomainService.retrievePasswordLiveTime();
+      final LocalDate passWordLastUpdateDate = currentUser.getLastTimePasswordUpdated();
+      final LocalDate passwordExpirationDate =
+          passWordLastUpdateDate.plusDays(passwordDurationDays);
+      if (DateUtils.isBeforeTenantDate(passwordExpirationDate)) {
         return true;
+      }
     }
+    return false;
+  }
+
+  private boolean shouldCheckForPasswordForceReset(
+      CommandWrapper commandWrapper, AppSelfServiceUser currentUser) {
+    for (CommandWrapper commandItem : EXEMPT_FROM_PASSWORD_RESET_CHECK) {
+      if (commandItem.actionName().equals(commandWrapper.actionName())
+          && commandItem.getEntityName().equals(commandWrapper.getEntityName())) {
+        return commandWrapper.getEntityId() == null
+            || !commandWrapper.getEntityId().equals(currentUser.getId());
+      }
+    }
+    return true;
+  }
+
+  private Object extractPrincipal() {
+    final SecurityContext context = SecurityContextHolder.getContext();
+    if (context != null) {
+      final Authentication auth = context.getAuthentication();
+      if (auth != null) {
+        return auth.getPrincipal();
+      }
+    }
+    return null;
+  }
 }

--- a/src/main/java/org/apache/fineract/selfservice/security/service/SelfServiceCompatibleSecurityContext.java
+++ b/src/main/java/org/apache/fineract/selfservice/security/service/SelfServiceCompatibleSecurityContext.java
@@ -1,0 +1,74 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.fineract.selfservice.security.service;
+
+import org.apache.fineract.infrastructure.configuration.domain.ConfigurationDomainService;
+import org.apache.fineract.infrastructure.security.service.SpringSecurityPlatformSecurityContext;
+import org.apache.fineract.selfservice.useradministration.domain.AppSelfServiceUser;
+import org.apache.fineract.useradministration.domain.AppUser;
+import org.apache.fineract.useradministration.exception.UnAuthenticatedUserException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/**
+ * Extends the core {@link SpringSecurityPlatformSecurityContext} to handle both
+ * {@link AppUser} and {@link AppSelfServiceUser} principals.
+ *
+ * Overrides {@code authenticatedUser()} and {@code getAuthenticatedUserIfPresent()} so that
+ * when the principal is an {@link AppSelfServiceUser}, a minimal {@link AppUser} stub is
+ * returned via {@link AppSelfServiceUserAdapter}, allowing core read services to pass their
+ * guard checks.
+ */
+public class SelfServiceCompatibleSecurityContext extends SpringSecurityPlatformSecurityContext {
+
+  public SelfServiceCompatibleSecurityContext(
+      ConfigurationDomainService configurationDomainService) {
+    super(configurationDomainService);
+  }
+
+  @Override
+  public AppUser authenticatedUser() {
+    final Object principal = extractPrincipal();
+
+    if (principal instanceof AppSelfServiceUser selfServiceUser) {
+      return AppSelfServiceUserAdapter.fromSelfServiceUser(selfServiceUser);
+    }
+
+    return super.authenticatedUser();
+  }
+
+  @Override
+  public AppUser getAuthenticatedUserIfPresent() {
+    final Object principal = extractPrincipal();
+
+    if (principal instanceof AppSelfServiceUser selfServiceUser) {
+      return AppSelfServiceUserAdapter.fromSelfServiceUser(selfServiceUser);
+    }
+
+    return super.getAuthenticatedUserIfPresent();
+  }
+
+  private Object extractPrincipal() {
+    final SecurityContext context = SecurityContextHolder.getContext();
+    if (context != null) {
+      final Authentication auth = context.getAuthentication();
+      if (auth != null) {
+        return auth.getPrincipal();
+      }
+    }
+    return null;
+  }
+}

--- a/src/main/java/org/apache/fineract/selfservice/security/service/SelfServiceSecurityBridgeConfiguration.java
+++ b/src/main/java/org/apache/fineract/selfservice/security/service/SelfServiceSecurityBridgeConfiguration.java
@@ -1,0 +1,37 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.fineract.selfservice.security.service;
+
+import org.apache.fineract.infrastructure.configuration.domain.ConfigurationDomainService;
+import org.apache.fineract.infrastructure.security.service.SpringSecurityPlatformSecurityContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Overrides the core {@code springSecurityPlatformSecurityContext} bean with a subclass
+ * that handles both {@code AppUser} and {@code AppSelfServiceUser} principals.
+ *
+ * The return type is {@link SpringSecurityPlatformSecurityContext} so that injection points
+ * depending on the concrete type (e.g. {@code AuthenticationApiResource}) are satisfied.
+ */
+@Configuration
+public class SelfServiceSecurityBridgeConfiguration {
+
+  @Bean("springSecurityPlatformSecurityContext")
+  public SpringSecurityPlatformSecurityContext springSecurityPlatformSecurityContext(
+      ConfigurationDomainService configurationDomainService) {
+    return new SelfServiceCompatibleSecurityContext(configurationDomainService);
+  }
+}

--- a/src/test/java/org/apache/fineract/selfservice/products/api/SelfLoanProductsApiResourceTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/products/api/SelfLoanProductsApiResourceTest.java
@@ -1,0 +1,126 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.fineract.selfservice.products.api;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.UriInfo;
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import org.apache.fineract.infrastructure.core.api.ApiRequestParameterHelper;
+import org.apache.fineract.infrastructure.core.serialization.ApiRequestJsonSerializationSettings;
+import org.apache.fineract.infrastructure.core.serialization.DefaultToApiJsonSerializer;
+import org.apache.fineract.portfolio.client.exception.ClientNotFoundException;
+import org.apache.fineract.portfolio.loanproduct.data.LoanProductData;
+import org.apache.fineract.portfolio.loanproduct.service.LoanProductReadPlatformService;
+import org.apache.fineract.selfservice.client.service.AppSelfServiceUserClientMapperReadService;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("unchecked")
+class SelfLoanProductsApiResourceTest {
+
+  @Mock private LoanProductReadPlatformService loanProductReadPlatformService;
+  @Mock private DefaultToApiJsonSerializer<LoanProductData> toApiJsonSerializer;
+  @Mock private ApiRequestParameterHelper apiRequestParameterHelper;
+  @Mock private AppSelfServiceUserClientMapperReadService appUserClientMapperReadService;
+  @Mock private UriInfo uriInfo;
+
+  private SelfLoanProductsApiResource resource;
+
+  private static final Long CLIENT_ID = 5L;
+  private static final Long PRODUCT_ID = 1L;
+
+  @BeforeEach
+  void setUp() {
+    resource = new SelfLoanProductsApiResource(
+        loanProductReadPlatformService,
+        toApiJsonSerializer,
+        apiRequestParameterHelper,
+        appUserClientMapperReadService);
+
+    Mockito.lenient().when(uriInfo.getQueryParameters()).thenReturn(new MultivaluedHashMap<>());
+    Mockito.lenient().when(apiRequestParameterHelper.process(any()))
+        .thenReturn(mock(ApiRequestJsonSerializationSettings.class));
+  }
+
+  @Test
+  void retrieveAllLoanProducts_validClient_callsReadService() {
+    Collection<LoanProductData> products = List.of(mock(LoanProductData.class));
+    when(loanProductReadPlatformService.retrieveAllLoanProducts()).thenReturn(products);
+    when(toApiJsonSerializer.serialize(any(), any(Collection.class))).thenReturn("[]");
+
+    String result = resource.retrieveAllLoanProducts(CLIENT_ID, uriInfo);
+
+    assertNotNull(result);
+    verify(loanProductReadPlatformService).retrieveAllLoanProducts();
+  }
+
+  @Test
+  void retrieveAllLoanProducts_callsValidateMapping() {
+    when(loanProductReadPlatformService.retrieveAllLoanProducts()).thenReturn(List.of());
+    when(toApiJsonSerializer.serialize(any(), any(Collection.class))).thenReturn("[]");
+
+    resource.retrieveAllLoanProducts(CLIENT_ID, uriInfo);
+
+    verify(appUserClientMapperReadService).validateAppSelfServiceUserClientsMapping(CLIENT_ID);
+  }
+
+  @Test
+  void retrieveLoanProductDetails_validClient_callsReadService() {
+    LoanProductData product = mock(LoanProductData.class);
+    when(loanProductReadPlatformService.retrieveLoanProduct(PRODUCT_ID)).thenReturn(product);
+    when(toApiJsonSerializer.serialize(any(), any(LoanProductData.class))).thenReturn("{}");
+
+    String result = resource.retrieveLoanProductDetails(CLIENT_ID, PRODUCT_ID, uriInfo);
+
+    assertNotNull(result);
+    verify(loanProductReadPlatformService).retrieveLoanProduct(PRODUCT_ID);
+  }
+
+  @Test
+  void retrieveLoanProductDetails_unmappedClient_throws() {
+    doThrow(new ClientNotFoundException(CLIENT_ID))
+        .when(appUserClientMapperReadService).validateAppSelfServiceUserClientsMapping(CLIENT_ID);
+
+    Assertions.assertThrows(
+        ClientNotFoundException.class,
+        () -> resource.retrieveLoanProductDetails(CLIENT_ID, PRODUCT_ID, uriInfo));
+  }
+
+  @Test
+  void noCoreApiResourceInjected() {
+    boolean hasCoreApiResource = Arrays.stream(SelfLoanProductsApiResource.class.getDeclaredFields())
+        .map(Field::getType)
+        .anyMatch(t -> t.getSimpleName().equals("LoanProductsApiResource"));
+    assertTrue(!hasCoreApiResource,
+        "SelfLoanProductsApiResource must not depend on core LoanProductsApiResource");
+  }
+}

--- a/src/test/java/org/apache/fineract/selfservice/products/api/SelfSavingsProductsApiResourceTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/products/api/SelfSavingsProductsApiResourceTest.java
@@ -1,0 +1,126 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.fineract.selfservice.products.api;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.UriInfo;
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import org.apache.fineract.infrastructure.core.api.ApiRequestParameterHelper;
+import org.apache.fineract.infrastructure.core.serialization.ApiRequestJsonSerializationSettings;
+import org.apache.fineract.infrastructure.core.serialization.DefaultToApiJsonSerializer;
+import org.apache.fineract.portfolio.client.exception.ClientNotFoundException;
+import org.apache.fineract.portfolio.savings.data.SavingsProductData;
+import org.apache.fineract.portfolio.savings.service.SavingsProductReadPlatformService;
+import org.apache.fineract.selfservice.client.service.AppSelfServiceUserClientMapperReadService;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("unchecked")
+class SelfSavingsProductsApiResourceTest {
+
+  @Mock private SavingsProductReadPlatformService savingsProductReadPlatformService;
+  @Mock private DefaultToApiJsonSerializer<SavingsProductData> toApiJsonSerializer;
+  @Mock private ApiRequestParameterHelper apiRequestParameterHelper;
+  @Mock private AppSelfServiceUserClientMapperReadService appUserClientMapperReadService;
+  @Mock private UriInfo uriInfo;
+
+  private SelfSavingsProductsApiResource resource;
+
+  private static final Long CLIENT_ID = 5L;
+  private static final Long PRODUCT_ID = 1L;
+
+  @BeforeEach
+  void setUp() {
+    resource = new SelfSavingsProductsApiResource(
+        savingsProductReadPlatformService,
+        toApiJsonSerializer,
+        apiRequestParameterHelper,
+        appUserClientMapperReadService);
+
+    Mockito.lenient().when(uriInfo.getQueryParameters()).thenReturn(new MultivaluedHashMap<>());
+    Mockito.lenient().when(apiRequestParameterHelper.process(any()))
+        .thenReturn(mock(ApiRequestJsonSerializationSettings.class));
+  }
+
+  @Test
+  void retrieveAll_validClient_callsReadService() {
+    Collection<SavingsProductData> products = List.of(mock(SavingsProductData.class));
+    when(savingsProductReadPlatformService.retrieveAll()).thenReturn(products);
+    when(toApiJsonSerializer.serialize(any(), any(Collection.class))).thenReturn("[]");
+
+    String result = resource.retrieveAll(CLIENT_ID, uriInfo);
+
+    assertNotNull(result);
+    verify(savingsProductReadPlatformService).retrieveAll();
+  }
+
+  @Test
+  void retrieveAll_callsValidateMapping() {
+    when(savingsProductReadPlatformService.retrieveAll()).thenReturn(List.of());
+    when(toApiJsonSerializer.serialize(any(), any(Collection.class))).thenReturn("[]");
+
+    resource.retrieveAll(CLIENT_ID, uriInfo);
+
+    verify(appUserClientMapperReadService).validateAppSelfServiceUserClientsMapping(CLIENT_ID);
+  }
+
+  @Test
+  void retrieveOne_validClient_callsReadService() {
+    SavingsProductData product = mock(SavingsProductData.class);
+    when(savingsProductReadPlatformService.retrieveOne(PRODUCT_ID)).thenReturn(product);
+    when(toApiJsonSerializer.serialize(any(), any(SavingsProductData.class))).thenReturn("{}");
+
+    String result = resource.retrieveOne(PRODUCT_ID, CLIENT_ID, uriInfo);
+
+    assertNotNull(result);
+    verify(savingsProductReadPlatformService).retrieveOne(PRODUCT_ID);
+  }
+
+  @Test
+  void retrieveOne_unmappedClient_throws() {
+    doThrow(new ClientNotFoundException(CLIENT_ID))
+        .when(appUserClientMapperReadService).validateAppSelfServiceUserClientsMapping(CLIENT_ID);
+
+    Assertions.assertThrows(
+        ClientNotFoundException.class,
+        () -> resource.retrieveOne(PRODUCT_ID, CLIENT_ID, uriInfo));
+  }
+
+  @Test
+  void noCoreApiResourceInjected() {
+    boolean hasCoreApiResource = Arrays.stream(SelfSavingsProductsApiResource.class.getDeclaredFields())
+        .map(Field::getType)
+        .anyMatch(t -> t.getSimpleName().equals("SavingsProductsApiResource"));
+    assertTrue(!hasCoreApiResource,
+        "SelfSavingsProductsApiResource must not depend on core SavingsProductsApiResource");
+  }
+}

--- a/src/test/java/org/apache/fineract/selfservice/products/api/SelfShareProductsApiResourceTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/products/api/SelfShareProductsApiResourceTest.java
@@ -1,0 +1,126 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.fineract.selfservice.products.api;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.UriInfo;
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import org.apache.fineract.infrastructure.core.api.ApiRequestParameterHelper;
+import org.apache.fineract.infrastructure.core.serialization.ApiRequestJsonSerializationSettings;
+import org.apache.fineract.infrastructure.core.serialization.DefaultToApiJsonSerializer;
+import org.apache.fineract.infrastructure.core.service.Page;
+import org.apache.fineract.portfolio.client.exception.ClientNotFoundException;
+import org.apache.fineract.portfolio.products.data.ProductData;
+import org.apache.fineract.portfolio.products.service.ShareProductReadPlatformService;
+import org.apache.fineract.selfservice.client.service.AppSelfServiceUserClientMapperReadService;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("unchecked")
+class SelfShareProductsApiResourceTest {
+
+  @Mock private ShareProductReadPlatformService shareProductReadPlatformService;
+  @Mock private DefaultToApiJsonSerializer<ProductData> toApiJsonSerializer;
+  @Mock private ApiRequestParameterHelper apiRequestParameterHelper;
+  @Mock private AppSelfServiceUserClientMapperReadService appUserClientMapperReadService;
+  @Mock private UriInfo uriInfo;
+
+  private SelfShareProductsApiResource resource;
+
+  private static final Long CLIENT_ID = 5L;
+  private static final Long PRODUCT_ID = 1L;
+
+  @BeforeEach
+  void setUp() {
+    resource = new SelfShareProductsApiResource(
+        shareProductReadPlatformService,
+        toApiJsonSerializer,
+        apiRequestParameterHelper,
+        appUserClientMapperReadService);
+
+    Mockito.lenient().when(uriInfo.getQueryParameters()).thenReturn(new MultivaluedHashMap<>());
+    Mockito.lenient().when(apiRequestParameterHelper.process(any()))
+        .thenReturn(mock(ApiRequestJsonSerializationSettings.class));
+  }
+
+  @Test
+  void retrieveAllProducts_validClient_callsReadService() {
+    Page<ProductData> page = mock(Page.class);
+    when(shareProductReadPlatformService.retrieveAllProducts(null, null)).thenReturn(page);
+    when(toApiJsonSerializer.serialize(any(), any(Page.class))).thenReturn("[]");
+
+    String result = resource.retrieveAllProducts(CLIENT_ID, null, null, uriInfo);
+
+    assertNotNull(result);
+    verify(shareProductReadPlatformService).retrieveAllProducts(null, null);
+  }
+
+  @Test
+  void retrieveAllProducts_callsValidateMapping() {
+    Page<ProductData> page = mock(Page.class);
+    when(shareProductReadPlatformService.retrieveAllProducts(null, null)).thenReturn(page);
+    when(toApiJsonSerializer.serialize(any(), any(Page.class))).thenReturn("[]");
+
+    resource.retrieveAllProducts(CLIENT_ID, null, null, uriInfo);
+
+    verify(appUserClientMapperReadService).validateAppSelfServiceUserClientsMapping(CLIENT_ID);
+  }
+
+  @Test
+  void retrieveProduct_validClient_callsReadService() {
+    ProductData product = mock(ProductData.class);
+    when(shareProductReadPlatformService.retrieveOne(PRODUCT_ID, false)).thenReturn(product);
+    when(toApiJsonSerializer.serialize(any(), any(ProductData.class))).thenReturn("{}");
+
+    String result = resource.retrieveProduct(CLIENT_ID, PRODUCT_ID, uriInfo);
+
+    assertNotNull(result);
+    verify(shareProductReadPlatformService).retrieveOne(PRODUCT_ID, false);
+  }
+
+  @Test
+  void retrieveProduct_unmappedClient_throws() {
+    doThrow(new ClientNotFoundException(CLIENT_ID))
+        .when(appUserClientMapperReadService).validateAppSelfServiceUserClientsMapping(CLIENT_ID);
+
+    Assertions.assertThrows(
+        ClientNotFoundException.class,
+        () -> resource.retrieveProduct(CLIENT_ID, PRODUCT_ID, uriInfo));
+  }
+
+  @Test
+  void noCoreApiResourceInjected() {
+    boolean hasCoreApiResource = Arrays.stream(SelfShareProductsApiResource.class.getDeclaredFields())
+        .map(Field::getType)
+        .anyMatch(t -> t.getSimpleName().equals("ProductsApiResource"));
+    assertTrue(!hasCoreApiResource,
+        "SelfShareProductsApiResource must not depend on core ProductsApiResource");
+  }
+}


### PR DESCRIPTION
Self-service product endpoints fail at runtime because core Fineract's `authenticatedUser()` casts the principal to `AppUser`, but self-service auth produces `AppSelfServiceUser`.

### What this PR does

- **Decouples** `SelfLoanProductsApiResource`, `SelfSavingsProductsApiResource`, and `SelfShareProductsApiResource` from core `*ApiResource` classes by injecting read platform services directly.
- **Bridges the security model** with `SelfServiceCompatibleSecurityContext` — a subclass of `SpringSecurityPlatformSecurityContext` that transparently handles `AppSelfServiceUser` principals, so core read services pass their guard checks without modification.
- **Adds 15 unit tests** with regression guards preventing re-introduction of core API dependencies.

### Endpoints fixed

`GET /self/loanproducts` · `GET /self/loanproducts/{id}` · `GET /self/savingsproducts` · `GET /self/savingsproducts/{id}` · `GET /self/products/share` · `GET /self/products/share/{id}`

### Verified

✅ 82 unit tests pass · ✅ Docker E2E — all 6 endpoints return correct responses · ✅ Core admin API unaffected
