### PR TITLE
MX-172: Implement atomic self enrollment flow

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,10 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-validation</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-security</artifactId>
       <scope>compile</scope>
     </dependency>

--- a/src/main/java/org/apache/fineract/selfservice/registration/SelfServiceApiConstants.java
+++ b/src/main/java/org/apache/fineract/selfservice/registration/SelfServiceApiConstants.java
@@ -43,6 +43,28 @@ public final class SelfServiceApiConstants {
     public static final String emailModeParamName = "email";
     public static final String mobileModeParamName = "mobile";
     public static final String requestIdParamName = "requestId";
+    public static final String legalFormIdParamName = "legalFormId";
+    public static final String isStaffParamName = "isStaff";
+    public static final String officeIdParamName = "officeId";
+    public static final String localeParamName = "locale";
+    public static final String dateFormatParamName = "dateFormat";
+    public static final String activationDateParamName = "activationDate";
+    public static final String clientClassificationIdParamName = "clientClassificationId";
+    public static final String clientTypeIdParamName = "clientTypeId";
+    // Both keys are intentionally supported because copyFirstPresent accepts either request parameter casing.
+    public static final String externalIdParamName = "externalId";
+    public static final String externalIDParamName = "externalID";
+    public static final String submittedOnDateParamName = "submittedOnDate";
+    public static final String activeParamName = "active";
+    public static final String addressParamName = "address";
+    public static final String datatablesParamName = "datatables";
+    public static final String familyMembersParamName = "familyMembers";
+    public static final String dateOfBirthParamName = "dateOfBirth";
+    public static final String genderIdParamName = "genderId";
+    // Lowercase keys are preserved for self-enrollment payload compatibility alongside the camelCase variants.
+    public static final String firstnameParamName = "firstname";
+    public static final String middlenameParamName = "middlename";
+    public static final String lastnameParamName = "lastname";
     public static final String createRequestSuccessMessage = "Self service request created.";
     
     public static final Set<String> REGISTRATION_REQUEST_DATA_PARAMETERS = Collections
@@ -54,6 +76,14 @@ public final class SelfServiceApiConstants {
     
     public static final List<Object> SUPPORTED_AUTHENTICATION_MODE_PARAMETERS = List
             .copyOf(Arrays.asList(emailModeParamName, mobileModeParamName));
+            
+    public static final Set<String> SELF_ENROLLMENT_DATA_PARAMETERS = Collections
+            .unmodifiableSet(new HashSet<>(Arrays.asList(usernameParamName, passwordParamName, firstNameParamName,
+                    mobileNumberParamName, lastNameParamName, emailParamName, authenticationModeParamName, middleNameParamName,
+                    firstnameParamName, middlenameParamName, lastnameParamName, officeIdParamName, localeParamName, dateFormatParamName,
+                    legalFormIdParamName, isStaffParamName, clientClassificationIdParamName, clientTypeIdParamName, externalIdParamName,
+                    externalIDParamName, submittedOnDateParamName, activationDateParamName, activeParamName, addressParamName,
+                    datatablesParamName, familyMembersParamName, dateOfBirthParamName, genderIdParamName)));
     
     public static final String SELF_SERVICE_USER_ROLE = "Self Service User";
 

--- a/src/main/java/org/apache/fineract/selfservice/registration/api/SelfServiceEnrollmentRequest.java
+++ b/src/main/java/org/apache/fineract/selfservice/registration/api/SelfServiceEnrollmentRequest.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.apache.fineract.selfservice.registration.api;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Data
+@NoArgsConstructor
+public class SelfServiceEnrollmentRequest {
+
+    @Schema(example = "vilma", requiredMode = Schema.RequiredMode.REQUIRED)
+    public String username;
+
+    @Schema(example = "SecretPassword123#", requiredMode = Schema.RequiredMode.REQUIRED)
+    public String password;
+
+    @Schema(example = "Vilma", requiredMode = Schema.RequiredMode.REQUIRED)
+    public String firstName;
+
+    @Schema(example = "VILMA")
+    public String firstname;
+
+    @Schema(example = "PICAPIEDRA")
+    public String middlename;
+
+    @Schema(example = "Flintstone", requiredMode = Schema.RequiredMode.REQUIRED)
+    public String lastName;
+
+    @Schema(example = "PEREZ")
+    public String lastname;
+
+    @Schema(example = "5522649498", requiredMode = Schema.RequiredMode.REQUIRED)
+    public String mobileNumber;
+
+    @Schema(example = "vilma@hotmail.com", requiredMode = Schema.RequiredMode.REQUIRED)
+    public String email;
+
+    @Schema(example = "email", requiredMode = Schema.RequiredMode.REQUIRED)
+    public String authenticationMode;
+
+    @Schema(example = "1")
+    public Long legalFormId;
+
+    @Schema(example = "1")
+    public Long officeId;
+
+    @Schema(example = "17 febrero 2026")
+    public String submittedOnDate;
+
+    @Schema(example = "17 febrero 2026")
+    public String activationDate;
+
+    @Schema(example = "false")
+    public Boolean isStaff;
+    
+    @Schema(example = "false")
+    public Boolean active;
+
+    @Schema(example = "ID12345")
+    public String externalId;
+
+    @Schema(example = "ID12345")
+    public String externalID;
+
+    @Schema(example = "dd MMMM yyyy")
+    public String dateFormat;
+
+    @Schema(example = "es")
+    public String locale;
+
+}

--- a/src/main/java/org/apache/fineract/selfservice/registration/api/SelfServiceRegistrationApiResource.java
+++ b/src/main/java/org/apache/fineract/selfservice/registration/api/SelfServiceRegistrationApiResource.java
@@ -14,7 +14,14 @@
  */
 package org.apache.fineract.selfservice.registration.api;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
@@ -27,6 +34,9 @@ import org.apache.fineract.selfservice.registration.service.SelfServiceRegistrat
 import org.apache.fineract.selfservice.useradministration.domain.AppSelfServiceUser;
 import org.springframework.stereotype.Component;
 
+/**
+ * JAX-RS resource exposing self-service registration and enrollment endpoints.
+ */
 @Path("/v1/self/registration")
 @Component
 @Tag(name = "Self Service Registration", description = "")
@@ -36,18 +46,54 @@ public class SelfServiceRegistrationApiResource {
     private final SelfServiceRegistrationWritePlatformService selfServiceRegistrationWritePlatformService;
     private final DefaultToApiJsonSerializer<AppSelfServiceUser> toApiJsonSerializer;
 
+    /**
+     * Creates a self-service registration request pending later confirmation.
+     *
+     * @param apiRequestBodyAsJson request payload as raw JSON
+     * @return success message for request creation
+     */
     @POST
+    @Consumes({MediaType.APPLICATION_JSON})
     @Produces({MediaType.APPLICATION_JSON})
     public String createSelfServiceRegistrationRequest(final String apiRequestBodyAsJson) {
         this.selfServiceRegistrationWritePlatformService.createRegistrationRequest(apiRequestBodyAsJson);
         return SelfServiceApiConstants.createRequestSuccessMessage;
     }
 
+    /**
+     * Creates a self-service user from a confirmed registration request.
+     *
+     * @param apiRequestBodyAsJson request payload as raw JSON
+     * @return serialized command result containing the created user identifier
+     */
     @POST
     @Path("user")
+    @Consumes({MediaType.APPLICATION_JSON})
     @Produces({MediaType.APPLICATION_JSON})
     public String createSelfServiceUser(final String apiRequestBodyAsJson) {
         AppSelfServiceUser user = this.selfServiceRegistrationWritePlatformService.createSelfServiceUser(apiRequestBodyAsJson);
+        return this.toApiJsonSerializer.serialize(CommandProcessingResult.resourceResult(user.getId()));
+    }
+
+    /**
+     * Creates a client and linked self-service user in a single request.
+     *
+     * @param apiRequestBodyAsJson request payload as raw JSON
+     * @return serialized command result containing the created user identifier
+     */
+    @POST
+    @Path("client-user")
+    @Consumes({MediaType.APPLICATION_JSON})
+    @Produces({MediaType.APPLICATION_JSON})
+    @Operation(summary = "Self Enrollment Flow", description = "Creates a Fineract Client and Self Service User in one shot.")
+    @RequestBody(required = true, content = @Content(schema = @Schema(implementation = SelfServiceEnrollmentRequest.class)))
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "OK"),
+        @ApiResponse(responseCode = "400", description = "Bad Request"),
+        @ApiResponse(responseCode = "409", description = "Conflict (Duplicate Username, Email, etc)")
+    })
+    public String selfEnroll(final String apiRequestBodyAsJson) {
+        AppSelfServiceUser user = this.selfServiceRegistrationWritePlatformService.selfEnroll(apiRequestBodyAsJson);
         return this.toApiJsonSerializer.serialize(CommandProcessingResult.resourceResult(user.getId()));
     }
 }

--- a/src/main/java/org/apache/fineract/selfservice/registration/exception/SelfServiceEnrollmentConflictException.java
+++ b/src/main/java/org/apache/fineract/selfservice/registration/exception/SelfServiceEnrollmentConflictException.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.apache.fineract.selfservice.registration.exception;
+
+/**
+ * Raised when anonymous self-enrollment violates a uniqueness or other conflict constraint.
+ */
+public class SelfServiceEnrollmentConflictException extends RuntimeException {
+
+    private final String parameterName;
+    private final String userMessageGlobalisationCode;
+
+    /**
+     * Creates a conflict exception for a specific enrollment field.
+     *
+     * @param userMessageGlobalisationCode message code exposed to API clients for localization
+     * @param defaultMessage fallback user-facing message
+     * @param parameterName request field associated with the conflict
+     */
+    public SelfServiceEnrollmentConflictException(String userMessageGlobalisationCode, String defaultMessage, String parameterName) {
+        super(defaultMessage);
+        this.parameterName = parameterName;
+        this.userMessageGlobalisationCode = userMessageGlobalisationCode;
+    }
+
+    /**
+     * @return the request parameter associated with the conflict
+     */
+    public String getParameterName() {
+        return parameterName;
+    }
+
+    /**
+     * @return the globalization code describing the conflict
+     */
+    public String getUserMessageGlobalisationCode() {
+        return userMessageGlobalisationCode;
+    }
+}

--- a/src/main/java/org/apache/fineract/selfservice/registration/exceptionmapper/SelfServiceEnrollmentConflictExceptionMapper.java
+++ b/src/main/java/org/apache/fineract/selfservice/registration/exceptionmapper/SelfServiceEnrollmentConflictExceptionMapper.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.apache.fineract.selfservice.registration.exceptionmapper;
+
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.fineract.selfservice.registration.exception.SelfServiceEnrollmentConflictException;
+import org.springframework.stereotype.Component;
+
+/**
+ * Maps {@link SelfServiceEnrollmentConflictException} to an HTTP conflict response.
+ *
+ * @since 1.15.0
+ */
+@Provider
+@Component
+public class SelfServiceEnrollmentConflictExceptionMapper implements ExceptionMapper<SelfServiceEnrollmentConflictException> {
+
+    /**
+     * Builds the conflict response body for a self-enrollment constraint violation.
+     *
+     * @param exception the enrollment conflict to serialize
+     * @return HTTP 409 response containing the conflict details
+     */
+    @Override
+    public Response toResponse(SelfServiceEnrollmentConflictException exception) {
+        Map<String, Object> error = new LinkedHashMap<>();
+        error.put("defaultUserMessage", exception.getMessage());
+        error.put("parameterName", exception.getParameterName());
+        error.put("developerMessage", exception.getMessage());
+        error.put("userMessageGlobalisationCode", exception.getUserMessageGlobalisationCode());
+
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("developerMessage", "The request caused a data integrity issue to be fired by the database.");
+        body.put("httpStatusCode", "409");
+        body.put("defaultUserMessage", exception.getMessage());
+        body.put("userMessageGlobalisationCode", exception.getUserMessageGlobalisationCode());
+        body.put("errors", List.of(error));
+
+        return Response.status(Response.Status.CONFLICT).type(MediaType.APPLICATION_JSON).entity(body).build();
+    }
+}

--- a/src/main/java/org/apache/fineract/selfservice/registration/service/SelfServiceRegistrationWritePlatformService.java
+++ b/src/main/java/org/apache/fineract/selfservice/registration/service/SelfServiceRegistrationWritePlatformService.java
@@ -22,4 +22,33 @@ public interface SelfServiceRegistrationWritePlatformService {
     SelfServiceRegistration createRegistrationRequest(String apiRequestBodyAsJson);
 
     AppSelfServiceUser createSelfServiceUser(String apiRequestBodyAsJson);
+
+    /**
+     * Executes the legacy token-confirmation flow when {@code requestId} and
+     * {@code authenticationToken} are supplied; otherwise performs one-shot self-enrollment using
+     * client creation fields.
+     *
+     * @param apiRequestBodyAsJson JSON request body containing either legacy confirmation fields
+     *     ({@code requestId}, {@code authenticationToken}) or self-enrollment fields accepted by
+     *     the enrollment endpoint
+     * @return the created self-service user, including the generated identifier after persistence
+     * @throws org.apache.fineract.infrastructure.core.exception.PlatformApiDataValidationException
+     *     if required fields are missing or invalid
+     * @throws org.apache.fineract.infrastructure.core.exception.PlatformDataIntegrityException if a
+     *     duplicate user or other integrity issue is detected
+     * @throws org.apache.fineract.selfservice.registration.exception.SelfServiceEnrollmentConflictException
+     *     if enrollment fails with a conflict that maps to HTTP 409
+     *
+     * Side effects: persists registration or enrollment data, may create a client and a linked
+     * self-service user, and may trigger downstream notification or mapping writes.
+     */
+    AppSelfServiceUser createSelfServiceUserOrEnroll(String apiRequestBodyAsJson);
+
+    /**
+     * Executes atomic one-shot self-enrollment by provisioning a Client and User.
+     * 
+     * @param apiRequestBodyAsJson The incoming request containing enrollment data matching {@code SelfServiceEnrollmentRequest}.
+     * @return The freshly created AppSelfServiceUser object.
+     */
+    AppSelfServiceUser selfEnroll(String apiRequestBodyAsJson);
 }

--- a/src/main/java/org/apache/fineract/selfservice/registration/service/SelfServiceRegistrationWritePlatformServiceImpl.java
+++ b/src/main/java/org/apache/fineract/selfservice/registration/service/SelfServiceRegistrationWritePlatformServiceImpl.java
@@ -58,6 +58,7 @@ import org.apache.fineract.portfolio.group.domain.Group;
 import org.apache.fineract.selfservice.registration.SelfServiceApiConstants;
 import org.apache.fineract.selfservice.registration.domain.SelfServiceRegistration;
 import org.apache.fineract.selfservice.registration.domain.SelfServiceRegistrationRepository;
+import org.apache.fineract.selfservice.registration.exception.SelfServiceEnrollmentConflictException;
 import org.apache.fineract.selfservice.registration.exception.SelfServiceRegistrationNotFoundException;
 import org.apache.fineract.selfservice.useradministration.domain.AppSelfServiceUser;
 import org.apache.fineract.selfservice.useradministration.domain.AppSelfServiceUserClientMapping;
@@ -70,10 +71,27 @@ import org.apache.fineract.selfservice.useradministration.domain.SelfServiceUser
 import org.apache.fineract.useradministration.exception.RoleNotFoundException;
 import org.apache.fineract.selfservice.useradministration.service.AppSelfServiceUserReadPlatformService;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.orm.jpa.JpaSystemException;
 import org.springframework.security.authentication.AuthenticationServiceException;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.apache.fineract.useradministration.domain.AppUser;
+import org.apache.fineract.useradministration.domain.AppUserRepository;
+import org.apache.fineract.portfolio.client.service.ClientWritePlatformService;
+import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
+import org.springframework.core.env.Environment;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import java.util.Collections;
+import org.apache.commons.lang3.StringUtils;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -93,6 +111,10 @@ public class SelfServiceRegistrationWritePlatformServiceImpl implements SelfServ
     private final RoleRepository roleRepository;
     private static final SecureRandom secureRandom = new SecureRandom();
     private final AppSelfServiceUserClientMappingRepository appUserClientMappingRepository;
+    private final JdbcTemplate jdbcTemplate;
+    private final AppUserRepository appUserRepository;
+    private final ClientWritePlatformService clientWritePlatformService;
+    private final Environment env;
 
     @Override
     public SelfServiceRegistration createRegistrationRequest(String apiRequestBodyAsJson) {
@@ -290,6 +312,24 @@ public class SelfServiceRegistrationWritePlatformServiceImpl implements SelfServ
 
     }
 
+    /**
+     * Chooses between the legacy token-confirmation flow and the one-shot enrollment flow based on
+     * the request payload.
+     *
+     * @param apiRequestBodyAsJson JSON request body containing either confirmation fields or
+     *     self-enrollment data
+     * @return the created self-service user
+     */
+    @Transactional(rollbackFor = Exception.class)
+    @Override
+    public AppSelfServiceUser createSelfServiceUserOrEnroll(String apiRequestBodyAsJson) {
+        JsonObject json = JsonParser.parseString(apiRequestBodyAsJson).getAsJsonObject();
+        if (json.has(SelfServiceApiConstants.requestIdParamName) || json.has(SelfServiceApiConstants.authenticationTokenParamName)) {
+            return createSelfServiceUser(apiRequestBodyAsJson);
+        }
+        return selfEnroll(apiRequestBodyAsJson);
+    }
+
     private void handleDataIntegrityIssues(final JsonCommand command, final Throwable realCause, final Exception dve, String username) {
         if (realCause.getMessage().contains("'username_org'")) {
             final StringBuilder defaultMessageBuilder = new StringBuilder("User with username ").append(username)
@@ -298,6 +338,251 @@ public class SelfServiceRegistrationWritePlatformServiceImpl implements SelfServ
                     username);
         }
         throw ErrorHandler.getMappable(dve, "error.msg.unknown.data.integrity.issue", "Unknown data integrity issue with resource.");
+    }
+
+    /**
+     * Creates a client and linked self-service user in a single transaction using the configured
+     * audit user for privileged client creation.
+     *
+     * @param apiRequestBodyAsJson JSON request body containing self-enrollment data
+     * @return the created self-service user linked to the newly created client
+     */
+    @Transactional(rollbackFor = Exception.class)
+    @Override
+    public AppSelfServiceUser selfEnroll(String apiRequestBodyAsJson) {
+        Gson gson = new Gson();
+        final Type typeOfMap = new TypeToken<Map<String, Object>>() {}.getType();
+        final List<ApiParameterError> dataValidationErrors = new ArrayList<>();
+        final DataValidatorBuilder baseDataValidator = new DataValidatorBuilder(dataValidationErrors).resource("user");
+        this.fromApiJsonHelper.checkForUnsupportedParameters(typeOfMap, apiRequestBodyAsJson,
+                SelfServiceApiConstants.SELF_ENROLLMENT_DATA_PARAMETERS);
+        JsonElement element = gson.fromJson(apiRequestBodyAsJson.toString(), JsonElement.class);
+
+        String username = this.fromApiJsonHelper.extractStringNamed(SelfServiceApiConstants.usernameParamName, element);
+        baseDataValidator.reset().parameter(SelfServiceApiConstants.usernameParamName).value(username).notBlank().notExceedingLengthOf(100);
+
+        String password = this.fromApiJsonHelper.extractStringNamed(SelfServiceApiConstants.passwordParamName, element);
+        final PasswordValidationPolicy validationPolicy = this.passwordValidationPolicy.findActivePasswordValidationPolicy();
+        baseDataValidator.reset().parameter(SelfServiceApiConstants.passwordParamName).value(password)
+                .matchesRegularExpression(validationPolicy.getRegex(), validationPolicy.getDescription()).notExceedingLengthOf(100);
+
+        String authenticationMode = this.fromApiJsonHelper.extractStringNamed(SelfServiceApiConstants.authenticationModeParamName, element);
+        baseDataValidator.reset().parameter(SelfServiceApiConstants.authenticationModeParamName).value(authenticationMode).notBlank()
+                .isOneOfTheseStringValues(SelfServiceApiConstants.emailModeParamName, SelfServiceApiConstants.mobileModeParamName);
+
+        String email = this.fromApiJsonHelper.extractStringNamed(SelfServiceApiConstants.emailParamName, element);
+        baseDataValidator.reset().parameter(SelfServiceApiConstants.emailParamName).value(email).notExceedingLengthOf(100);
+
+        boolean isEmailAuthenticationMode = authenticationMode != null && authenticationMode.equalsIgnoreCase(SelfServiceApiConstants.emailModeParamName);
+        if (isEmailAuthenticationMode) {
+             baseDataValidator.reset().parameter(SelfServiceApiConstants.emailParamName).value(email).notBlank();
+        }
+
+        String mobileNumber = this.fromApiJsonHelper.extractStringNamed(SelfServiceApiConstants.mobileNumberParamName, element);
+        if (!isEmailAuthenticationMode) {
+            // Mobile auth: phone is required and must be valid
+            baseDataValidator.reset().parameter(SelfServiceApiConstants.mobileNumberParamName).value(mobileNumber).notBlank()
+                    .validatePhoneNumber();
+        } else if (mobileNumber != null) {
+            // Email auth: phone is optional but must be valid if provided,
+            // because Fineract's ClientDataValidator always validates mobileNo format.
+            baseDataValidator.reset().parameter(SelfServiceApiConstants.mobileNumberParamName).value(mobileNumber)
+                    .validatePhoneNumber();
+        }
+
+        if (!dataValidationErrors.isEmpty()) {
+            throw new PlatformApiDataValidationException(dataValidationErrors);
+        }
+
+        validateForDuplicateUsernameForEnrollment(username);
+
+        JsonObject originalJson = JsonParser.parseString(apiRequestBodyAsJson).getAsJsonObject();
+        JsonObject sanitizedJson = normalizeSelfEnrollmentClientPayload(originalJson);
+        JsonElement parsedSanitizedElement = sanitizedJson;
+
+        String auditUsername = env.getProperty("fineract.selfservice.enrollment.audit-user", "mifos");
+        final Authentication previousAuth = SecurityContextHolder.getContext().getAuthentication();
+        AppUser auditUser = resolveEnrollmentAuditUser(auditUsername);
+        Authentication auth = new UsernamePasswordAuthenticationToken(auditUser, null, auditUser.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(auth);
+
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCompletion(int status) {
+                if (previousAuth != null) {
+                    SecurityContextHolder.getContext().setAuthentication(previousAuth);
+                } else {
+                    SecurityContextHolder.clearContext();
+                }
+            }
+        });
+
+        try {
+            JsonCommand command = JsonCommand.fromJsonElement(null, parsedSanitizedElement, this.fromApiJsonHelper);
+            CommandProcessingResult result = clientWritePlatformService.createClient(command);
+            Long newClientId = result.getResourceId();
+
+            Client client = clientRepository.findOneWithNotFoundDetection(newClientId);
+            Role ssRole = roleRepository.getRoleByName(SelfServiceApiConstants.SELF_SERVICE_USER_ROLE);
+            if (ssRole == null) {
+                throw new RoleNotFoundException(SelfServiceApiConstants.SELF_SERVICE_USER_ROLE);
+            }
+            Collection<SimpleGrantedAuthority> authorities = new ArrayList<>();
+            authorities.add(new SimpleGrantedAuthority("DUMMY_ROLE_NOT_USED_OR_PERSISTED_TO_AVOID_EXCEPTION"));
+
+            User springConfigUser = new User(username, password, authorities);
+            AppSelfServiceUser appUser = new AppSelfServiceUser(
+                client.getOffice(), springConfigUser, Collections.singleton(ssRole),
+                email, client.getFirstname(), client.getLastname(), null,
+                true, true, Collections.emptyList(), null
+            );
+
+            userDomainService.create(appUser, false);
+            appUserClientMappingRepository.saveClientUserMapping(appUser.getId(), client.getId());
+
+            log.info("Self-enrollment successful: clientId={}", newClientId);
+            return appUser;
+
+        } catch (PlatformDataIntegrityException pde) {
+            throw translateEnrollmentConflict(pde);
+        } catch (DataIntegrityViolationException dve) {
+            String msg = dve.getMostSpecificCause().getMessage().toLowerCase();
+            if (msg.contains("username") || msg.contains("username_org")) {
+                throw enrollmentConflict("error.msg.user.duplicate.username", "Username already exists", "username");
+            }
+            if (msg.contains("mobile_no") || msg.contains("mobileno")) {
+                throw enrollmentConflict("error.msg.client.duplicate.mobileNo", "Mobile number already exists", "mobileNo");
+            }
+            if (msg.contains("email")) {
+                throw enrollmentConflict("error.msg.client.duplicate.email", "Email already exists", "email");
+            }
+            throw ErrorHandler.getMappable(dve, "error.msg.unknown.data.integrity.issue", "Unknown data integrity issue");
+        }
+    }
+
+    private AppUser resolveEnrollmentAuditUser(String auditUsername) {
+        try {
+            Long auditUserId = jdbcTemplate.queryForObject("SELECT id FROM m_appuser WHERE username = ?", Long.class, auditUsername);
+            if (auditUserId == null) {
+                throw new IllegalStateException(
+                        "Self-enrollment audit user '" + auditUsername + "' is configured but no matching m_appuser id was returned.");
+            }
+            return appUserRepository.findById(auditUserId).orElseThrow(
+                    () -> new IllegalStateException("Self-enrollment audit user '" + auditUsername
+                            + "' was found in m_appuser lookup but could not be loaded from the repository."));
+        } catch (EmptyResultDataAccessException e) {
+            throw new IllegalStateException("Configured self-enrollment audit user '" + auditUsername
+                    + "' does not exist. Set fineract.selfservice.enrollment.audit-user to a valid username.", e);
+        }
+    }
+
+    private void validateForDuplicateUsernameForEnrollment(String username) {
+        boolean isDuplicateUserName = this.appUserReadPlatformService.isUsernameExist(username);
+        if (isDuplicateUserName) {
+            throw enrollmentConflict("error.msg.user.duplicate.username", "Username already exists", "username");
+        }
+    }
+
+    private SelfServiceEnrollmentConflictException enrollmentConflict(String code, String message, String parameterName) {
+        return new SelfServiceEnrollmentConflictException(code, message, parameterName);
+    }
+
+    private RuntimeException translateEnrollmentConflict(PlatformDataIntegrityException exception) {
+        String code = exception.getGlobalisationMessageCode();
+        if ("error.msg.client.duplicate.mobileNo".equals(code)) {
+            return enrollmentConflict(code, exception.getDefaultUserMessage(), "mobileNo");
+        }
+        if ("error.msg.client.duplicate.email".equals(code)) {
+            return enrollmentConflict(code, exception.getDefaultUserMessage(), "email");
+        }
+        if ("error.msg.user.duplicate.username".equals(code)) {
+            return enrollmentConflict(code, exception.getDefaultUserMessage(), "username");
+        }
+        return exception;
+    }
+
+    private JsonObject normalizeSelfEnrollmentClientPayload(JsonObject originalJson) {
+        JsonObject sanitizedJson = new JsonObject();
+
+        copyFirstPresent(originalJson, sanitizedJson, SelfServiceApiConstants.firstnameParamName,
+                SelfServiceApiConstants.firstnameParamName, SelfServiceApiConstants.firstNameParamName);
+        copyFirstPresent(originalJson, sanitizedJson, SelfServiceApiConstants.middlenameParamName,
+                SelfServiceApiConstants.middlenameParamName, SelfServiceApiConstants.middleNameParamName);
+        copyFirstPresent(originalJson, sanitizedJson, SelfServiceApiConstants.lastnameParamName,
+                SelfServiceApiConstants.lastnameParamName, SelfServiceApiConstants.lastNameParamName);
+        copyIfPresent(originalJson, sanitizedJson, "mobileNo", SelfServiceApiConstants.mobileNumberParamName);
+        copyIfPresent(originalJson, sanitizedJson, "emailAddress", SelfServiceApiConstants.emailParamName);
+        copyIfPresent(originalJson, sanitizedJson, SelfServiceApiConstants.clientTypeIdParamName, SelfServiceApiConstants.clientTypeIdParamName);
+        copyIfPresent(originalJson, sanitizedJson, SelfServiceApiConstants.clientClassificationIdParamName,
+                SelfServiceApiConstants.clientClassificationIdParamName);
+        copyIfPresent(originalJson, sanitizedJson, SelfServiceApiConstants.dateOfBirthParamName, SelfServiceApiConstants.dateOfBirthParamName);
+        copyIfPresent(originalJson, sanitizedJson, SelfServiceApiConstants.genderIdParamName, SelfServiceApiConstants.genderIdParamName);
+        copyIfPresent(originalJson, sanitizedJson, SelfServiceApiConstants.addressParamName, SelfServiceApiConstants.addressParamName);
+        copyIfPresent(originalJson, sanitizedJson, SelfServiceApiConstants.datatablesParamName, SelfServiceApiConstants.datatablesParamName);
+        copyIfPresent(originalJson, sanitizedJson, SelfServiceApiConstants.familyMembersParamName, SelfServiceApiConstants.familyMembersParamName);
+        copyFirstPresent(originalJson, sanitizedJson, SelfServiceApiConstants.externalIdParamName,
+                SelfServiceApiConstants.externalIdParamName, SelfServiceApiConstants.externalIDParamName);
+
+        long officeId = Long.parseLong(env.getProperty("fineract.selfservice.enrollment.default-office-id", "1"));
+        sanitizedJson.addProperty(SelfServiceApiConstants.officeIdParamName, officeId);
+
+        int legalFormId = originalJson.has(SelfServiceApiConstants.legalFormIdParamName)
+                ? originalJson.get(SelfServiceApiConstants.legalFormIdParamName).getAsInt()
+                : Integer.parseInt(env.getProperty("fineract.selfservice.enrollment.default-legal-form-id", "1"));
+        sanitizedJson.addProperty(SelfServiceApiConstants.legalFormIdParamName, legalFormId);
+
+        String submittedOnDate = stringValueOrDefault(originalJson, SelfServiceApiConstants.submittedOnDateParamName, null);
+        String dateFormat = stringValueOrDefault(originalJson, SelfServiceApiConstants.dateFormatParamName, null);
+        if (StringUtils.isBlank(dateFormat)) {
+            if (looksIsoDate(submittedOnDate)) {
+                dateFormat = "yyyy-MM-dd";
+            } else {
+                dateFormat = env.getProperty("fineract.selfservice.enrollment.default-date-format", "yyyy-MM-dd");
+            }
+        }
+        sanitizedJson.addProperty(SelfServiceApiConstants.dateFormatParamName, dateFormat);
+
+        String locale = stringValueOrDefault(originalJson, SelfServiceApiConstants.localeParamName,
+                env.getProperty("fineract.selfservice.enrollment.default-locale", "en"));
+        sanitizedJson.addProperty(SelfServiceApiConstants.localeParamName, locale);
+
+        boolean isActive = Boolean.parseBoolean(env.getProperty("fineract.selfservice.enrollment.default-active", "false"));
+        sanitizedJson.addProperty(SelfServiceApiConstants.activeParamName, isActive);
+
+        String today = java.time.LocalDate.now(java.time.ZoneId.of("UTC")).toString();
+        sanitizedJson.addProperty(SelfServiceApiConstants.submittedOnDateParamName,
+                StringUtils.defaultIfBlank(submittedOnDate, today));
+        if (isActive) {
+            sanitizedJson.addProperty(SelfServiceApiConstants.activationDateParamName, today);
+        }
+
+        return sanitizedJson;
+    }
+
+    private void copyIfPresent(JsonObject source, JsonObject target, String targetKey, String sourceKey) {
+        if (source.has(sourceKey)) {
+            target.add(targetKey, source.get(sourceKey));
+        }
+    }
+
+    private void copyFirstPresent(JsonObject source, JsonObject target, String targetKey, String... sourceKeys) {
+        for (String sourceKey : sourceKeys) {
+            if (source.has(sourceKey)) {
+                target.add(targetKey, source.get(sourceKey));
+                return;
+            }
+        }
+    }
+
+    private String stringValueOrDefault(JsonObject json, String key, String defaultValue) {
+        if (json.has(key) && !json.get(key).isJsonNull()) {
+            return json.get(key).getAsString();
+        }
+        return defaultValue;
+    }
+
+    private boolean looksIsoDate(String value) {
+        return StringUtils.isNotBlank(value) && value.matches("\\d{4}-\\d{2}-\\d{2}");
     }
 
 }

--- a/src/main/java/org/apache/fineract/selfservice/registration/starter/SelfRegistrationConfiguration.java
+++ b/src/main/java/org/apache/fineract/selfservice/registration/starter/SelfRegistrationConfiguration.java
@@ -35,6 +35,10 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.jdbc.core.JdbcTemplate;
 
+import org.apache.fineract.useradministration.domain.AppUserRepository;
+import org.apache.fineract.portfolio.client.service.ClientWritePlatformService;
+import org.springframework.core.env.Environment;
+
 @Configuration
 public class SelfRegistrationConfiguration {
 
@@ -55,10 +59,13 @@ public class SelfRegistrationConfiguration {
             SmsMessageScheduledJobService smsMessageScheduledJobService,
             SmsCampaignDropdownReadPlatformService smsCampaignDropdownReadPlatformService,
             AppSelfServiceUserReadPlatformService appUserReadPlatformService, RoleRepository roleRepository,
-            AppSelfServiceUserClientMappingRepository appUserClientMappingRepository) {
+            AppSelfServiceUserClientMappingRepository appUserClientMappingRepository,
+            JdbcTemplate jdbcTemplate, AppUserRepository appUserRepository, 
+            ClientWritePlatformService clientWritePlatformService, Environment env) {
         return new SelfServiceRegistrationWritePlatformServiceImpl(selfServiceRegistrationRepository, fromApiJsonHelper,
                 selfServiceRegistrationReadPlatformService, clientRepository, passwordValidationPolicy, userDomainService,
                 gmailBackedPlatformEmailService, smsMessageRepository, smsMessageScheduledJobService,
-                 smsCampaignDropdownReadPlatformService, appUserReadPlatformService, roleRepository, appUserClientMappingRepository);
+                 smsCampaignDropdownReadPlatformService, appUserReadPlatformService, roleRepository, appUserClientMappingRepository,
+                 jdbcTemplate, appUserRepository, clientWritePlatformService, env);
     }
 }

--- a/src/main/java/org/apache/fineract/selfservice/security/starter/SelfServiceSecurityConfiguration.java
+++ b/src/main/java/org/apache/fineract/selfservice/security/starter/SelfServiceSecurityConfiguration.java
@@ -121,8 +121,10 @@ public class SelfServiceSecurityConfiguration {
                 // === PUBLIC ENDPOINTS ===
                 .requestMatchers(HttpMethod.POST, "/api/v1/self/registration").permitAll()
                 .requestMatchers(HttpMethod.POST, "/api/v1/self/registration/user").permitAll()
+                .requestMatchers(HttpMethod.POST, "/api/v1/self/registration/client-user").permitAll()
                 .requestMatchers(HttpMethod.POST, "/v1/self/registration").permitAll()
                 .requestMatchers(HttpMethod.POST, "/v1/self/registration/user").permitAll()
+                .requestMatchers(HttpMethod.POST, "/v1/self/registration/client-user").permitAll()
 
                 // Self authentication (login)
                 .requestMatchers(HttpMethod.POST, "/api/v1/self/authentication").permitAll()

--- a/src/test/java/org/apache/fineract/selfservice/registration/api/SelfServiceEnrollmentIntegrationTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/registration/api/SelfServiceEnrollmentIntegrationTest.java
@@ -1,0 +1,246 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.apache.fineract.selfservice.registration.api;
+
+import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import io.restassured.response.Response;
+import java.io.IOException;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import org.apache.fineract.selfservice.testing.support.SelfServiceIntegrationTestBase;
+import org.apache.fineract.selfservice.testing.support.SelfServiceTestUtils;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.Container;
+
+/**
+ * Integration tests for the self-enrollment endpoint that creates a client and self-service user.
+ */
+public class SelfServiceEnrollmentIntegrationTest extends SelfServiceIntegrationTestBase {
+
+    private static final String ENROLLMENT_PATH = "/fineract-provider/api/v1/self/registration/client-user";
+    private static final long CONCURRENT_ENROLLMENT_START_TIMEOUT_SECONDS = 5;
+    private static final AtomicLong UNIQUE_ID_SEQUENCE = new AtomicLong(System.nanoTime());
+
+    /**
+     * Generates a unique, digits-only suffix for phone numbers.
+     * A process-local atomic sequence avoids collisions better than hashing UUIDs into a small range.
+     */
+    private static String numericId() {
+        return String.format("%08d", Math.floorMod(UNIQUE_ID_SEQUENCE.incrementAndGet(), 100000000));
+    }
+
+    /**
+     * Builds a unique enrollment payload for success-path assertions.
+     *
+     * @return request JSON with unique username, mobile number, and email
+     */
+    private String generateUniquePayload() {
+        String id = numericId();
+        return """
+            {
+              "username": "user_%s",
+              "password": "Strong#Abc123",
+              "firstName": "Test",
+              "lastName": "User",
+              "mobileNumber": "555%s",
+              "email": "test%s@fineract.test",
+              "authenticationMode": "email",
+              "active": true
+            }
+            """.formatted(id, id, id);
+    }
+
+    /**
+     * Builds an enrollment payload that reuses a specific mobile suffix to trigger duplicate-number scenarios.
+     *
+     * @param phone the mobile suffix shared across requests
+     * @return request JSON with a duplicate mobile number and unique user identity fields
+     */
+    private String generateDuplicateMobilePayload(String phone) {
+        String id = numericId();
+        return """
+            {
+              "username": "diffuser_%s",
+              "password": "Strong#Abc123",
+              "firstName": "Test",
+              "lastName": "User",
+              "mobileNumber": "555%s",
+              "email": "diff%s@fineract.test",
+              "authenticationMode": "email",
+              "active": true
+            }
+            """.formatted(id, phone, id);
+    }
+
+    /**
+     * Executes a self-enrollment request, optionally waiting for a shared latch to coordinate concurrent submissions.
+     *
+     * @param payload request JSON to post
+     * @param latch latch used to align concurrent requests, or {@code null} for immediate execution
+     * @return the HTTP response returned by the self-enrollment endpoint
+     */
+    private Response executeSelfEnrollment(String payload, CountDownLatch latch) {
+        try {
+            if (latch != null
+                    && !latch.await(CONCURRENT_ENROLLMENT_START_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                fail("Timed out waiting to start concurrent enrollment requests");
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            fail("Interrupted while waiting to start concurrent enrollment requests", e);
+        }
+        return given(SelfServiceTestUtils.requestSpec(getFineractPort()))
+            .body(payload)
+            .when()
+            .post(ENROLLMENT_PATH)
+            .then()
+            .log().body()
+            .extract().response();
+    }
+
+    /**
+     * Runs a scalar count query against the test database using a single string parameter.
+     *
+     * @param sql SQL containing a single {@code ?} placeholder
+     * @param parameter value to inject into the placeholder after SQL-escaping single quotes
+     * @return the parsed count returned by PostgreSQL
+     */
+    private long queryCount(String sql, String parameter) {
+        try {
+            String sanitizedParam = parameter.replace("'", "''");
+            Container.ExecResult result = postgres.execInContainer(
+                "psql", "-U", "postgres", "-d", "fineract_default", "-t", "-A", "-c",
+                sql.replace("?", "'" + sanitizedParam + "'")
+            );
+            return Long.parseLong(result.getStdout().trim());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Failed to query test database", e);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to query test database", e);
+        }
+    }
+
+    /**
+     * Verifies that a valid self-enrollment request creates both resources successfully.
+     */
+    @Test
+    @DisplayName("Successfully enrolls an atomic Client and User")
+    void testSuccessfulSelfEnrollment() {
+        String payload = generateUniquePayload();
+        Response response = given(SelfServiceTestUtils.requestSpec(getFineractPort()))
+            .body(payload)
+            .when()
+            .post(ENROLLMENT_PATH)
+            .then()
+            .log().body()
+            .extract().response();
+
+        assertEquals(200, response.getStatusCode(),
+            "Expected successful enrollment. Body: " + response.body().asString());
+    }
+
+    /**
+     * Verifies that a second enrollment attempt with the same mobile number returns a conflict.
+     */
+    @Test
+    @DisplayName("Fails enrollment due to duplicate mobile number with 409 Conflict")
+    void testDuplicateMobileNumberFailsConstraint() {
+        String phone = numericId();
+        String id1 = numericId();
+        String payload1 = """
+            {
+              "username": "user1_%s",
+              "password": "Strong#Abc123",
+              "firstName": "Test",
+              "lastName": "User",
+              "mobileNumber": "555%s",
+              "email": "test1%s@fineract.test",
+              "authenticationMode": "email",
+              "active": true
+            }
+            """.formatted(id1, phone, id1);
+
+        // First enroll should succeed
+        Response response1 = executeSelfEnrollment(payload1, null);
+        assertEquals(200, response1.getStatusCode(),
+            "First enrollment should succeed. Body: " + response1.body().asString());
+
+        String payload2 = generateDuplicateMobilePayload(phone);
+        
+        // Second enroll should fail with 409 constraint violation
+        Response response2 = executeSelfEnrollment(payload2, null);
+        assertEquals(409, response2.getStatusCode(), "Expected 409 conflict for duplicate mobile number");
+    }
+
+    /**
+     * Verifies concurrent enrollments with the same mobile number do not leave orphaned client records.
+     */
+    @Test
+    @DisplayName("Concurrent enrollment avoids partial DB state via transactional isolation")
+    void testConcurrentRaceCondition() {
+        String phone = numericId();
+        String payload1 = generateDuplicateMobilePayload(phone);
+        String payload2 = generateDuplicateMobilePayload(phone);
+
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            CountDownLatch latch = new CountDownLatch(1);
+            CompletableFuture<Response> req1 = CompletableFuture
+                    .supplyAsync(() -> executeSelfEnrollment(payload1, latch), executor)
+                    .orTimeout(30, java.util.concurrent.TimeUnit.SECONDS);
+            CompletableFuture<Response> req2 = CompletableFuture
+                    .supplyAsync(() -> executeSelfEnrollment(payload2, latch), executor)
+                    .orTimeout(30, java.util.concurrent.TimeUnit.SECONDS);
+
+            // Release the latch to start both concurrently
+            latch.countDown();
+
+            Response r1 = req1.join();
+            Response r2 = req2.join();
+
+            int status1 = r1.getStatusCode();
+            int status2 = r2.getStatusCode();
+
+            // At least one succeeds or fails, but BOTH cannot succeed
+            assertTrue(
+                (status1 == 200 && status2 == 409) || 
+                (status1 == 409 && status2 == 200) || 
+                (status1 == 409 && status2 == 409),
+                "Expected race condition to resolve as atomic commit/fail. Got statuses: " + status1 + " and " + status2
+            );
+
+            long mappedClientCount = queryCount(
+                "select count(*) from m_client c "
+                    + "join m_selfservice_user_client_mapping m on m.client_id = c.id "
+                    + "where c.mobile_no = ?",
+                "555" + phone
+            );
+            long orphanClientCount = queryCount(
+                "select count(*) from m_client c "
+                    + "left join m_selfservice_user_client_mapping m on m.client_id = c.id "
+                    + "where c.mobile_no = ? and m.client_id is null",
+                "555" + phone
+            );
+
+            assertEquals(1L, mappedClientCount, "Expected exactly one client-user mapping for the shared mobile number");
+            assertEquals(0L, orphanClientCount, "Expected no orphan client for the failed enrollment");
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+}

--- a/src/test/java/org/apache/fineract/selfservice/registration/api/SelfServiceRegistrationIntegrationTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/registration/api/SelfServiceRegistrationIntegrationTest.java
@@ -27,15 +27,15 @@ class SelfServiceRegistrationIntegrationTest extends SelfServiceIntegrationTestB
   }
 
   @Test
-  @DisplayName("POST /v1/self/registration with invalid client logic returns 400")
-  void createRegistration_invalidClient_returns400() {
+  @DisplayName("POST /v1/self/registration with invalid client logic returns 404")
+  void createRegistration_invalidClient_returns404() {
     String payload = """
         {
           "accountNumber": "000000000",
           "firstName": "Inv",
           "lastName": "alid",
           "username": "invaliduser",
-          "password": "Password123!",
+          "password": "Strong#Abc123",
           "authenticationMode": "email",
           "email": "invalid@test.com"
         }
@@ -46,6 +46,6 @@ class SelfServiceRegistrationIntegrationTest extends SelfServiceIntegrationTestB
     .when()
         .post(SelfServiceTestUtils.SELF_REGISTRATION_PATH)
     .then()
-        .statusCode(400);
+        .statusCode(404);
   }
 }

--- a/src/test/java/org/apache/fineract/selfservice/registration/service/SelfServiceRegistrationWritePlatformServiceImplTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/registration/service/SelfServiceRegistrationWritePlatformServiceImplTest.java
@@ -39,6 +39,10 @@ import org.apache.fineract.useradministration.domain.PasswordValidationPolicy;
 import org.apache.fineract.useradministration.domain.PasswordValidationPolicyRepository;
 import org.apache.fineract.useradministration.domain.Role;
 import org.apache.fineract.useradministration.domain.RoleRepository;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.apache.fineract.useradministration.domain.AppUserRepository;
+import org.apache.fineract.portfolio.client.service.ClientWritePlatformService;
+import org.springframework.core.env.Environment;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -62,6 +66,10 @@ class SelfServiceRegistrationWritePlatformServiceImplTest {
     @Mock private AppSelfServiceUserReadPlatformService appUserReadPlatformService;
     @Mock private RoleRepository roleRepository;
     @Mock private AppSelfServiceUserClientMappingRepository appUserClientMappingRepository;
+    @Mock private JdbcTemplate jdbcTemplate;
+    @Mock private AppUserRepository appUserRepository;
+    @Mock private ClientWritePlatformService clientWritePlatformService;
+    @Mock private Environment env;
 
     private SelfServiceRegistrationWritePlatformServiceImpl service;
 
@@ -80,7 +88,11 @@ class SelfServiceRegistrationWritePlatformServiceImplTest {
             smsCampaignDropdownReadPlatformService,
             appUserReadPlatformService,
             roleRepository,
-            appUserClientMappingRepository
+            appUserClientMappingRepository,
+            jdbcTemplate,
+            appUserRepository,
+            clientWritePlatformService,
+            env
         );
     }
 
@@ -102,7 +114,7 @@ class SelfServiceRegistrationWritePlatformServiceImplTest {
         when(fromApiJsonHelper.extractStringNamed(eq(SelfServiceApiConstants.middleNameParamName), any())).thenReturn(null);
         when(fromApiJsonHelper.extractStringNamed(eq(SelfServiceApiConstants.lastNameParamName), any())).thenReturn("Doe");
         when(fromApiJsonHelper.extractStringNamed(eq(SelfServiceApiConstants.usernameParamName), any())).thenReturn("jdoe");
-        when(fromApiJsonHelper.extractStringNamed(eq(SelfServiceApiConstants.passwordParamName), any())).thenReturn("Password123!");
+        when(fromApiJsonHelper.extractStringNamed(eq(SelfServiceApiConstants.passwordParamName), any())).thenReturn("Strong#Abc123");
         when(fromApiJsonHelper.extractStringNamed(eq(SelfServiceApiConstants.authenticationModeParamName), any())).thenReturn("email");
         when(fromApiJsonHelper.extractStringNamed(eq(SelfServiceApiConstants.emailParamName), any())).thenReturn("john@test.com");
 
@@ -123,7 +135,7 @@ class SelfServiceRegistrationWritePlatformServiceImplTest {
         when(fromApiJsonHelper.extractStringNamed(eq(SelfServiceApiConstants.middleNameParamName), any())).thenReturn(null);
         when(fromApiJsonHelper.extractStringNamed(eq(SelfServiceApiConstants.lastNameParamName), any())).thenReturn("Doe");
         when(fromApiJsonHelper.extractStringNamed(eq(SelfServiceApiConstants.usernameParamName), any())).thenReturn("jdoe");
-        when(fromApiJsonHelper.extractStringNamed(eq(SelfServiceApiConstants.passwordParamName), any())).thenReturn("Password123!");
+        when(fromApiJsonHelper.extractStringNamed(eq(SelfServiceApiConstants.passwordParamName), any())).thenReturn("Strong#Abc123");
         when(fromApiJsonHelper.extractStringNamed(eq(SelfServiceApiConstants.authenticationModeParamName), any())).thenReturn("email");
         when(fromApiJsonHelper.extractStringNamed(eq(SelfServiceApiConstants.emailParamName), any())).thenReturn("john@test.com");
 

--- a/src/test/java/org/apache/fineract/selfservice/security/api/SelfServicePermissionEnforcementIntegrationTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/security/api/SelfServicePermissionEnforcementIntegrationTest.java
@@ -78,7 +78,7 @@ public class SelfServicePermissionEnforcementIntegrationTest extends SelfService
     regBody.put("firstName", "Test");
     regBody.put("lastName", clientName);
     regBody.put("username", username);
-    regBody.put("password", "Password123!");
+    regBody.put("password", "Strong#Abc123");
     regBody.put("email", username + "@fineract.org");
     regBody.put("authenticationMode", "email");
 


### PR DESCRIPTION
closes: https://mifosforge.jira.com/browse/MX-172

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public self-enrollment API for creating client-user accounts with expanded registration fields (names variants, contact, office, legal form, locale/date settings, external IDs), stronger input validation, and clear 409 conflict responses for duplicate data.

* **Security**
  * New client-user registration endpoint is explicitly permitted for unauthenticated access.

* **Tests**
  * Added integration tests for successful, duplicate, and concurrent self-enrollment scenarios; updated related test expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->