### PR TITLE
MX-235: Fix to MPL for only new generated files

### DIFF
--- a/src/test/java/org/apache/fineract/selfservice/account/api/SelfBeneficiaryTPTIT.java
+++ b/src/test/java/org/apache/fineract/selfservice/account/api/SelfBeneficiaryTPTIT.java
@@ -1,16 +1,8 @@
 /**
- * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
- * agreements. See the NOTICE file distributed with this work for additional information regarding
- * copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the License. You may obtain a
- * copy of the License at
+ * Copyright since 2026 Mifos Initiative
  *
- * <p>http://www.apache.org/licenses/LICENSE-2.0
- *
- * <p>Unless required by applicable law or agreed to in writing, software distributed under the
- * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing permissions and
- * limitations under the License.
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 package org.apache.fineract.selfservice.account.api;
 

--- a/src/test/java/org/apache/fineract/selfservice/client/api/SelfClientsApiIntegrationTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/client/api/SelfClientsApiIntegrationTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package org.apache.fineract.selfservice.client.api;
 
 import static io.restassured.RestAssured.given;

--- a/src/test/java/org/apache/fineract/selfservice/client/api/SelfClientsApiResourceTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/client/api/SelfClientsApiResourceTest.java
@@ -1,16 +1,8 @@
 /**
- * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
- * agreements. See the NOTICE file distributed with this work for additional information regarding
- * copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the License. You may obtain a
- * copy of the License at
+ * Copyright since 2026 Mifos Initiative
  *
- * <p>http://www.apache.org/licenses/LICENSE-2.0
- *
- * <p>Unless required by applicable law or agreed to in writing, software distributed under the
- * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing permissions and
- * limitations under the License.
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 package org.apache.fineract.selfservice.client.api;
 

--- a/src/test/java/org/apache/fineract/selfservice/config/SelfServiceModuleIsEnabledConditionTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/config/SelfServiceModuleIsEnabledConditionTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package org.apache.fineract.selfservice.config;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/src/test/java/org/apache/fineract/selfservice/loanaccount/api/SelfLoansApiResourceTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/loanaccount/api/SelfLoansApiResourceTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package org.apache.fineract.selfservice.loanaccount.api;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -5,8 +11,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;

--- a/src/test/java/org/apache/fineract/selfservice/loanaccount/data/SelfLoansDataValidatorTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/loanaccount/data/SelfLoansDataValidatorTest.java
@@ -1,7 +1,12 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package org.apache.fineract.selfservice.loanaccount.data;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
 
 import java.util.HashMap;
 import org.apache.fineract.infrastructure.core.exception.InvalidJsonException;

--- a/src/test/java/org/apache/fineract/selfservice/products/api/SelfLoanProductsApiResourceTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/products/api/SelfLoanProductsApiResourceTest.java
@@ -1,16 +1,8 @@
 /**
- * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
- * agreements. See the NOTICE file distributed with this work for additional information regarding
- * copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the License. You may obtain a
- * copy of the License at
+ * Copyright since 2026 Mifos Initiative
  *
- * <p>http://www.apache.org/licenses/LICENSE-2.0
- *
- * <p>Unless required by applicable law or agreed to in writing, software distributed under the
- * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing permissions and
- * limitations under the License.
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 package org.apache.fineract.selfservice.products.api;
 

--- a/src/test/java/org/apache/fineract/selfservice/products/api/SelfProductsApiIntegrationTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/products/api/SelfProductsApiIntegrationTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package org.apache.fineract.selfservice.products.api;
 
 import static io.restassured.RestAssured.given;

--- a/src/test/java/org/apache/fineract/selfservice/products/api/SelfSavingsProductsApiResourceTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/products/api/SelfSavingsProductsApiResourceTest.java
@@ -1,16 +1,8 @@
 /**
- * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
- * agreements. See the NOTICE file distributed with this work for additional information regarding
- * copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the License. You may obtain a
- * copy of the License at
+ * Copyright since 2026 Mifos Initiative
  *
- * <p>http://www.apache.org/licenses/LICENSE-2.0
- *
- * <p>Unless required by applicable law or agreed to in writing, software distributed under the
- * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing permissions and
- * limitations under the License.
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 package org.apache.fineract.selfservice.products.api;
 

--- a/src/test/java/org/apache/fineract/selfservice/products/api/SelfShareProductsApiResourceTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/products/api/SelfShareProductsApiResourceTest.java
@@ -1,16 +1,8 @@
 /**
- * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
- * agreements. See the NOTICE file distributed with this work for additional information regarding
- * copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the License. You may obtain a
- * copy of the License at
+ * Copyright since 2026 Mifos Initiative
  *
- * <p>http://www.apache.org/licenses/LICENSE-2.0
- *
- * <p>Unless required by applicable law or agreed to in writing, software distributed under the
- * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing permissions and
- * limitations under the License.
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 package org.apache.fineract.selfservice.products.api;
 

--- a/src/test/java/org/apache/fineract/selfservice/registration/SelfServiceApiConstantsTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/registration/SelfServiceApiConstantsTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package org.apache.fineract.selfservice.registration;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/src/test/java/org/apache/fineract/selfservice/registration/api/SelfServiceRegistrationIntegrationTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/registration/api/SelfServiceRegistrationIntegrationTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package org.apache.fineract.selfservice.registration.api;
 
 import static io.restassured.RestAssured.given;

--- a/src/test/java/org/apache/fineract/selfservice/registration/domain/SelfServiceRegistrationTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/registration/domain/SelfServiceRegistrationTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package org.apache.fineract.selfservice.registration.domain;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/src/test/java/org/apache/fineract/selfservice/registration/service/SelfServiceRegistrationWritePlatformServiceImplTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/registration/service/SelfServiceRegistrationWritePlatformServiceImplTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package org.apache.fineract.selfservice.registration.service;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -9,7 +15,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.util.Map;
 import org.apache.fineract.infrastructure.campaigns.sms.service.SmsCampaignDropdownReadPlatformService;
 import org.apache.fineract.infrastructure.core.domain.FineractPlatformTenant;
 import org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil;

--- a/src/test/java/org/apache/fineract/selfservice/runreport/SelfRunReportApiResourceTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/runreport/SelfRunReportApiResourceTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package org.apache.fineract.selfservice.runreport;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;

--- a/src/test/java/org/apache/fineract/selfservice/runreport/SelfRunReportIntegrationTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/runreport/SelfRunReportIntegrationTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package org.apache.fineract.selfservice.runreport;
 
 import static io.restassured.RestAssured.given;

--- a/src/test/java/org/apache/fineract/selfservice/savings/api/SelfSavingsAccountApiResourceTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/savings/api/SelfSavingsAccountApiResourceTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package org.apache.fineract.selfservice.savings.api;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/src/test/java/org/apache/fineract/selfservice/savings/api/SelfSavingsApiIntegrationTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/savings/api/SelfSavingsApiIntegrationTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package org.apache.fineract.selfservice.savings.api;
 
 import static io.restassured.RestAssured.given;

--- a/src/test/java/org/apache/fineract/selfservice/savings/data/SelfSavingsDataValidatorTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/savings/data/SelfSavingsDataValidatorTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package org.apache.fineract.selfservice.savings.data;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/src/test/java/org/apache/fineract/selfservice/security/SelfServiceSecurityFilterChainIntegrationTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/security/SelfServiceSecurityFilterChainIntegrationTest.java
@@ -1,8 +1,13 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package org.apache.fineract.selfservice.security;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/test/java/org/apache/fineract/selfservice/security/SelfServiceSecurityTestConfig.java
+++ b/src/test/java/org/apache/fineract/selfservice/security/SelfServiceSecurityTestConfig.java
@@ -1,16 +1,8 @@
 /**
- * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
- * agreements. See the NOTICE file distributed with this work for additional information regarding
- * copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the License. You may obtain a
- * copy of the License at
+ * Copyright since 2026 Mifos Initiative
  *
- * <p>http://www.apache.org/licenses/LICENSE-2.0
- *
- * <p>Unless required by applicable law or agreed to in writing, software distributed under the
- * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing permissions and
- * limitations under the License.
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 package org.apache.fineract.selfservice.security;
 

--- a/src/test/java/org/apache/fineract/selfservice/security/SelfServiceSecurityWiringTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/security/SelfServiceSecurityWiringTest.java
@@ -1,16 +1,8 @@
 /**
- * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
- * agreements. See the NOTICE file distributed with this work for additional information regarding
- * copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the License. You may obtain a
- * copy of the License at
+ * Copyright since 2026 Mifos Initiative
  *
- * <p>http://www.apache.org/licenses/LICENSE-2.0
- *
- * <p>Unless required by applicable law or agreed to in writing, software distributed under the
- * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing permissions and
- * limitations under the License.
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 package org.apache.fineract.selfservice.security;
 

--- a/src/test/java/org/apache/fineract/selfservice/security/api/SelfAuthenticationApiResourceIntegrationTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/security/api/SelfAuthenticationApiResourceIntegrationTest.java
@@ -1,16 +1,8 @@
 /**
- * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
- * agreements. See the NOTICE file distributed with this work for additional information regarding
- * copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the License. You may obtain a
- * copy of the License at
+ * Copyright since 2026 Mifos Initiative
  *
- * <p>http://www.apache.org/licenses/LICENSE-2.0
- *
- * <p>Unless required by applicable law or agreed to in writing, software distributed under the
- * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing permissions and
- * limitations under the License.
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 package org.apache.fineract.selfservice.security.api;
 

--- a/src/test/java/org/apache/fineract/selfservice/security/api/SelfAuthenticationApiResourceTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/security/api/SelfAuthenticationApiResourceTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package org.apache.fineract.selfservice.security.api;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/src/test/java/org/apache/fineract/selfservice/security/api/SelfServicePermissionEnforcementIntegrationTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/security/api/SelfServicePermissionEnforcementIntegrationTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package org.apache.fineract.selfservice.security.api;
 
 import static io.restassured.RestAssured.given;

--- a/src/test/java/org/apache/fineract/selfservice/security/api/SelfServiceSecurityGrantsIntegrationTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/security/api/SelfServiceSecurityGrantsIntegrationTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package org.apache.fineract.selfservice.security.api;
 
 import static io.restassured.RestAssured.given;

--- a/src/test/java/org/apache/fineract/selfservice/security/filter/SelfServiceBasicAuthenticationFilterTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/security/filter/SelfServiceBasicAuthenticationFilterTest.java
@@ -1,20 +1,8 @@
 /**
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements. See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership. The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License. You may obtain a copy of the License at
+ * Copyright since 2026 Mifos Initiative
  *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 package org.apache.fineract.selfservice.security.filter;
 

--- a/src/test/java/org/apache/fineract/selfservice/security/permissions/AppSelfServiceUserExplicitReadPermissionTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/security/permissions/AppSelfServiceUserExplicitReadPermissionTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package org.apache.fineract.selfservice.security.permissions;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;

--- a/src/test/java/org/apache/fineract/selfservice/security/service/PlatformSelfServiceSecurityContextImplTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/security/service/PlatformSelfServiceSecurityContextImplTest.java
@@ -1,23 +1,14 @@
 /**
- * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
- * agreements. See the NOTICE file distributed with this work for additional information regarding
- * copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the License. You may obtain a
- * copy of the License at
+ * Copyright since 2026 Mifos Initiative
  *
- * <p>http://www.apache.org/licenses/LICENSE-2.0
- *
- * <p>Unless required by applicable law or agreed to in writing, software distributed under the
- * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing permissions and
- * limitations under the License.
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 package org.apache.fineract.selfservice.security.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -25,7 +16,6 @@ import static org.mockito.Mockito.when;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;

--- a/src/test/java/org/apache/fineract/selfservice/security/service/SelfServiceCompatibleSecurityContextTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/security/service/SelfServiceCompatibleSecurityContextTest.java
@@ -1,16 +1,8 @@
 /**
- * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
- * agreements. See the NOTICE file distributed with this work for additional information regarding
- * copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the License. You may obtain a
- * copy of the License at
+ * Copyright since 2026 Mifos Initiative
  *
- * <p>http://www.apache.org/licenses/LICENSE-2.0
- *
- * <p>Unless required by applicable law or agreed to in writing, software distributed under the
- * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing permissions and
- * limitations under the License.
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 package org.apache.fineract.selfservice.security.service;
 

--- a/src/test/java/org/apache/fineract/selfservice/security/service/TenantAwareJpaPlatformSelfServiceUserDetailsServiceTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/security/service/TenantAwareJpaPlatformSelfServiceUserDetailsServiceTest.java
@@ -1,41 +1,24 @@
 /**
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements. See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership. The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License. You may obtain a copy of the License at
+ * Copyright since 2026 Mifos Initiative
  *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 package org.apache.fineract.selfservice.security.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.util.Collections;
-import org.apache.fineract.selfservice.registration.SelfServiceApiConstants;
 import org.apache.fineract.selfservice.security.domain.PlatformSelfServiceUserRepository;
 import org.apache.fineract.selfservice.useradministration.domain.AppSelfServiceUser;
 import org.apache.fineract.selfservice.useradministration.service.SelfServiceRoleReadPlatformService;
-import org.apache.fineract.useradministration.data.RoleData;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 
 @ExtendWith(MockitoExtension.class)

--- a/src/test/java/org/apache/fineract/selfservice/shareaccounts/data/SelfShareAccountsDataValidatorTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/shareaccounts/data/SelfShareAccountsDataValidatorTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package org.apache.fineract.selfservice.shareaccounts.data;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/src/test/java/org/apache/fineract/selfservice/testing/support/SelfServiceIntegrationTestBase.java
+++ b/src/test/java/org/apache/fineract/selfservice/testing/support/SelfServiceIntegrationTestBase.java
@@ -1,16 +1,8 @@
 /**
- * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
- * agreements. See the NOTICE file distributed with this work for additional information regarding
- * copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the License. You may obtain a
- * copy of the License at
+ * Copyright since 2026 Mifos Initiative
  *
- * <p>http://www.apache.org/licenses/LICENSE-2.0
- *
- * <p>Unless required by applicable law or agreed to in writing, software distributed under the
- * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing permissions and
- * limitations under the License.
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 package org.apache.fineract.selfservice.testing.support;
 

--- a/src/test/java/org/apache/fineract/selfservice/testing/support/SelfServiceTestUtils.java
+++ b/src/test/java/org/apache/fineract/selfservice/testing/support/SelfServiceTestUtils.java
@@ -1,16 +1,8 @@
 /**
- * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
- * agreements. See the NOTICE file distributed with this work for additional information regarding
- * copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the License. You may obtain a
- * copy of the License at
+ * Copyright since 2026 Mifos Initiative
  *
- * <p>http://www.apache.org/licenses/LICENSE-2.0
- *
- * <p>Unless required by applicable law or agreed to in writing, software distributed under the
- * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing permissions and
- * limitations under the License.
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 package org.apache.fineract.selfservice.testing.support;
 

--- a/src/test/java/org/apache/fineract/selfservice/useradministration/domain/AppSelfServiceUserTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/useradministration/domain/AppSelfServiceUserTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package org.apache.fineract.selfservice.useradministration.domain;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,5 +1,13 @@
+######################################################
+# Copyright since 2026 Mifos Initiative
+# 
+# <p>This Source Code Form is subject to the terms 
+# of the Mozilla Public License, v. 2.0. If a copy
+# of the MPL was not distributed with this file, 
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+######################################################
 spring.main.allow-bean-definition-overriding=false
-
 fineract.security.basicauth.enabled=true
 fineract.security.2fa.enabled=false
 fineract.security.cors.enabled=false


### PR DESCRIPTION
Fix to MPL for only new generated files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated license headers across test files to reflect Mozilla Public License v2.0 and Mifos Initiative copyright.
  * Cleaned up unused imports in test files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->