### PR TITLE
MX-229: Split the grants in an independent file

### DIFF
--- a/src/main/resources/db/changelog/tenant/module/selfservice/module-changelog-master.xml
+++ b/src/main/resources/db/changelog/tenant/module/selfservice/module-changelog-master.xml
@@ -14,4 +14,5 @@
   <include file="parts/002-grant-selfservice-product-read-permissions.xml" relativeToChangelogFile="true"/>
   <include file="parts/003-grant-selfservice-client-read-permissions.xml" relativeToChangelogFile="true"/>
   <include file="parts/004-grant-selfservice-report-read-permissions.xml" relativeToChangelogFile="true"/>
+  <include file="parts/005-grant-selfservice-savings-account-read-permissions.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/tenant/module/selfservice/parts/001-create-selfserviceuser-initial-schema.xml
+++ b/src/main/resources/db/changelog/tenant/module/selfservice/parts/001-create-selfserviceuser-initial-schema.xml
@@ -289,28 +289,5 @@
                 WHERE t.id = s.id
             );
         </sql>
-    </changeSet>    
-    <!-- Give minimal grants for Savings Account to the Self Service Role-->
-    <changeSet author="fineract" id="ss-0001-13">
-        <preConditions onFail="MARK_RAN">            
-            <tableExists tableName="m_role_permission"/>
-            <tableExists tableName="m_permission"/>
-            <tableExists tableName="m_role"/>
-        </preConditions>
-        <sql>
-            INSERT INTO m_role_permission (role_id, permission_id)
-            SELECT 
-                r.id AS role_id,
-                p.id AS permission_id
-            FROM m_role r
-            JOIN m_permission p ON p.code = 'READ_SAVINGSACCOUNT'
-            WHERE r.name = 'Self Service User'
-              AND NOT EXISTS (
-                    SELECT 1 
-                    FROM m_role_permission rp 
-                    WHERE rp.role_id = r.id 
-                      AND rp.permission_id = p.id
-                  );
-        </sql>
-    </changeSet>
+    </changeSet>        
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/tenant/module/selfservice/parts/005-grant-selfservice-savings-account-read-permissions.xml
+++ b/src/main/resources/db/changelog/tenant/module/selfservice/parts/005-grant-selfservice-savings-account-read-permissions.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+ Copyright since 2026 Mifos Initiative
+ 
+ <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+-->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+    <!-- Give minimal grants for Savings Account to the Self Service Role-->
+    <changeSet author="fineract" id="ss-0005-1">
+        <preConditions onFail="MARK_RAN">            
+            <tableExists tableName="m_role_permission"/>
+            <tableExists tableName="m_permission"/>
+            <tableExists tableName="m_role"/>
+        </preConditions>
+        <sql>
+            INSERT INTO m_role_permission (role_id, permission_id)
+            SELECT 
+                r.id AS role_id,
+                p.id AS permission_id
+            FROM m_role r
+            JOIN m_permission p ON p.code = 'READ_SAVINGSACCOUNT'
+            WHERE r.name = 'Self Service User'
+              AND NOT EXISTS (
+                    SELECT 1 
+                    FROM m_role_permission rp 
+                    WHERE rp.role_id = r.id 
+                      AND rp.permission_id = p.id
+                  );
+        </sql>
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized database migration structure for selfservice module permissions.
  * Updated Self Service User role to grant savings account read access through a dedicated migration file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->