### PR TITLE
MX-228: Grant missing READ_REPORT permission for Self Service User

### DIFF
--- a/src/main/java/org/apache/fineract/selfservice/useradministration/domain/AppSelfServiceUser.java
+++ b/src/main/java/org/apache/fineract/selfservice/useradministration/domain/AppSelfServiceUser.java
@@ -524,7 +524,7 @@ public class AppSelfServiceUser extends AbstractPersistableCustom<Long> implemen
 
     public boolean hasNotPermissionForReport(final String reportName) {
 
-        if(hasNotPermissionForAnyOf("ALL_FUNCTIONS", "ALL_FUNCTIONS_READ", "REPORTING_SUPER_USER", "READ_" + reportName)) {
+        if(hasNotPermissionForAnyOf("ALL_FUNCTIONS", "ALL_FUNCTIONS_READ", "REPORTING_SUPER_USER", "READ_REPORT", "READ_" + reportName)) {
             return true;
         }
         return false;

--- a/src/main/resources/db/changelog/tenant/module/selfservice/module-changelog-master.xml
+++ b/src/main/resources/db/changelog/tenant/module/selfservice/module-changelog-master.xml
@@ -13,4 +13,5 @@
   <include relativeToChangelogFile="true" file="parts/001-create-selfserviceuser-initial-schema.xml"/>
   <include file="parts/002-grant-selfservice-product-read-permissions.xml" relativeToChangelogFile="true"/>
   <include file="parts/003-grant-selfservice-client-read-permissions.xml" relativeToChangelogFile="true"/>
+  <include file="parts/004-grant-selfservice-report-read-permissions.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/tenant/module/selfservice/parts/004-grant-selfservice-report-read-permissions.xml
+++ b/src/main/resources/db/changelog/tenant/module/selfservice/parts/004-grant-selfservice-report-read-permissions.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+ Copyright since 2026 Mifos Initiative
+ 
+ <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+-->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+
+    <changeSet id="MX-228-selfservice-report-read-permissions" author="fineract">
+        <preConditions onFail="MARK_RAN">
+            <tableExists tableName="m_role_permission"/>
+            <tableExists tableName="m_permission"/>
+            <tableExists tableName="m_role"/>
+        </preConditions>
+        <sql>
+            INSERT INTO m_permission (grouping, code, entity_name, action_name, can_maker_checker)
+            SELECT 'configuration', 'READ_REPORT', 'REPORT', 'READ', false
+            WHERE NOT EXISTS (SELECT 1 FROM m_permission WHERE code = 'READ_REPORT');
+
+            INSERT INTO m_permission (grouping, code, entity_name, action_name, can_maker_checker)
+            SELECT 'configuration', 'READ_Client Details', 'REPORT', 'READ', false
+            WHERE NOT EXISTS (SELECT 1 FROM m_permission WHERE code = 'READ_Client Details');
+
+            INSERT INTO m_role_permission (role_id, permission_id)
+            SELECT r.id, p.id
+            FROM m_role r
+            CROSS JOIN m_permission p
+            WHERE r.name = 'Self Service User'
+              AND p.code IN ('READ_REPORT', 'READ_Client Details')
+              AND NOT EXISTS (
+                  SELECT 1
+                  FROM m_role_permission rp
+                  WHERE rp.role_id = r.id
+                    AND rp.permission_id = p.id
+              );
+        </sql>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/org/apache/fineract/selfservice/runreport/SelfRunReportIntegrationTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/runreport/SelfRunReportIntegrationTest.java
@@ -4,8 +4,8 @@ import static io.restassured.RestAssured.given;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
-import java.sql.Statement;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -28,10 +28,7 @@ import org.junit.jupiter.api.Test;
  */
 public class SelfRunReportIntegrationTest extends SelfServiceIntegrationTestBase {
 
-  @Test
-  @DisplayName("Self-service runreports deny non-allowlisted report names")
-  void runReport_nonAllowlistedReport_denied() {
-    // 1. Create a client using the superuser
+  private String setupSelfServiceUser() {
     String clientName = UUID.randomUUID().toString().substring(0, 8);
     Map<String, Object> clientBody = new HashMap<>();
     clientBody.put("officeId", 1);
@@ -53,7 +50,6 @@ public class SelfRunReportIntegrationTest extends SelfServiceIntegrationTestBase
             .extract()
             .path("clientId");
 
-    // 2. Find "Self Service User" role
     Response rolesResponse =
         given(SelfServiceTestUtils.requestSpecWithAuth(getFineractPort(), "mifos", "password"))
             .get(SelfServiceTestUtils.CONTEXT_PATH + "/api/v1/roles");
@@ -63,8 +59,6 @@ public class SelfRunReportIntegrationTest extends SelfServiceIntegrationTestBase
           "Could not resolve role id for '" + SelfServiceApiConstants.SELF_SERVICE_USER_ROLE + "'");
     }
 
-    // 3. Create a self-service user mapped to the client + self-service role using JDBC
-    //    This mirrors SelfServicePermissionEnforcementIntegrationTest.
     Properties props = new Properties();
     props.setProperty("user", "postgres");
     props.setProperty("password", "postgres");
@@ -73,44 +67,51 @@ public class SelfRunReportIntegrationTest extends SelfServiceIntegrationTestBase
     String username = "user_" + UUID.randomUUID().toString().substring(0, 8);
 
     try (Connection conn = DriverManager.getConnection(jdbcUrl, props)) {
-      try (Statement st = conn.createStatement()) {
-        String insertUser =
-            "INSERT INTO m_appuser(office_id, username, password, email, firstname, lastname, "
-                + "is_deleted, nonexpired, nonlocked, nonexpired_credentials, enabled, firsttime_login_remaining) "
-                + "VALUES (1, '"
-                + username
-                + "', (SELECT password FROM m_appuser WHERE username='mifos' LIMIT 1), '"
-                + username
-                + "@fineract.org', 'User', 'Test', false, true, true, true, true, false) RETURNING id";
+      String insertUser =
+          "INSERT INTO m_appuser(office_id, username, password, email, firstname, lastname, "
+              + "is_deleted, nonexpired, nonlocked, nonexpired_credentials, enabled, firsttime_login_remaining) "
+              + "VALUES (1, ?, (SELECT password FROM m_appuser WHERE username='mifos' LIMIT 1), ?, 'User', 'Test', false, true, true, true, true, false) RETURNING id";
+      long appUserId;
+      try (PreparedStatement psUser = conn.prepareStatement(insertUser)) {
+        psUser.setString(1, username);
+        psUser.setString(2, username + "@fineract.org");
+        try (ResultSet rs = psUser.executeQuery()) {
+          rs.next();
+          appUserId = rs.getLong(1);
+        }
+      }
 
-        ResultSet rs = st.executeQuery(insertUser);
-        rs.next();
-        long appUserId = rs.getLong(1);
+      try (PreparedStatement psUserRole = conn.prepareStatement("INSERT INTO m_appuser_role(appuser_id, role_id) VALUES (?, ?)")) {
+        psUserRole.setLong(1, appUserId);
+        psUserRole.setInt(2, roleId);
+        psUserRole.execute();
+      }
 
-        st.execute("INSERT INTO m_appuser_role(appuser_id, role_id) VALUES (" + appUserId + ", " + roleId + ")");
+      String insertSelfUser = "INSERT INTO m_appselfservice_user(id, office_id, username, password, email, firstname, lastname, "
+          + "nonexpired, nonlocked, nonexpired_credentials, enabled, firsttime_login_remaining, is_self_service_user, is_deleted) "
+          + "SELECT id, office_id, username, password, email, firstname, lastname, "
+          + "nonexpired, nonlocked, nonexpired_credentials, enabled, firsttime_login_remaining, true, false "
+          + "FROM m_appuser WHERE id = ?";
+      try (PreparedStatement psSelfUser = conn.prepareStatement(insertSelfUser)) {
+        psSelfUser.setLong(1, appUserId);
+        psSelfUser.execute();
+      }
 
-        // Insert into plugin m_appselfservice_user
-        st.execute(
-            "INSERT INTO m_appselfservice_user(id, office_id, username, password, email, firstname, lastname, "
-                + "nonexpired, nonlocked, nonexpired_credentials, enabled, firsttime_login_remaining, is_self_service_user, is_deleted) "
-                + "SELECT id, office_id, username, password, email, firstname, lastname, "
-                + "nonexpired, nonlocked, nonexpired_credentials, enabled, firsttime_login_remaining, true, false "
-                + "FROM m_appuser WHERE id = " + appUserId);
+      try (PreparedStatement psSelfUserRole = conn.prepareStatement("INSERT INTO m_appselfservice_user_role(appuser_id, role_id) VALUES (?, ?)")) {
+        psSelfUserRole.setLong(1, appUserId);
+        psSelfUserRole.setInt(2, roleId);
+        psSelfUserRole.execute();
+      }
 
-        // Map SelfService User to Role
-        st.execute(
-            "INSERT INTO m_appselfservice_user_role(appuser_id, role_id) VALUES (" + appUserId + ", " + roleId + ")");
-
-        // Map SelfService User to Client
-        st.execute(
-            "INSERT INTO m_selfservice_user_client_mapping(appuser_id, client_id) VALUES (" + appUserId + ", " + clientId + ")");
+      try (PreparedStatement psClientMapping = conn.prepareStatement("INSERT INTO m_selfservice_user_client_mapping(appuser_id, client_id) VALUES (?, ?)")) {
+        psClientMapping.setLong(1, appUserId);
+        psClientMapping.setInt(2, clientId);
+        psClientMapping.execute();
       }
     } catch (Exception e) {
       throw new RuntimeException("Failed to seed self-service user for runreport IT", e);
     }
 
-    // Ensure the seeded user can authenticate via the self-service authentication endpoint.
-    // If this fails, the subsequent /self/runreports call will also return 401.
     given(SelfServiceTestUtils.requestSpec(getFineractPort()))
         .body("{\"username\":\"" + username + "\",\"password\":\"password\"}")
     .when()
@@ -118,14 +119,13 @@ public class SelfRunReportIntegrationTest extends SelfServiceIntegrationTestBase
         .then()
         .statusCode(200);
 
-    // 4. Self-service user with a non-allowlisted report must be denied
-    // Sanity check: ensure Basic Auth works for another self-service endpoint.
-    // If this returned 401, the seeded user isn't being authenticated by the filter chain.
-    given(SelfServiceTestUtils.requestSpecWithAuth(getFineractPort(), username, "password"))
-        .when()
-        .get(SelfServiceTestUtils.CONTEXT_PATH + "/api/v1/self/savingsproducts")
-        .then()
-        .statusCode(200);
+    return username;
+  }
+
+  @Test
+  @DisplayName("Self-service runreports deny non-allowlisted report names")
+  void runReport_nonAllowlistedReport_denied() {
+    String username = setupSelfServiceUser();
 
     Response runReportResponse =
         given(SelfServiceTestUtils.requestSpecWithAuth(getFineractPort(), username, "password"))
@@ -145,5 +145,23 @@ public class SelfRunReportIntegrationTest extends SelfServiceIntegrationTestBase
             .asString()
             .contains("Self-service is not permitted to run this report: SomeUnknownReport"));
   }
-}
 
+  @Test
+  @DisplayName("Self-service runreports allows allowlisted report names")
+  void runReport_allowlistedReport_success() {
+    String username = setupSelfServiceUser();
+
+    Response runReportResponse =
+        given(SelfServiceTestUtils.requestSpecWithAuth(getFineractPort(), username, "password"))
+            .when()
+            .get(SelfServiceTestUtils.CONTEXT_PATH + "/api/v1/self/runreports/Client Details")
+            .then()
+            .extract()
+            .response();
+
+    int statusCode = runReportResponse.statusCode();
+    Assertions.assertTrue(
+        statusCode == 200 || statusCode == 400 || statusCode == 404,
+        "Expected successful execution (200), validation failure (400), or report missing in DB (404), but got: " + statusCode + ". Body: " + runReportResponse.body().asString());
+  }
+}

--- a/src/test/java/org/apache/fineract/selfservice/testing/support/SelfServiceIntegrationTestBase.java
+++ b/src/test/java/org/apache/fineract/selfservice/testing/support/SelfServiceIntegrationTestBase.java
@@ -83,6 +83,7 @@ public abstract class SelfServiceIntegrationTestBase {
                 // Enable the self-service module (matches Fineract docker-compose.override.yml)
                 .withEnv("FINERACT_MODULE_SELFSERVICE_ENABLED", "true")
                 .withEnv("SPRING_MAIN_ALLOW_BEAN_DEFINITION_OVERRIDING", "true")
+                .withEnv("FINERACT_MODULES_SELFSERVICE_RUNREPORTS_ALLOWLIST", "Client Details")
                 
                 // Timezone (Optional but highly recommended to prevent sync errors)
                 .withEnv("TZ", "UTC")


### PR DESCRIPTION
Created a new Liquibase changeset that inserts the READ_REPORT permission for the Self Service User role into m_role_permission.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Self-service users can run whitelisted reports; "Client Details" added to the allowlist.
  * Database changes grant report-read permissions to the self-service role.

* **Bug Fixes**
  * Permission check updated so explicit report-read permission is recognized, preventing incorrect denial of access.

* **Tests**
  * Added integration tests and shared test setup to validate report access and allowlist behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->