### PR TITLE
MX-233: Fix ClassCastExceptions in self-service beneficiary operations

### DIFF
--- a/src/main/java/org/apache/fineract/selfservice/account/domain/SelfBeneficiariesTPT.java
+++ b/src/main/java/org/apache/fineract/selfservice/account/domain/SelfBeneficiariesTPT.java
@@ -33,7 +33,7 @@ import org.apache.fineract.infrastructure.core.domain.AbstractPersistableCustom;
           columnNames = {"name", "app_user_id", "is_active"},
           name = "name")
     })
-public class SelfBeneficiariesTPT extends AbstractPersistableCustom {
+public class SelfBeneficiariesTPT extends AbstractPersistableCustom<Long> {
 
   @Column(name = "app_user_id", nullable = false)
   private Long appUserId;

--- a/src/main/java/org/apache/fineract/selfservice/account/service/SelfBeneficiariesTPTWritePlatformServiceImpl.java
+++ b/src/main/java/org/apache/fineract/selfservice/account/service/SelfBeneficiariesTPTWritePlatformServiceImpl.java
@@ -44,6 +44,10 @@ import org.apache.fineract.selfservice.useradministration.domain.AppSelfServiceU
 import org.springframework.dao.DataAccessException;
 import org.springframework.transaction.annotation.Transactional;
 
+/**
+ * Implementation of {@link SelfBeneficiariesTPTWritePlatformService} 
+ * handling the business logic for creating, updating, and deleting self-service beneficiaries.
+ */
 @RequiredArgsConstructor
 @Slf4j
 public class SelfBeneficiariesTPTWritePlatformServiceImpl
@@ -55,6 +59,12 @@ public class SelfBeneficiariesTPTWritePlatformServiceImpl
   private final LoanRepositoryWrapper loanRepositoryWrapper;
   private final SavingsAccountRepositoryWrapper savingRepositoryWrapper;
 
+  /**
+   * Adds a new self-service beneficiary.
+   *
+   * @param command the JSON command containing beneficiary details
+   * @return the result containing the generated entity ID
+   */
   @Transactional
   @Override
   public CommandProcessingResult add(JsonCommand command) {
@@ -104,7 +114,7 @@ public class SelfBeneficiariesTPTWritePlatformServiceImpl
                 user.getId(), name, officeId, clientId, accountId, accountType, transferLimit);
         this.repository.saveAndFlush(beneficiary);
         return new CommandProcessingResultBuilder()
-            .withEntityId((Long) beneficiary.getId())
+            .withEntityId(beneficiary.getId())
             .build();
       } catch (DataAccessException dae) {
         handleDataIntegrityIssues(command, dae);
@@ -114,6 +124,12 @@ public class SelfBeneficiariesTPTWritePlatformServiceImpl
         officeName, accountNumber, PortfolioAccountType.fromInt(accountType).getCode());
   }
 
+  /**
+   * Updates an existing self-service beneficiary.
+   *
+   * @param command the JSON command containing the fields to update
+   * @return the result containing the entity ID and the changes made
+   */
   @Transactional
   @Override
   public CommandProcessingResult update(JsonCommand command) {
@@ -131,7 +147,7 @@ public class SelfBeneficiariesTPTWritePlatformServiceImpl
           this.repository.saveAndFlush(beneficiary);
 
           return new CommandProcessingResultBuilder() //
-              .withEntityId((Long) beneficiary.getId()) //
+              .withEntityId(beneficiary.getId()) //
               .with(changes)
               .build();
         } catch (DataAccessException dae) {
@@ -142,6 +158,12 @@ public class SelfBeneficiariesTPTWritePlatformServiceImpl
     throw new InvalidBeneficiaryException(beneficiaryId);
   }
 
+  /**
+   * Deallocates or softly deletes a self-service beneficiary.
+   *
+   * @param command the JSON command requesting deletion
+   * @return the result containing the deleted entity ID
+   */
   @Transactional
   @Override
   public CommandProcessingResult delete(JsonCommand command) {
@@ -154,7 +176,7 @@ public class SelfBeneficiariesTPTWritePlatformServiceImpl
       this.repository.save(beneficiary);
 
       return new CommandProcessingResultBuilder() //
-          .withEntityId((Long) beneficiary.getId()) //
+          .withEntityId(beneficiary.getId()) //
           .build();
     }
     throw new InvalidBeneficiaryException(beneficiaryId);

--- a/src/main/java/org/apache/fineract/selfservice/security/service/SelfServiceCompatibleSecurityContext.java
+++ b/src/main/java/org/apache/fineract/selfservice/security/service/SelfServiceCompatibleSecurityContext.java
@@ -15,11 +15,11 @@
 package org.apache.fineract.selfservice.security.service;
 
 import java.lang.reflect.Field;
+import org.apache.fineract.commands.domain.CommandWrapper;
 import org.apache.fineract.infrastructure.configuration.domain.ConfigurationDomainService;
 import org.apache.fineract.infrastructure.security.service.SpringSecurityPlatformSecurityContext;
 import org.apache.fineract.selfservice.useradministration.domain.AppSelfServiceUser;
 import org.apache.fineract.useradministration.domain.AppUser;
-import org.apache.fineract.useradministration.exception.UnAuthenticatedUserException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -40,6 +40,11 @@ public class SelfServiceCompatibleSecurityContext extends SpringSecurityPlatform
     super(configurationDomainService);
   }
 
+  /**
+   * Retrieves the authenticated user, wrapping self-service users in a stub.
+   *
+   * @return the authenticated AppUser
+   */
   @Override
   public AppUser authenticatedUser() {
     final Object principal = extractPrincipal();
@@ -51,6 +56,28 @@ public class SelfServiceCompatibleSecurityContext extends SpringSecurityPlatform
     return super.authenticatedUser();
   }
 
+  /**
+   * Retrieves the authenticated user from the context for a specific command.
+   *
+   * @param commandWrapper the command wrapper contextualizing the request
+   * @return the authenticated AppUser
+   */
+  @Override
+  public AppUser authenticatedUser(final CommandWrapper commandWrapper) {
+    final Object principal = extractPrincipal();
+
+    if (principal instanceof AppSelfServiceUser selfServiceUser) {
+      return toAppUserStub(selfServiceUser);
+    }
+
+    return super.authenticatedUser(commandWrapper);
+  }
+
+  /**
+   * Retrieves the authenticated user if one is currently present in the security context.
+   *
+   * @return the authenticated AppUser, or null if none
+   */
   @Override
   public AppUser getAuthenticatedUserIfPresent() {
     final Object principal = extractPrincipal();

--- a/src/main/resources/db/changelog/tenant/module/selfservice/module-changelog-master.xml
+++ b/src/main/resources/db/changelog/tenant/module/selfservice/module-changelog-master.xml
@@ -16,4 +16,5 @@
   <include file="parts/004-grant-selfservice-product-read-permissions.xml" relativeToChangelogFile="true"/>
   <include file="parts/005-grant-selfservice-report-read-permissions.xml" relativeToChangelogFile="true"/>
   <include file="parts/006-grant-selfservice-savings-account-read-permissions.xml" relativeToChangelogFile="true"/>
+  <include file="parts/007-grant-selfservice-beneficiary-tpt-permissions.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/tenant/module/selfservice/parts/007-grant-selfservice-beneficiary-tpt-permissions.xml
+++ b/src/main/resources/db/changelog/tenant/module/selfservice/parts/007-grant-selfservice-beneficiary-tpt-permissions.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+ Copyright since 2026 Mifos Initiative
+ 
+ <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+-->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+
+    <!-- Grant beneficiary TPT CRUD permissions to the 'Self Service User' role. -->
+    <changeSet id="ss-0007-1" author="fineract">
+        <preConditions onFail="MARK_RAN">
+            <tableExists tableName="m_role_permission"/>
+            <tableExists tableName="m_permission"/>
+            <tableExists tableName="m_role"/>
+        </preConditions>
+        <sql>
+            INSERT INTO m_permission (grouping, code, entity_name, action_name, can_maker_checker)
+            SELECT 'SSBENEFICIARYTPT', 'CREATE_SSBENEFICIARYTPT', 'SSBENEFICIARYTPT', 'CREATE', false
+            WHERE NOT EXISTS (SELECT 1 FROM m_permission WHERE code = 'CREATE_SSBENEFICIARYTPT');
+
+            INSERT INTO m_permission (grouping, code, entity_name, action_name, can_maker_checker)
+            SELECT 'SSBENEFICIARYTPT', 'UPDATE_SSBENEFICIARYTPT', 'SSBENEFICIARYTPT', 'UPDATE', false
+            WHERE NOT EXISTS (SELECT 1 FROM m_permission WHERE code = 'UPDATE_SSBENEFICIARYTPT');
+
+            INSERT INTO m_permission (grouping, code, entity_name, action_name, can_maker_checker)
+            SELECT 'SSBENEFICIARYTPT', 'DELETE_SSBENEFICIARYTPT', 'SSBENEFICIARYTPT', 'DELETE', false
+            WHERE NOT EXISTS (SELECT 1 FROM m_permission WHERE code = 'DELETE_SSBENEFICIARYTPT');
+
+            INSERT INTO m_permission (grouping, code, entity_name, action_name, can_maker_checker)
+            SELECT 'SSBENEFICIARYTPT', 'READ_SSBENEFICIARYTPT', 'SSBENEFICIARYTPT', 'READ', false
+            WHERE NOT EXISTS (SELECT 1 FROM m_permission WHERE code = 'READ_SSBENEFICIARYTPT');
+
+            INSERT INTO m_role_permission (role_id, permission_id)
+            SELECT r.id, p.id
+            FROM m_role r
+            CROSS JOIN m_permission p
+            WHERE r.name = 'Self Service User'
+              AND p.code IN ('CREATE_SSBENEFICIARYTPT', 'UPDATE_SSBENEFICIARYTPT', 'DELETE_SSBENEFICIARYTPT', 'READ_SSBENEFICIARYTPT')
+              AND NOT EXISTS (
+                  SELECT 1
+                  FROM m_role_permission rp
+                  WHERE rp.role_id = r.id
+                    AND rp.permission_id = p.id
+              );
+        </sql>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/org/apache/fineract/selfservice/account/api/SelfBeneficiaryTPTIT.java
+++ b/src/test/java/org/apache/fineract/selfservice/account/api/SelfBeneficiaryTPTIT.java
@@ -1,0 +1,348 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.fineract.selfservice.account.api;
+
+import static io.restassured.RestAssured.given;
+
+import io.restassured.response.Response;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.UUID;
+import org.apache.fineract.selfservice.registration.SelfServiceApiConstants;
+import org.apache.fineract.selfservice.testing.support.SelfServiceIntegrationTestBase;
+import org.apache.fineract.selfservice.testing.support.SelfServiceTestUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * E2E tests for self-service beneficiary TPT operations (add, update, delete).
+ */
+public class SelfBeneficiaryTPTIT extends SelfServiceIntegrationTestBase {
+
+  private static final String BENEFICIARIES_PATH =
+      SelfServiceTestUtils.CONTEXT_PATH + "/api/v1/self/beneficiaries/tpt";
+
+  private SeedResult seedSelfServiceUserAndSavingsAccount() {
+    String uniqueSuffix = UUID.randomUUID().toString().substring(0, 8);
+    Integer clientId = createClient(uniqueSuffix);
+    Integer productId = createSavingsProduct(uniqueSuffix);
+    Integer savingsId = openSavingsAccount(clientId, productId);
+    String accountNumber = activateAndGetSavingsAccountNumber(savingsId);
+    
+    Integer roleId = getSelfServiceRoleId();
+    String username = insertSelfServiceUserDirectly(uniqueSuffix, clientId, roleId);
+    
+    authenticateSelfUser(username);
+    return new SeedResult(username, accountNumber);
+  }
+
+  private Integer createClient(String uniqueSuffix) {
+    Map<String, Object> body = new HashMap<>();
+    body.put("officeId", 1);
+    body.put("legalFormId", 1);
+    body.put("firstname", "Beneficiary");
+    body.put("lastname", uniqueSuffix);
+    body.put("externalId", uniqueSuffix);
+    body.put("dateFormat", "dd MMMM yyyy");
+    body.put("locale", "en_GB");
+    body.put("active", true);
+    body.put("activationDate", "01 January 2026");
+
+    return given(SelfServiceTestUtils.requestSpecWithAuth(getFineractPort(), "mifos", "password"))
+        .body(body)
+        .post(SelfServiceTestUtils.CONTEXT_PATH + "/api/v1/clients")
+        .then()
+        .statusCode(200)
+        .extract()
+        .path("clientId");
+  }
+
+  private Integer createSavingsProduct(String uniqueSuffix) {
+    Map<String, Object> body = new HashMap<>();
+    body.put("name", "SS-Product-" + uniqueSuffix);
+    body.put("shortName", uniqueSuffix.substring(0, 4));
+    body.put("description", "Integration test savings product");
+    body.put("currencyCode", "USD");
+    body.put("digitsAfterDecimal", "4");
+    body.put("inMultiplesOf", "0");
+    body.put("locale", "en_GB");
+    body.put("nominalAnnualInterestRate", "10.0");
+    body.put("interestCalculationType", "1");
+    body.put("interestCalculationDaysInYearType", "365");
+    body.put("interestCompoundingPeriodType", "4");
+    body.put("interestPostingPeriodType", "4");
+    body.put("accountingRule", "1");
+
+    return given(SelfServiceTestUtils.requestSpecWithAuth(getFineractPort(), "mifos", "password"))
+        .body(body)
+        .post(SelfServiceTestUtils.CONTEXT_PATH + "/api/v1/savingsproducts")
+        .then()
+        .statusCode(200)
+        .extract()
+        .path("resourceId");
+  }
+
+  private Integer openSavingsAccount(Integer clientId, Integer productId) {
+    Map<String, Object> savingsBody = new HashMap<>();
+    savingsBody.put("clientId", clientId);
+    savingsBody.put("productId", productId);
+    savingsBody.put("locale", "en_GB");
+    savingsBody.put("dateFormat", "dd MMMM yyyy");
+    savingsBody.put("submittedOnDate", "01 January 2026");
+
+    return given(SelfServiceTestUtils.requestSpecWithAuth(getFineractPort(), "mifos", "password"))
+        .body(savingsBody)
+        .post(SelfServiceTestUtils.CONTEXT_PATH + "/api/v1/savingsaccounts")
+        .then()
+        .statusCode(200)
+        .extract()
+        .path("savingsId");
+  }
+
+  private String activateAndGetSavingsAccountNumber(Integer savingsId) {
+    Map<String, Object> approveBody = new HashMap<>();
+    approveBody.put("locale", "en");
+    approveBody.put("dateFormat", "dd MMMM yyyy");
+    approveBody.put("approvedOnDate", "01 January 2026");
+    given(SelfServiceTestUtils.requestSpecWithAuth(getFineractPort(), "mifos", "password"))
+        .body(approveBody)
+        .post(SelfServiceTestUtils.CONTEXT_PATH + "/api/v1/savingsaccounts/" + savingsId + "?command=approve")
+        .then()
+        .statusCode(200);
+
+    Map<String, Object> activateBody = new HashMap<>();
+    activateBody.put("locale", "en");
+    activateBody.put("dateFormat", "dd MMMM yyyy");
+    activateBody.put("activatedOnDate", "01 January 2026");
+    given(SelfServiceTestUtils.requestSpecWithAuth(getFineractPort(), "mifos", "password"))
+        .body(activateBody)
+        .post(SelfServiceTestUtils.CONTEXT_PATH + "/api/v1/savingsaccounts/" + savingsId + "?command=activate")
+        .then()
+        .statusCode(200);
+
+    return given(SelfServiceTestUtils.requestSpecWithAuth(getFineractPort(), "mifos", "password"))
+        .get(SelfServiceTestUtils.CONTEXT_PATH + "/api/v1/savingsaccounts/" + savingsId)
+        .then()
+        .statusCode(200)
+        .extract()
+        .path("accountNo");
+  }
+
+  private Integer getSelfServiceRoleId() {
+    return given(SelfServiceTestUtils.requestSpecWithAuth(getFineractPort(), "mifos", "password"))
+        .get(SelfServiceTestUtils.CONTEXT_PATH + "/api/v1/roles")
+        .then()
+        .statusCode(200)
+        .extract()
+        .path("find { it.name == '" + SelfServiceApiConstants.SELF_SERVICE_USER_ROLE + "' }.id");
+  }
+
+  private String insertSelfServiceUserDirectly(String uniqueSuffix, Integer clientId, Integer roleId) {
+    Properties props = new Properties();
+    props.setProperty("user", "postgres");
+    props.setProperty("password", "postgres");
+    String jdbcUrl = postgres.getJdbcUrl();
+    String username = "ssuser_" + uniqueSuffix;
+
+    try (Connection conn = DriverManager.getConnection(jdbcUrl, props)) {
+      String insertUser = "INSERT INTO m_appuser(office_id, username, password, email, firstname, lastname, "
+          + "is_deleted, nonexpired, nonlocked, nonexpired_credentials, enabled, firsttime_login_remaining) "
+          + "VALUES (1, ?, (SELECT password FROM m_appuser WHERE username='mifos' LIMIT 1), ?, "
+          + "'Beneficiary', 'User', false, true, true, true, true, false) RETURNING id";
+      long appUserId;
+      try (PreparedStatement ps = conn.prepareStatement(insertUser)) {
+        ps.setString(1, username);
+        ps.setString(2, username + "@fineract.org");
+        try (ResultSet rs = ps.executeQuery()) {
+          if (!rs.next()) throw new IllegalStateException("INSERT did not return generated user ID");
+          appUserId = rs.getLong(1);
+        }
+      }
+
+      try (PreparedStatement ps = conn.prepareStatement("INSERT INTO m_appuser_role(appuser_id, role_id) VALUES (?, ?)")) {
+        ps.setLong(1, appUserId);
+        ps.setInt(2, roleId);
+        ps.execute();
+      }
+
+      String insertSelfUser = "INSERT INTO m_appselfservice_user(id, office_id, username, password, email, firstname, lastname, "
+          + "nonexpired, nonlocked, nonexpired_credentials, enabled, firsttime_login_remaining, is_self_service_user, is_deleted) "
+          + "SELECT id, office_id, username, password, email, firstname, lastname, "
+          + "nonexpired, nonlocked, nonexpired_credentials, enabled, firsttime_login_remaining, true, false "
+          + "FROM m_appuser WHERE id = ?";
+      try (PreparedStatement ps = conn.prepareStatement(insertSelfUser)) {
+        ps.setLong(1, appUserId);
+        ps.execute();
+      }
+
+      try (PreparedStatement ps = conn.prepareStatement("INSERT INTO m_appselfservice_user_role(appuser_id, role_id) VALUES (?, ?)")) {
+        ps.setLong(1, appUserId);
+        ps.setInt(2, roleId);
+        ps.execute();
+      }
+
+      try (PreparedStatement ps = conn.prepareStatement("INSERT INTO m_selfservice_user_client_mapping(appuser_id, client_id) VALUES (?, ?)")) {
+        ps.setLong(1, appUserId);
+        ps.setInt(2, clientId);
+        ps.execute();
+      }
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to seed self-service user for beneficiary IT", e);
+    }
+    return username;
+  }
+
+  private void authenticateSelfUser(String username) {
+    given(SelfServiceTestUtils.requestSpec(getFineractPort()))
+        .body("{\"username\":\"" + username + "\",\"password\":\"password\"}")
+        .post(SelfServiceTestUtils.SELF_AUTH_PATH)
+        .then()
+        .statusCode(200);
+  }
+
+  /**
+   * Tests successfully adding a beneficiary using a self-service user context.
+   */
+  @Test
+  @DisplayName("POST /self/beneficiaries/tpt returns 200 for self-service user")
+  void addBeneficiary_selfServiceUser_returns200() {
+    SeedResult seed = seedSelfServiceUserAndSavingsAccount();
+
+    Map<String, Object> body = new HashMap<>();
+    body.put("locale", "en");
+    body.put("name", "Test Beneficiary");
+    body.put("officeName", "Head Office");
+    body.put("accountNumber", seed.accountNumber());
+    body.put("accountType", 2);
+    body.put("transferLimit", 500);
+
+    Response response =
+        given(SelfServiceTestUtils.requestSpecWithAuth(getFineractPort(), seed.username(), "password"))
+            .body(body)
+            .post(BENEFICIARIES_PATH)
+            .then()
+            .extract()
+            .response();
+
+    Assertions.assertEquals(
+        200,
+        response.statusCode(),
+        "Expected 200 but got: " + response.statusCode() + ". Body: " + response.body().asString());
+    Integer resourceId = response.jsonPath().getInt("resourceId");
+    Assertions.assertNotNull(resourceId, "resourceId should be present in response");
+  }
+
+  /**
+   * Tests successfully updating an existing beneficiary using a self-service user context.
+   */
+  @Test
+  @DisplayName("PUT /self/beneficiaries/tpt/{id} returns 200 for self-service user")
+  void updateBeneficiary_selfServiceUser_returns200() {
+    SeedResult seed = seedSelfServiceUserAndSavingsAccount();
+
+    Map<String, Object> addBody = new HashMap<>();
+    addBody.put("locale", "en");
+    addBody.put("name", "Update Test Beneficiary");
+    addBody.put("officeName", "Head Office");
+    addBody.put("accountNumber", seed.accountNumber());
+    addBody.put("accountType", 2);
+    addBody.put("transferLimit", 500);
+
+    Integer beneficiaryId =
+        given(SelfServiceTestUtils.requestSpecWithAuth(getFineractPort(), seed.username(), "password"))
+            .body(addBody)
+            .post(BENEFICIARIES_PATH)
+            .then()
+            .statusCode(200)
+            .extract()
+            .path("resourceId");
+
+    Map<String, Object> updateBody = new HashMap<>();
+    updateBody.put("name", "Updated Name");
+    updateBody.put("transferLimit", 1000);
+
+    Response updateResponse =
+        given(SelfServiceTestUtils.requestSpecWithAuth(getFineractPort(), seed.username(), "password"))
+            .body(updateBody)
+            .put(BENEFICIARIES_PATH + "/" + beneficiaryId)
+            .then()
+            .extract()
+            .response();
+
+    Assertions.assertEquals(
+        200,
+        updateResponse.statusCode(),
+        "PUT returned: " + updateResponse.statusCode() + ". Body: " + updateResponse.body().asString());
+
+    given(SelfServiceTestUtils.requestSpecWithAuth(getFineractPort(), seed.username(), "password"))
+        .get(BENEFICIARIES_PATH)
+        .then()
+        .statusCode(200)
+        .body("find { it.id == " + beneficiaryId + " }.name", org.hamcrest.Matchers.equalTo("Updated Name"))
+        .body("find { it.id == " + beneficiaryId + " }.transferLimit", org.hamcrest.Matchers.equalTo(1000));
+  }
+
+  /**
+   * Tests successfully deleting a beneficiary using a self-service user context.
+   */
+  @Test
+  @DisplayName("DELETE /self/beneficiaries/tpt/{id} returns 200 for self-service user")
+  void deleteBeneficiary_selfServiceUser_returns200() {
+    SeedResult seed = seedSelfServiceUserAndSavingsAccount();
+
+    Map<String, Object> addBody = new HashMap<>();
+    addBody.put("locale", "en");
+    addBody.put("name", "Delete Test Beneficiary");
+    addBody.put("officeName", "Head Office");
+    addBody.put("accountNumber", seed.accountNumber());
+    addBody.put("accountType", 2);
+    addBody.put("transferLimit", 500);
+
+    Integer beneficiaryId =
+        given(SelfServiceTestUtils.requestSpecWithAuth(getFineractPort(), seed.username(), "password"))
+            .body(addBody)
+            .post(BENEFICIARIES_PATH)
+            .then()
+            .statusCode(200)
+            .extract()
+            .path("resourceId");
+
+    Response deleteResponse =
+        given(SelfServiceTestUtils.requestSpecWithAuth(getFineractPort(), seed.username(), "password"))
+            .delete(BENEFICIARIES_PATH + "/" + beneficiaryId)
+            .then()
+            .extract()
+            .response();
+
+    Assertions.assertEquals(
+        200,
+        deleteResponse.statusCode(),
+        "DELETE returned: " + deleteResponse.statusCode() + ". Body: " + deleteResponse.body().asString());
+
+    given(SelfServiceTestUtils.requestSpecWithAuth(getFineractPort(), seed.username(), "password"))
+        .get(BENEFICIARIES_PATH)
+        .then()
+        .statusCode(200)
+        .body("find { it.id == " + beneficiaryId + " }", org.hamcrest.Matchers.nullValue());
+  }
+
+  private record SeedResult(String username, String accountNumber) {}
+}

--- a/src/test/java/org/apache/fineract/selfservice/security/service/SelfServiceCompatibleSecurityContextTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/security/service/SelfServiceCompatibleSecurityContextTest.java
@@ -15,13 +15,15 @@
 package org.apache.fineract.selfservice.security.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.HashMap;
+import java.util.HashSet;
+import org.apache.fineract.commands.domain.CommandWrapper;
 import org.apache.fineract.infrastructure.businessdate.domain.BusinessDateType;
 import org.apache.fineract.infrastructure.configuration.domain.ConfigurationDomainService;
 import org.apache.fineract.infrastructure.core.domain.FineractPlatformTenant;
@@ -29,6 +31,7 @@ import org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil;
 import org.apache.fineract.organisation.office.domain.Office;
 import org.apache.fineract.selfservice.useradministration.domain.AppSelfServiceUser;
 import org.apache.fineract.useradministration.domain.AppUser;
+import org.apache.fineract.useradministration.exception.UnAuthenticatedUserException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -37,8 +40,12 @@ import org.springframework.security.core.context.SecurityContextHolder;
 
 class SelfServiceCompatibleSecurityContextTest {
 
+  private ConfigurationDomainService config;
+  private SelfServiceCompatibleSecurityContext ctx;
+  private Office office;
+
   @BeforeEach
-  void setUpTenantContext() {
+  void setUp() {
     FineractPlatformTenant tenant =
         new FineractPlatformTenant(1L, "default", "Default Tenant", "UTC", null);
     ThreadLocalContextUtil.setTenant(tenant);
@@ -46,6 +53,12 @@ class SelfServiceCompatibleSecurityContextTest {
     businessDates.put(BusinessDateType.BUSINESS_DATE, LocalDate.now());
     businessDates.put(BusinessDateType.COB_DATE, LocalDate.now().minusDays(1));
     ThreadLocalContextUtil.setBusinessDates(businessDates);
+
+    config = mock(ConfigurationDomainService.class);
+    ctx = new SelfServiceCompatibleSecurityContext(config);
+
+    office = mock(Office.class);
+    when(office.getId()).thenReturn(1L);
   }
 
   @AfterEach
@@ -54,18 +67,11 @@ class SelfServiceCompatibleSecurityContextTest {
     ThreadLocalContextUtil.clearTenant();
   }
 
-  @Test
-  void authenticatedUser_shouldReturnAppUserStubForSelfServicePrincipal() {
-    ConfigurationDomainService config = mock(ConfigurationDomainService.class);
-    SelfServiceCompatibleSecurityContext ctx = new SelfServiceCompatibleSecurityContext(config);
-
-    Office office = mock(Office.class);
-    when(office.getId()).thenReturn(1L);
-
+  private AppSelfServiceUser mockSelfServiceUser(long id, String username) {
     AppSelfServiceUser principal = mock(AppSelfServiceUser.class);
-    when(principal.getId()).thenReturn(42L);
+    when(principal.getId()).thenReturn(id);
     when(principal.getOffice()).thenReturn(office);
-    when(principal.getUsername()).thenReturn("ssuser");
+    when(principal.getUsername()).thenReturn(username);
     when(principal.getPassword()).thenReturn("secret");
     when(principal.isEnabled()).thenReturn(true);
     when(principal.isAccountNonExpired()).thenReturn(true);
@@ -73,49 +79,121 @@ class SelfServiceCompatibleSecurityContextTest {
     when(principal.isAccountNonLocked()).thenReturn(true);
     when(principal.getAuthorities()).thenReturn(new ArrayList<>());
     when(principal.getRoles()).thenReturn(new HashSet<>());
-    when(principal.getEmail()).thenReturn("ss@test.com");
-    when(principal.getFirstname()).thenReturn("Self");
-    when(principal.getLastname()).thenReturn("User");
+    when(principal.getEmail()).thenReturn(username + "@test.com");
+    when(principal.getFirstname()).thenReturn("First");
+    when(principal.getLastname()).thenReturn("Last");
+    return principal;
+  }
 
+  private void setSecurityPrincipal(Object principal) {
     SecurityContextHolder.getContext()
         .setAuthentication(new UsernamePasswordAuthenticationToken(principal, null));
+  }
+
+  private CommandWrapper beneficiaryCommandWrapper() {
+    CommandWrapper cw = mock(CommandWrapper.class);
+    when(cw.actionName()).thenReturn("CREATE");
+    when(cw.getEntityName()).thenReturn("SSBENEFICIARYTPT");
+    when(cw.getEntityId()).thenReturn(null);
+    return cw;
+  }
+
+  // ── authenticatedUser() ──────────────────────────────────────────────────
+
+  /**
+   * Tests that a valid self-service principal returns an AppUser stub.
+   */
+  @Test
+  void authenticatedUser_selfServicePrincipal_returnsStub() {
+    AppSelfServiceUser principal = mockSelfServiceUser(42L, "ssuser");
+    setSecurityPrincipal(principal);
 
     AppUser stub = ctx.authenticatedUser();
+
     assertThat(stub.getId()).isEqualTo(42L);
     assertThat(stub.getUsername()).isEqualTo("ssuser");
     assertThat(stub.getOffice()).isSameAs(office);
+    assertThat(stub.getEmail()).isEqualTo("ssuser@test.com");
+    assertThat(stub.getFirstname()).isEqualTo("First");
+    assertThat(stub.getLastname()).isEqualTo("Last");
   }
 
+  /**
+   * Tests that missing principal throws UnAuthenticatedUserException.
+   */
   @Test
-  void getAuthenticatedUserIfPresent_shouldReturnAppUserStubForSelfServicePrincipal() {
-    ConfigurationDomainService config = mock(ConfigurationDomainService.class);
-    SelfServiceCompatibleSecurityContext ctx = new SelfServiceCompatibleSecurityContext(config);
+  void authenticatedUser_noPrincipal_throwsUnAuthenticatedUserException() {
+    assertThatThrownBy(() -> ctx.authenticatedUser())
+        .isInstanceOf(UnAuthenticatedUserException.class);
+  }
 
-    Office office = mock(Office.class);
-    when(office.getId()).thenReturn(1L);
+  // ── authenticatedUser(CommandWrapper) ────────────────────────────────────
 
-    AppSelfServiceUser principal = mock(AppSelfServiceUser.class);
-    when(principal.getId()).thenReturn(7L);
-    when(principal.getOffice()).thenReturn(office);
-    when(principal.getUsername()).thenReturn("ssuser2");
-    when(principal.getPassword()).thenReturn("secret");
-    when(principal.isEnabled()).thenReturn(true);
-    when(principal.isAccountNonExpired()).thenReturn(true);
-    when(principal.isCredentialsNonExpired()).thenReturn(true);
-    when(principal.isAccountNonLocked()).thenReturn(true);
-    when(principal.getAuthorities()).thenReturn(new ArrayList<>());
-    when(principal.getRoles()).thenReturn(new HashSet<>());
-    when(principal.getEmail()).thenReturn("ss2@test.com");
-    when(principal.getFirstname()).thenReturn("Self");
-    when(principal.getLastname()).thenReturn("User2");
+  /**
+   * Tests context resolution with a command wrapper for self-service users.
+   */
+  @Test
+  void authenticatedUserWithCommandWrapper_selfServicePrincipal_returnsStubWithCorrectFields() {
+    AppSelfServiceUser principal = mockSelfServiceUser(99L, "ssuser3");
+    setSecurityPrincipal(principal);
 
-    SecurityContextHolder.getContext()
-        .setAuthentication(new UsernamePasswordAuthenticationToken(principal, null));
+    AppUser stub = ctx.authenticatedUser(beneficiaryCommandWrapper());
+
+    assertThat(stub.getId()).isEqualTo(99L);
+    assertThat(stub.getUsername()).isEqualTo("ssuser3");
+    assertThat(stub.getOffice()).isSameAs(office);
+    assertThat(stub.getEmail()).isEqualTo("ssuser3@test.com");
+    assertThat(stub.getFirstname()).isEqualTo("First");
+    assertThat(stub.getLastname()).isEqualTo("Last");
+  }
+
+  /**
+   * Tests command wrapper resolution throws when no principal is found.
+   */
+  @Test
+  void authenticatedUserWithCommandWrapper_noPrincipal_throwsUnAuthenticatedUserException() {
+    assertThatThrownBy(() -> ctx.authenticatedUser(beneficiaryCommandWrapper()))
+        .isInstanceOf(UnAuthenticatedUserException.class);
+  }
+
+  /**
+   * Tests that password-expired self-service users are returned without throwing ResetPasswordException.
+   */
+  @Test
+  void authenticatedUserWithCommandWrapper_passwordExpiredSelfServiceUser_returnsStubWithoutThrowingResetPasswordException() {
+    AppSelfServiceUser principal = mockSelfServiceUser(55L, "expireduser");
+    when(principal.isPasswordResetRequired()).thenReturn(true);
+    setSecurityPrincipal(principal);
+
+    AppUser stub = ctx.authenticatedUser(beneficiaryCommandWrapper());
+
+    assertThat(stub.getId()).isEqualTo(55L);
+  }
+
+  // ── getAuthenticatedUserIfPresent() ──────────────────────────────────────
+
+  /**
+   * Tests getAuthenticatedUserIfPresent returns a stub for self-service user.
+   */
+  @Test
+  void getAuthenticatedUserIfPresent_selfServicePrincipal_returnsStub() {
+    AppSelfServiceUser principal = mockSelfServiceUser(7L, "ssuser2");
+    setSecurityPrincipal(principal);
 
     AppUser stub = ctx.getAuthenticatedUserIfPresent();
+
     assertThat(stub.getId()).isEqualTo(7L);
     assertThat(stub.getUsername()).isEqualTo("ssuser2");
     assertThat(stub.getOffice()).isSameAs(office);
   }
-}
 
+  /**
+   * Tests getAuthenticatedUserIfPresent returns null when absent.
+   */
+  @Test
+  void getAuthenticatedUserIfPresent_noPrincipal_returnsNull() {
+    AppUser result = ctx.getAuthenticatedUserIfPresent();
+
+    assertThat(result).isNull();
+  }
+}

--- a/src/test/java/org/apache/fineract/selfservice/testing/support/SelfServiceIntegrationTestBase.java
+++ b/src/test/java/org/apache/fineract/selfservice/testing/support/SelfServiceIntegrationTestBase.java
@@ -98,6 +98,19 @@ public abstract class SelfServiceIntegrationTestBase {
                         MountableFile.forHostPath("target/selfservice-plugin-1.15.0-SNAPSHOT.jar"), 
                         "/app/plugins/selfservice-plugin.jar"
                 )
+                
+                // Prepend the plugin JAR to the JIB container's classpath.
+                .withCreateContainerCmdModifier(cmd -> {
+                    cmd.withEntrypoint(
+                            "sh", "-c",
+                            "CLASSPATH=$(cat /app/jib-classpath-file) && " +
+                            "exec java $JAVA_TOOL_OPTIONS " +
+                            "-Duser.home=/tmp -Dfile.encoding=UTF-8 -Duser.timezone=UTC -Djava.security.egd=file:/dev/./urandom " +
+                            "-cp /app/plugins/selfservice-plugin.jar:$CLASSPATH " +
+                            "org.apache.fineract.ServerApplication"
+                    );
+                    cmd.withCmd();
+                })
                         
                 // HostPortWaitStrategy still runs an internal port check that requires bash (missing in
                 // apache/fineract images). HTTPS + allowInsecure waits until the app serves actuator.


### PR DESCRIPTION
Fixes three bugs that together made the TPT beneficiary feature completely
unusable for self-service users.

- **Security context** — added missing `authenticatedUser(CommandWrapper)` override
  to `SelfServiceCompatibleSecurityContext`; prevents `AppSelfServiceUser` from
  falling through to the base-class hard cast.
- **JPA type erasure** — parameterized `SelfBeneficiariesTPT` as
  `AbstractPersistableCustom<Long>`; eliminates `String → Long` cast on persist.
- **Permissions** — Liquibase migration `007` grants `CREATE/UPDATE/DELETE_SSBENEFICIARYTPT`
  to the Self Service User role; previously 403 on every write.

Verified by 3 new E2E tests (POST / PUT / DELETE) against a real Fineract +
PostgreSQL 15 stack via Testcontainers. All 23 tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled Third Party Transfer (TPT) beneficiary management for self-service users (create/read/update/delete).

* **Security**
  * Improved authentication handling to resolve self-service principals via command-aware lookup.

* **Database**
  * Added permission grants so self-service users receive TPT beneficiary CRUD rights.

* **Tests**
  * Added comprehensive end-to-end integration tests and updated test container runtime setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->