### PR TITLE
MX-238: Secure selfservice token flows

### DIFF
--- a/src/main/java/org/apache/fineract/selfservice/registration/SelfServiceApiConstants.java
+++ b/src/main/java/org/apache/fineract/selfservice/registration/SelfServiceApiConstants.java
@@ -39,10 +39,12 @@ public final class SelfServiceApiConstants {
     public static final String emailParamName = "email";
     public static final String usernameParamName = "username";
     public static final String authenticationTokenParamName = "authenticationToken";
+    public static final String externalAuthenticationTokenParamName = "externalAuthenticationToken";
     public static final String authenticationModeParamName = "authenticationMode";
     public static final String emailModeParamName = "email";
     public static final String mobileModeParamName = "mobile";
     public static final String requestIdParamName = "requestId";
+    public static final String repeatPasswordParamName = "repeatPassword";
     public static final String legalFormIdParamName = "legalFormId";
     public static final String isStaffParamName = "isStaff";
     public static final String officeIdParamName = "officeId";
@@ -73,10 +75,16 @@ public final class SelfServiceApiConstants {
                     mobileNumberParamName, lastNameParamName, emailParamName, authenticationModeParamName,middleNameParamName)));
     
     public static final Set<String> FORGOT_PASSWORD_REQUEST_DATA_PARAMETERS = Collections
-            .unmodifiableSet(new HashSet<>(Arrays.asList(usernameParamName, authenticationModeParamName)));
+            .unmodifiableSet(new HashSet<>(Arrays.asList(usernameParamName, externalIdParamName, externalIDParamName,
+                    authenticationModeParamName)));
     
     public static final Set<String> CREATE_USER_REQUEST_DATA_PARAMETERS = Collections
-            .unmodifiableSet(new HashSet<>(Arrays.asList(requestIdParamName, authenticationTokenParamName)));
+            .unmodifiableSet(new HashSet<>(Arrays.asList(requestIdParamName, authenticationTokenParamName,
+                    externalAuthenticationTokenParamName)));
+
+    public static final Set<String> FORGOT_PASSWORD_RENEW_DATA_PARAMETERS = Collections
+            .unmodifiableSet(new HashSet<>(Arrays.asList(requestIdParamName, authenticationTokenParamName,
+                    externalAuthenticationTokenParamName, passwordParamName, repeatPasswordParamName)));
     
     public static final List<Object> SUPPORTED_AUTHENTICATION_MODE_PARAMETERS = List
             .copyOf(Arrays.asList(emailModeParamName, mobileModeParamName));
@@ -90,5 +98,4 @@ public final class SelfServiceApiConstants {
                     datatablesParamName, familyMembersParamName, dateOfBirthParamName, genderIdParamName)));
     
     public static final String SELF_SERVICE_USER_ROLE = "Self Service User";
-
 }

--- a/src/main/java/org/apache/fineract/selfservice/registration/domain/SelfServiceRegistration.java
+++ b/src/main/java/org/apache/fineract/selfservice/registration/domain/SelfServiceRegistration.java
@@ -20,9 +20,12 @@ package org.apache.fineract.selfservice.registration.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.Version;
 import java.time.LocalDateTime;
 import org.apache.fineract.infrastructure.core.domain.AbstractPersistableCustom;
 import org.apache.fineract.infrastructure.core.service.DateUtils;
@@ -31,6 +34,8 @@ import org.apache.fineract.portfolio.client.domain.Client;
 @Entity
 @Table(name = "request_audit_table")
 public class SelfServiceRegistration extends AbstractPersistableCustom<Long> {
+
+    public static final String PASSWORD_RESET_SENTINEL = "<PASSWORD_RESET>";
 
     @ManyToOne
     @JoinColumn(name = "client_id", nullable = false)
@@ -57,19 +62,37 @@ public class SelfServiceRegistration extends AbstractPersistableCustom<Long> {
     @Column(name = "authentication_token", length = 100, nullable = true)
     private String authenticationToken;
 
+    @Column(name = "external_authorization_token", length = 100, nullable = true)
+    private String externalAuthorizationToken;
+
     @Column(name = "username", length = 100, nullable = false)
     private String username;
 
-    @Column(name = "password", length = 100, nullable = false)
+    @Column(name = "password", length = 250, nullable = false)
     private String password;
 
     @Column(name = "created_date", nullable = false)
     private LocalDateTime createdDate;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "request_type", length = 30, nullable = false)
+    private SelfServiceRequestType requestType;
+
+    @Column(name = "expires_at")
+    private LocalDateTime expiresAt;
+
+    @Column(name = "consumed", nullable = false)
+    private boolean consumed;
+
+    @Version
+    @Column(name = "version")
+    private Long version;
+
     public SelfServiceRegistration() {}
 
     public SelfServiceRegistration(final Client client, String accountNumber, final String firstName, final String middleName, final String lastName,
-            final String mobileNumber, final String email, final String authenticationToken, final String username, final String password) {
+            final String mobileNumber, final String email, final String authenticationToken, final String externalAuthorizationToken,
+            final String username, final String password, final SelfServiceRequestType requestType, final LocalDateTime expiresAt) {
         this.client = client;
         this.accountNumber = accountNumber;
         this.firstName = firstName;
@@ -78,16 +101,21 @@ public class SelfServiceRegistration extends AbstractPersistableCustom<Long> {
         this.mobileNumber = mobileNumber;
         this.email = email;
         this.authenticationToken = authenticationToken;
+        this.externalAuthorizationToken = externalAuthorizationToken;
         this.username = username;
         this.password = password;
         this.createdDate = DateUtils.getLocalDateTimeOfSystem();
+        this.requestType = requestType;
+        this.expiresAt = expiresAt;
+        this.consumed = false;
     }
 
     public static SelfServiceRegistration instance(final Client client, final String accountNumber, final String firstName, final String middleName,
-            final String lastName, final String mobileNumber, final String email, final String authenticationToken, final String username,
-            final String password) {
-        return new SelfServiceRegistration(client, accountNumber, firstName, middleName, lastName, mobileNumber, email, authenticationToken, username,
-                password);
+            final String lastName, final String mobileNumber, final String email, final String authenticationToken,
+            final String externalAuthorizationToken, final String username, final String password, final SelfServiceRequestType requestType,
+            final LocalDateTime expiresAt) {
+        return new SelfServiceRegistration(client, accountNumber, firstName, middleName, lastName, mobileNumber, email, authenticationToken,
+                externalAuthorizationToken, username, password, requestType, expiresAt);
     }
 
     public Client getClient() {
@@ -118,6 +146,10 @@ public class SelfServiceRegistration extends AbstractPersistableCustom<Long> {
         return this.authenticationToken;
     }
 
+    public String getExternalAuthorizationToken() {
+        return this.externalAuthorizationToken;
+    }
+
     public LocalDateTime getCreatedDate() {
         return this.createdDate;
     }
@@ -132,6 +164,42 @@ public class SelfServiceRegistration extends AbstractPersistableCustom<Long> {
 
     public String getAccountNumber() {
         return this.accountNumber;
+    }
+
+    public SelfServiceRequestType getRequestType() {
+        return this.requestType;
+    }
+
+    public LocalDateTime getExpiresAt() {
+        return this.expiresAt;
+    }
+
+    /**
+     * Returns whether this request has already been consumed and can no longer be reused.
+     *
+     * @return {@code true} when the request has been consumed
+     */
+    public boolean isConsumed() {
+        return this.consumed;
+    }
+
+    /**
+     * Returns whether the request is expired at the supplied point in time.
+     *
+     * @param now timestamp to compare against the configured expiry
+     * @return {@code true} when the request has reached or passed its expiry time
+     */
+    public boolean isExpired(LocalDateTime now) {
+        return this.expiresAt != null && !now.isBefore(this.expiresAt);
+    }
+
+    /**
+     * Marks this request as consumed. Optimistic locking via {@code @Version}
+     * ensures only one concurrent caller succeeds; the loser gets an
+     * {@link jakarta.persistence.OptimisticLockException}.
+     */
+    public void markConsumed() {
+        this.consumed = true;
     }
 
 }

--- a/src/main/java/org/apache/fineract/selfservice/registration/domain/SelfServiceRegistrationRepository.java
+++ b/src/main/java/org/apache/fineract/selfservice/registration/domain/SelfServiceRegistrationRepository.java
@@ -25,9 +25,34 @@ public interface SelfServiceRegistrationRepository
 
   String FIND_BY_REQUEST_AND_AUTHENTICATION_TOKEN =
       "select request from SelfServiceRegistration request where request.id = :id and "
-          + "request.authenticationToken = :authenticationToken";
+          + "request.authenticationToken = :authenticationToken and request.requestType = :requestType";
 
+  String FIND_BY_EXTERNAL_AUTHORIZATION_TOKEN =
+      "select request from SelfServiceRegistration request where request.externalAuthorizationToken = :externalAuthorizationToken "
+          + "and request.requestType = :requestType";
+
+  /**
+   * Looks up a self-service request by its legacy identifier pair and request type.
+   *
+   * @param id persisted request identifier
+   * @param authenticationToken persisted legacy authentication token
+   * @param requestType expected request type scope
+   * @return matching request, or {@code null} when no request matches
+   */
   @Query(FIND_BY_REQUEST_AND_AUTHENTICATION_TOKEN)
   SelfServiceRegistration getRequestByIdAndAuthenticationToken(
-      @Param("id") Long id, @Param("authenticationToken") String authenticationToken);
+      @Param("id") Long id, @Param("authenticationToken") String authenticationToken,
+      @Param("requestType") SelfServiceRequestType requestType);
+
+  /**
+   * Looks up a self-service request by its external authorization token and request type.
+   *
+   * @param externalAuthorizationToken external one-shot token presented by the caller
+   * @param requestType expected request type scope
+   * @return matching request, or {@code null} when no request matches
+   */
+  @Query(FIND_BY_EXTERNAL_AUTHORIZATION_TOKEN)
+  SelfServiceRegistration getRequestByExternalAuthorizationToken(
+      @Param("externalAuthorizationToken") String externalAuthorizationToken,
+      @Param("requestType") SelfServiceRequestType requestType);
 }

--- a/src/main/java/org/apache/fineract/selfservice/registration/domain/SelfServiceRequestType.java
+++ b/src/main/java/org/apache/fineract/selfservice/registration/domain/SelfServiceRequestType.java
@@ -1,0 +1,23 @@
+package org.apache.fineract.selfservice.registration.domain;
+
+/**
+ * Identifies the type of self-service request stored in {@code request_audit_table}.
+ *
+ * <p>The value determines which workflow may consume the stored token and ensures that a token
+ * issued for one workflow cannot be reused in another.
+ */
+public enum SelfServiceRequestType {
+    /**
+     * Request created for self-service registration confirmation.
+     *
+     * <p>Use this for tokens that activate or finalize creation of a self-service user.
+     */
+    REGISTRATION,
+
+    /**
+     * Request created for self-service password reset.
+     *
+     * <p>Use this for tokens that authorize renewal of an existing self-service password.
+     */
+    PASSWORD_RESET
+}

--- a/src/main/java/org/apache/fineract/selfservice/registration/exception/SelfServiceRegistrationNotFoundException.java
+++ b/src/main/java/org/apache/fineract/selfservice/registration/exception/SelfServiceRegistrationNotFoundException.java
@@ -22,9 +22,12 @@ public class SelfServiceRegistrationNotFoundException
   public SelfServiceRegistrationNotFoundException(Long requestId, String authenticationToken) {
     super(
         "error.msg.self.service.registration.not.found",
-        "Self service registration not found with request id : "
-            + requestId
-            + " and authentication token :"
-            + authenticationToken);
+        "Self service request not found for provided request id and authentication token");
+  }
+
+  public SelfServiceRegistrationNotFoundException(String externalAuthenticationToken) {
+    super(
+        "error.msg.self.service.registration.not.found",
+        "Self service request not found for provided external authentication token");
   }
 }

--- a/src/main/java/org/apache/fineract/selfservice/registration/service/RawPlatformUser.java
+++ b/src/main/java/org/apache/fineract/selfservice/registration/service/RawPlatformUser.java
@@ -1,0 +1,33 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.selfservice.registration.service;
+
+import java.util.Collections;
+import org.apache.fineract.infrastructure.security.domain.PlatformUser;
+import org.springframework.security.core.userdetails.User;
+
+final class RawPlatformUser extends User implements PlatformUser {
+
+    private static final long serialVersionUID = 1L;
+    private static final String USERNAME_PLACEHOLDER = "selfservice-encoder";
+
+    RawPlatformUser(String rawPassword) {
+        super(USERNAME_PLACEHOLDER, rawPassword, Collections.emptyList());
+    }
+}

--- a/src/main/java/org/apache/fineract/selfservice/registration/service/SelfServiceAuthorizationTokenService.java
+++ b/src/main/java/org/apache/fineract/selfservice/registration/service/SelfServiceAuthorizationTokenService.java
@@ -1,0 +1,116 @@
+package org.apache.fineract.selfservice.registration.service;
+
+import java.security.SecureRandom;
+import java.time.LocalDateTime;
+import java.util.Locale;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.core.env.Environment;
+
+/**
+ * Generates self-service authorization tokens and resolves their expiry configuration.
+ */
+public class SelfServiceAuthorizationTokenService {
+
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+    private static final String STRING_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+    private static final int MIN_NUMERIC_LENGTH = 8;
+    private static final int DEFAULT_NUMERIC_LENGTH = 8;
+    private static final int MAX_TOKEN_LENGTH = 100;
+    private static final String DEFAULT_TOKEN_TYPE = "uuidv7";
+    private static final int DEFAULT_EXPIRY_SECONDS = 30;
+    private final Environment env;
+
+    /**
+     * Creates the token service backed by Spring environment properties.
+     *
+     * @param env environment providing token type, length, and expiry overrides
+     */
+    public SelfServiceAuthorizationTokenService(Environment env) {
+        this.env = env;
+    }
+
+    /**
+     * Generates a token using the configured token type.
+     *
+     * <p>Supported types are {@code numeric}, {@code string}, and the default {@code uuidv7} mode.
+     * The default produces high-entropy UUIDv7 tokens; short numeric tokens are opt-in only.
+     *
+     * @return generated token string
+     */
+    public String generateToken() {
+        return switch (resolveTokenType()) {
+            case "string" -> randomString(resolveTokenLength());
+            case "numeric" -> randomNumericToken(resolveTokenLength());
+            default -> uuidV7();
+        };
+    }
+
+    /**
+     * Calculates the absolute expiry time for a token created at the supplied timestamp.
+     *
+     * @param createdAt token creation timestamp
+     * @return token expiry timestamp
+     */
+    public LocalDateTime calculateExpiry(LocalDateTime createdAt) {
+        return createdAt.plusSeconds(resolveExpirySeconds());
+    }
+
+    /**
+     * Resolves the configured token lifetime in seconds.
+     *
+     * <p>Defaults to {@value #DEFAULT_EXPIRY_SECONDS} seconds when not configured.
+     *
+     * @return token expiry duration in seconds
+     */
+    public int resolveExpirySeconds() {
+        int expirySeconds = env.getProperty("mifos.self.service.token.expiry.time", Integer.class, DEFAULT_EXPIRY_SECONDS);
+        if (expirySeconds < 1) {
+            throw new IllegalStateException("mifos.self.service.token.expiry.time must be greater than 0");
+        }
+        return expirySeconds;
+    }
+
+    private String resolveTokenType() {
+        return StringUtils.defaultIfBlank(env.getProperty("mifos.self.service.token.type"), DEFAULT_TOKEN_TYPE).trim().toLowerCase(Locale.ROOT);
+    }
+
+    private int resolveTokenLength() {
+        Integer configuredLength = env.getProperty("mifos.self.service.token.length", Integer.class);
+        if (configuredLength == null) {
+            configuredLength = env.getProperty("mifos.self.service.token.lenght", Integer.class, DEFAULT_NUMERIC_LENGTH);
+        }
+        int length = configuredLength == null ? DEFAULT_NUMERIC_LENGTH : configuredLength;
+        length = Math.min(length, MAX_TOKEN_LENGTH);
+        if ("numeric".equals(resolveTokenType())) {
+            return Math.max(length, MIN_NUMERIC_LENGTH);
+        }
+        return Math.max(length, 1);
+    }
+
+    private String randomNumericToken(int length) {
+        StringBuilder token = new StringBuilder(length);
+        for (int index = 0; index < length; index++) {
+            token.append(SECURE_RANDOM.nextInt(10));
+        }
+        return token.toString();
+    }
+
+    private String randomString(int length) {
+        StringBuilder token = new StringBuilder(length);
+        for (int index = 0; index < length; index++) {
+            token.append(STRING_ALPHABET.charAt(SECURE_RANDOM.nextInt(STRING_ALPHABET.length())));
+        }
+        return token.toString();
+    }
+
+    private String uuidV7() {
+        long unixMillis = System.currentTimeMillis();
+        long randA = SECURE_RANDOM.nextLong() & 0x0fffL;
+        long randB = SECURE_RANDOM.nextLong();
+
+        long msb = ((unixMillis & 0xffffffffffffL) << 16) | 0x7000L | randA;
+        long lsb = (randB & 0x3fffffffffffffffL) | 0x8000000000000000L;
+
+        return new java.util.UUID(msb, lsb).toString();
+    }
+}

--- a/src/main/java/org/apache/fineract/selfservice/registration/service/SelfServiceForgotPassworWritePlatformService.java
+++ b/src/main/java/org/apache/fineract/selfservice/registration/service/SelfServiceForgotPassworWritePlatformService.java
@@ -14,11 +14,24 @@
  */
 package org.apache.fineract.selfservice.registration.service;
 
+import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
 import org.apache.fineract.selfservice.registration.domain.SelfServiceRegistration;
 
 public interface SelfServiceForgotPassworWritePlatformService {
 
     SelfServiceRegistration createForgotPasswordRequest(String apiRequestBodyAsJson);
 
-    
+    /**
+     * Renews a self-service password using either the legacy {@code requestId +
+     * authenticationToken} pair or the newer {@code externalAuthenticationToken}.
+     *
+     * <p>The payload must include {@code password} and {@code repeatPassword}; the token must be
+     * valid, unexpired, and unused. The returned {@link CommandProcessingResult} identifies the
+     * updated self-service user. Validation errors, missing identifiers, expired tokens, and
+     * invalid tokens are reported as platform exceptions.
+     *
+     * @param apiRequestBodyAsJson request payload containing token fields and the new password
+     * @return command result for the updated self-service user
+     */
+    CommandProcessingResult renewPassword(String apiRequestBodyAsJson);
 }

--- a/src/main/java/org/apache/fineract/selfservice/registration/service/SelfServiceForgotPasswordWritePlatformServiceImpl.java
+++ b/src/main/java/org/apache/fineract/selfservice/registration/service/SelfServiceForgotPasswordWritePlatformServiceImpl.java
@@ -22,7 +22,7 @@ import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.reflect.TypeToken;
 import java.lang.reflect.Type;
-import java.security.SecureRandom;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -30,45 +30,49 @@ import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.fineract.infrastructure.campaigns.sms.data.SmsProviderData;
 import org.apache.fineract.infrastructure.campaigns.sms.domain.SmsCampaign;
 import org.apache.fineract.infrastructure.campaigns.sms.service.SmsCampaignDropdownReadPlatformService;
 import org.apache.fineract.infrastructure.core.api.JsonCommand;
 import org.apache.fineract.infrastructure.core.data.ApiParameterError;
+import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
+import org.apache.fineract.infrastructure.core.data.CommandProcessingResultBuilder;
 import org.apache.fineract.infrastructure.core.data.DataValidatorBuilder;
 import org.apache.fineract.infrastructure.core.domain.EmailDetail;
-import org.apache.fineract.infrastructure.core.exception.ErrorHandler;
 import org.apache.fineract.infrastructure.core.exception.PlatformApiDataValidationException;
 import org.apache.fineract.infrastructure.core.exception.PlatformDataIntegrityException;
 import org.apache.fineract.infrastructure.core.serialization.FromJsonHelper;
+import org.apache.fineract.infrastructure.core.service.DateUtils;
 import org.apache.fineract.infrastructure.core.service.GmailBackedPlatformEmailService;
+import org.apache.fineract.infrastructure.security.service.PlatformPasswordEncoder;
 import org.apache.fineract.infrastructure.sms.domain.SmsMessage;
 import org.apache.fineract.infrastructure.sms.domain.SmsMessageRepository;
 import org.apache.fineract.infrastructure.sms.domain.SmsMessageStatusType;
 import org.apache.fineract.infrastructure.sms.scheduler.SmsMessageScheduledJobService;
 import org.apache.fineract.organisation.staff.domain.Staff;
+import org.apache.fineract.portfolio.client.domain.Client;
 import org.apache.fineract.portfolio.client.domain.ClientRepositoryWrapper;
-import org.apache.fineract.portfolio.client.exception.ClientNotFoundException;
 import org.apache.fineract.portfolio.group.domain.Group;
 import org.apache.fineract.selfservice.registration.SelfServiceApiConstants;
 import org.apache.fineract.selfservice.registration.domain.SelfServiceRegistration;
 import org.apache.fineract.selfservice.registration.domain.SelfServiceRegistrationRepository;
-import org.apache.fineract.selfservice.registration.exception.SelfServiceEnrollmentConflictException;
+import org.apache.fineract.selfservice.registration.domain.SelfServiceRequestType;
+import org.apache.fineract.selfservice.registration.exception.SelfServiceRegistrationNotFoundException;
+import org.apache.fineract.selfservice.useradministration.domain.AppSelfServiceUser;
+import org.apache.fineract.selfservice.useradministration.domain.AppSelfServiceUserClientMapping;
 import org.apache.fineract.selfservice.useradministration.domain.AppSelfServiceUserClientMappingRepository;
-import org.apache.fineract.useradministration.domain.PasswordValidationPolicyRepository;
-import org.apache.fineract.useradministration.domain.RoleRepository;
+import org.apache.fineract.selfservice.useradministration.domain.AppSelfServiceUserRepository;
 import org.apache.fineract.selfservice.useradministration.domain.SelfServiceUserDomainService;
 import org.apache.fineract.selfservice.useradministration.service.AppSelfServiceUserReadPlatformService;
-import org.springframework.dao.EmptyResultDataAccessException;
-import org.apache.fineract.useradministration.domain.AppUser;
 import org.apache.fineract.useradministration.domain.AppUserRepository;
-import org.apache.fineract.portfolio.client.service.ClientWritePlatformService;
+import org.apache.fineract.useradministration.domain.PasswordValidationPolicy;
+import org.apache.fineract.useradministration.domain.PasswordValidationPolicyRepository;
+import org.apache.fineract.useradministration.domain.RoleRepository;
 import org.springframework.core.env.Environment;
+import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.jdbc.core.JdbcTemplate;
-import com.google.gson.JsonObject;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.fineract.portfolio.client.domain.Client;
-import org.apache.fineract.selfservice.useradministration.domain.AppSelfServiceUserClientMapping;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -86,12 +90,13 @@ public class SelfServiceForgotPasswordWritePlatformServiceImpl implements SelfSe
     private final SmsCampaignDropdownReadPlatformService smsCampaignDropdownReadPlatformService;
     private final AppSelfServiceUserReadPlatformService appUserReadPlatformService;
     private final RoleRepository roleRepository;
-    private static final SecureRandom secureRandom = new SecureRandom();
     private final AppSelfServiceUserClientMappingRepository appUserClientMappingRepository;
     private final JdbcTemplate jdbcTemplate;
     private final AppUserRepository appUserRepository;
-    private final ClientWritePlatformService clientWritePlatformService;
     private final Environment env;
+    private final PlatformPasswordEncoder platformPasswordEncoder;
+    private final AppSelfServiceUserRepository appSelfServiceUserRepository;
+    private final SelfServiceAuthorizationTokenService selfServiceAuthorizationTokenService;
 
     @Override
     public SelfServiceRegistration createForgotPasswordRequest(String apiRequestBodyAsJson) {
@@ -101,48 +106,184 @@ public class SelfServiceForgotPasswordWritePlatformServiceImpl implements SelfSe
         final DataValidatorBuilder baseDataValidator = new DataValidatorBuilder(dataValidationErrors).resource("user");
         this.fromApiJsonHelper.checkForUnsupportedParameters(typeOfMap, apiRequestBodyAsJson,
                 SelfServiceApiConstants.FORGOT_PASSWORD_REQUEST_DATA_PARAMETERS);
-        JsonElement element = gson.fromJson(apiRequestBodyAsJson.toString(), JsonElement.class);
+        JsonElement element = gson.fromJson(apiRequestBodyAsJson, JsonElement.class);
 
-        String userName = this.fromApiJsonHelper.extractStringNamed(SelfServiceApiConstants.usernameParamName, element);
-        baseDataValidator.reset().parameter(SelfServiceApiConstants.usernameParamName).value(userName).notBlank().notExceedingLengthOf(100);
-        
-        /*TODO: If present the externalId of the client can be used for comparing if it matches the records
-        String externalId = this.fromApiJsonHelper.extractStringNamed(SelfServiceApiConstants.externalIdParamName, element);
-        baseDataValidator.reset().parameter(SelfServiceApiConstants.externalIdParamName).value(externalId).notNull().notBlank()
-                .notExceedingLengthOf(100);
-        */
+        String username = this.fromApiJsonHelper.extractStringNamed(SelfServiceApiConstants.usernameParamName, element);
+        baseDataValidator.reset().parameter(SelfServiceApiConstants.usernameParamName).value(username).notBlank().notExceedingLengthOf(100);
+
+        String externalId = extractExternalId(element);
+        if (externalId != null) {
+            baseDataValidator.reset().parameter(SelfServiceApiConstants.externalIdParamName).value(externalId).notBlank()
+                    .notExceedingLengthOf(100);
+        }
 
         String authenticationMode = this.fromApiJsonHelper.extractStringNamed(SelfServiceApiConstants.authenticationModeParamName, element);
-        baseDataValidator.reset().parameter(SelfServiceApiConstants.authenticationModeParamName).value(authenticationMode).notBlank();
-        
-        boolean isEmailAuthenticationMode = authenticationMode.equalsIgnoreCase(SelfServiceApiConstants.emailModeParamName);
-        
-        validateForExistingUsername(userName);
+        baseDataValidator.reset().parameter(SelfServiceApiConstants.authenticationModeParamName).value(authenticationMode).notBlank()
+                .isOneOfTheseStringValues(SelfServiceApiConstants.emailModeParamName, SelfServiceApiConstants.mobileModeParamName);
 
-        throwExceptionIfValidationError(dataValidationErrors, userName, authenticationMode);
+        if (!dataValidationErrors.isEmpty()) {
+            throw new PlatformApiDataValidationException(dataValidationErrors);
+        }
 
-        String authenticationToken = randomAuthorizationTokenGeneration();
-        
-        AppSelfServiceUserClientMapping appSelfServiceUserClientMapping = this.appUserClientMappingRepository.fetchByAppuserUsername(userName);
-        
-        Client client = this.clientRepository.getClientByAccountNumber(appSelfServiceUserClientMapping.getClient().getAccountNumber());
-        
-        SelfServiceRegistration selfServiceRegistration = SelfServiceRegistration.instance(client, "", "", "", "",
-                "", appSelfServiceUserClientMapping.getAppUser().getEmail(), authenticationToken, userName, "");
-        this.selfServiceRegistrationRepository.saveAndFlush(selfServiceRegistration);
-        sendAuthorizationToken(selfServiceRegistration, isEmailAuthenticationMode);
-        return selfServiceRegistration;
+        AppSelfServiceUserClientMapping mapping = resolveUserMapping(username);
+        if (mapping == null) {
+            return null;
+        }
+        Client client = mapping.getClient();
+        AppSelfServiceUser appUser = mapping.getAppUser();
+        if (!matchesExternalId(externalId, client)) {
+            return null;
+        }
 
+        boolean isEmailAuthenticationMode = SelfServiceApiConstants.emailModeParamName.equalsIgnoreCase(authenticationMode);
+        String email = appUser.getEmail();
+        String mobileNumber = client.getMobileNo();
+        if (isEmailAuthenticationMode && StringUtils.isBlank(email)) {
+            return null;
+        }
+        if (!isEmailAuthenticationMode && StringUtils.isBlank(mobileNumber)) {
+            return null;
+        }
+
+        LocalDateTime createdAt = DateUtils.getLocalDateTimeOfSystem();
+        String token = selfServiceAuthorizationTokenService.generateToken();
+        SelfServiceRegistration request = SelfServiceRegistration.instance(client, client.getAccountNumber(), client.getFirstname(),
+                client.getMiddlename(), client.getLastname(), mobileNumber, email, token, token, username,
+                SelfServiceRegistration.PASSWORD_RESET_SENTINEL, SelfServiceRequestType.PASSWORD_RESET,
+                selfServiceAuthorizationTokenService.calculateExpiry(createdAt));
+        selfServiceRegistrationRepository.saveAndFlush(request);
+        trySendAuthorizationToken(request, isEmailAuthenticationMode);
+        return request;
     }
 
-    public void validateForExistingUsername(String username) {
-        boolean isExistingUserName = this.appUserReadPlatformService.isUsernameExist(username);
-        if (!isExistingUserName) {
-            final StringBuilder defaultMessageBuilder = new StringBuilder("User with username ").append(username)
-                    .append(" not found.");
-            throw new PlatformDataIntegrityException("error.msg.user.notfound.username", defaultMessageBuilder.toString(),
-                    SelfServiceApiConstants.usernameParamName, username);
+    @Transactional(rollbackFor = Exception.class)
+    @Override
+    public CommandProcessingResult renewPassword(String apiRequestBodyAsJson) {
+        Gson gson = new Gson();
+        final Type typeOfMap = new TypeToken<Map<String, Object>>() {}.getType();
+        final List<ApiParameterError> dataValidationErrors = new ArrayList<>();
+        final DataValidatorBuilder baseDataValidator = new DataValidatorBuilder(dataValidationErrors).resource("user");
+        this.fromApiJsonHelper.checkForUnsupportedParameters(typeOfMap, apiRequestBodyAsJson,
+                SelfServiceApiConstants.FORGOT_PASSWORD_RENEW_DATA_PARAMETERS);
+        JsonElement element = gson.fromJson(apiRequestBodyAsJson, JsonElement.class);
+
+        String password = this.fromApiJsonHelper.extractStringNamed(SelfServiceApiConstants.passwordParamName, element);
+        String repeatPassword = this.fromApiJsonHelper.extractStringNamed(SelfServiceApiConstants.repeatPasswordParamName, element);
+        baseDataValidator.reset().parameter(SelfServiceApiConstants.passwordParamName).value(password).notBlank().notExceedingLengthOf(100);
+        baseDataValidator.reset().parameter(SelfServiceApiConstants.repeatPasswordParamName).value(repeatPassword).notBlank()
+                .notExceedingLengthOf(100);
+
+        final PasswordValidationPolicy validationPolicy = this.passwordValidationPolicy.findActivePasswordValidationPolicy();
+        baseDataValidator.reset().parameter(SelfServiceApiConstants.passwordParamName).value(password)
+                .matchesRegularExpression(validationPolicy.getRegex(), validationPolicy.getDescription()).notExceedingLengthOf(100);
+
+        if (password != null && !password.equals(repeatPassword)) {
+            dataValidationErrors.add(ApiParameterError.parameterError("error.msg.password.confirmation.mismatch",
+                    "Password and repeatPassword must match.", SelfServiceApiConstants.repeatPasswordParamName, repeatPassword));
         }
+
+        SelfServiceRegistration request = resolvePasswordResetRequest(element, baseDataValidator, dataValidationErrors);
+        if (!dataValidationErrors.isEmpty()) {
+            throw new PlatformApiDataValidationException(dataValidationErrors);
+        }
+
+        AppSelfServiceUser appUser = this.appSelfServiceUserRepository.findAppSelfServiceUserByName(request.getUsername());
+        if (appUser == null) {
+            throw new PlatformDataIntegrityException("error.msg.user.notfound.username", "User with username " + request.getUsername() + " not found.",
+                    SelfServiceApiConstants.usernameParamName, request.getUsername());
+        }
+
+        appUser.updatePassword(encodePassword(password));
+        appUser.updatePasswordResetRequired(false);
+        appSelfServiceUserRepository.saveAndFlush(appUser);
+        request.markConsumed();
+        try {
+            selfServiceRegistrationRepository.saveAndFlush(request);
+        } catch (OptimisticLockingFailureException e) {
+            throw new PlatformDataIntegrityException("error.msg.self.service.request.token.invalid",
+                    "The supplied self-service token is expired or already used.",
+                    SelfServiceApiConstants.externalAuthenticationTokenParamName);
+        }
+
+        return new CommandProcessingResultBuilder().withEntityId(appUser.getId()).build();
+    }
+
+    private SelfServiceRegistration resolvePasswordResetRequest(JsonElement element, DataValidatorBuilder baseDataValidator,
+            List<ApiParameterError> dataValidationErrors) {
+        String externalToken = this.fromApiJsonHelper.extractStringNamed(SelfServiceApiConstants.externalAuthenticationTokenParamName, element);
+        if (externalToken != null) {
+            baseDataValidator.reset().parameter(SelfServiceApiConstants.externalAuthenticationTokenParamName).value(externalToken).notBlank()
+                    .notExceedingLengthOf(100);
+            if (!dataValidationErrors.isEmpty()) {
+                return null;
+            }
+            SelfServiceRegistration request = selfServiceRegistrationRepository.getRequestByExternalAuthorizationToken(externalToken,
+                    SelfServiceRequestType.PASSWORD_RESET);
+            validateRequestState(request, externalToken);
+            return request;
+        }
+
+        Long requestId = this.fromApiJsonHelper.extractLongNamed(SelfServiceApiConstants.requestIdParamName, element);
+        String authenticationToken = this.fromApiJsonHelper.extractStringNamed(SelfServiceApiConstants.authenticationTokenParamName, element);
+        baseDataValidator.reset().parameter(SelfServiceApiConstants.requestIdParamName).value(requestId).notNull().integerGreaterThanZero();
+        baseDataValidator.reset().parameter(SelfServiceApiConstants.authenticationTokenParamName).value(authenticationToken).notBlank().notNull()
+                .notExceedingLengthOf(100);
+        if (!dataValidationErrors.isEmpty()) {
+            return null;
+        }
+        SelfServiceRegistration request = selfServiceRegistrationRepository.getRequestByIdAndAuthenticationToken(requestId, authenticationToken,
+                SelfServiceRequestType.PASSWORD_RESET);
+        validateRequestState(request, requestId, authenticationToken);
+        return request;
+    }
+
+    private AppSelfServiceUserClientMapping resolveUserMapping(String username) {
+        if (!this.appUserReadPlatformService.isUsernameExist(username)) {
+            return null;
+        }
+        return this.appUserClientMappingRepository.fetchByAppuserUsername(username);
+    }
+
+    private boolean matchesExternalId(String externalId, Client client) {
+        if (externalId == null) {
+            return true;
+        }
+        String clientExternalId = client.getExternalId() == null ? null : client.getExternalId().getValue();
+        return externalId.equals(clientExternalId);
+    }
+
+    private String extractExternalId(JsonElement element) {
+        String externalId = this.fromApiJsonHelper.extractStringNamed(SelfServiceApiConstants.externalIdParamName, element);
+        if (externalId != null) {
+            return externalId;
+        }
+        return this.fromApiJsonHelper.extractStringNamed(SelfServiceApiConstants.externalIDParamName, element);
+    }
+
+    private void validateRequestState(SelfServiceRegistration request, String externalToken) {
+        if (request == null) {
+            throw new SelfServiceRegistrationNotFoundException(externalToken);
+        }
+        if (request.isConsumed() || request.isExpired(DateUtils.getLocalDateTimeOfSystem())) {
+            throw new PlatformDataIntegrityException("error.msg.self.service.request.token.invalid",
+                    "The supplied self-service token is expired or already used.", SelfServiceApiConstants.externalAuthenticationTokenParamName,
+                    externalToken);
+        }
+    }
+
+    private void validateRequestState(SelfServiceRegistration request, Long requestId, String authenticationToken) {
+        if (request == null) {
+            throw new SelfServiceRegistrationNotFoundException(requestId, authenticationToken);
+        }
+        if (request.isConsumed() || request.isExpired(DateUtils.getLocalDateTimeOfSystem())) {
+            throw new PlatformDataIntegrityException("error.msg.self.service.request.token.invalid",
+                    "The supplied self-service token is expired or already used.", SelfServiceApiConstants.authenticationTokenParamName,
+                    authenticationToken);
+        }
+    }
+
+    private String encodePassword(String rawPassword) {
+        return platformPasswordEncoder.encode(new RawPlatformUser(rawPassword));
     }
 
     public void sendAuthorizationToken(SelfServiceRegistration selfServiceRegistration, Boolean isEmailAuthenticationMode) {
@@ -153,6 +294,15 @@ public class SelfServiceForgotPasswordWritePlatformServiceImpl implements SelfSe
         }
     }
 
+    private void trySendAuthorizationToken(SelfServiceRegistration selfServiceRegistration, boolean isEmailAuthenticationMode) {
+        try {
+            sendAuthorizationToken(selfServiceRegistration, isEmailAuthenticationMode);
+        } catch (RuntimeException e) {
+            log.error("Failed to deliver self-service {} token for request {}", selfServiceRegistration.getRequestType(),
+                    selfServiceRegistration.getId(), e);
+        }
+    }
+
     private void sendAuthorizationMessage(SelfServiceRegistration selfServiceRegistration) {
         Collection<SmsProviderData> smsProviders = this.smsCampaignDropdownReadPlatformService.retrieveSmsProviders();
         if (smsProviders.isEmpty()) {
@@ -160,9 +310,8 @@ public class SelfServiceForgotPasswordWritePlatformServiceImpl implements SelfSe
                     "Mobile service provider not available.");
         }
         Long providerId = new ArrayList<>(smsProviders).get(0).getId();
-        final String message = "Hola  " + selfServiceRegistration.getFirstName() + "," + "\n\n"
-                + "Para crear un usuario, utilice los siguientes datos \n" + "\nId de Petición : " + selfServiceRegistration.getId()
-                + "\n Código de Autorización : " + selfServiceRegistration.getAuthenticationToken();
+        final String message = "Hola  " + selfServiceRegistration.getFirstName() + ","
+                + "\n\nCódigo de Autorización : " + selfServiceRegistration.getExternalAuthorizationToken();
         String externalId = null;
         Group group = null;
         Staff staff = null;
@@ -176,25 +325,11 @@ public class SelfServiceForgotPasswordWritePlatformServiceImpl implements SelfSe
 
     private void sendAuthorizationMail(SelfServiceRegistration selfServiceRegistration) {
         final String subject = "Código de Autorización ";
-        final String body = "Hola  " + selfServiceRegistration.getFirstName() + "," + "\n" + "Para crear un usuario, utilice los siguientes datos\n\n"
-                + "\nId de Petición: " + selfServiceRegistration.getId() + "\nCódigo de Autorización : "
-                + selfServiceRegistration.getAuthenticationToken();
+        final String body = "Hola  " + selfServiceRegistration.getFirstName() + ","
+                + "\nCódigo de Autorización : " + selfServiceRegistration.getExternalAuthorizationToken();
 
         final EmailDetail emailDetail = new EmailDetail(subject, body, selfServiceRegistration.getEmail(),
                 selfServiceRegistration.getFirstName());
         this.gmailBackedPlatformEmailService.sendDefinedEmail(emailDetail);
     }
-
-    private void throwExceptionIfValidationError(final List<ApiParameterError> dataValidationErrors, String userName, String authenticationMode) {
-        if (!dataValidationErrors.isEmpty()) {
-            throw new PlatformApiDataValidationException(dataValidationErrors);
-        }        
-    }
-
-    public static String randomAuthorizationTokenGeneration() {
-        Integer randomPIN = (int) (secureRandom.nextDouble() * 9000) + 1000;
-        return randomPIN.toString();
-    }
-
-
 }

--- a/src/main/java/org/apache/fineract/selfservice/registration/service/SelfServiceRegistrationWritePlatformServiceImpl.java
+++ b/src/main/java/org/apache/fineract/selfservice/registration/service/SelfServiceRegistrationWritePlatformServiceImpl.java
@@ -20,19 +20,23 @@ package org.apache.fineract.selfservice.registration.service;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import com.google.gson.reflect.TypeToken;
 import jakarta.persistence.PersistenceException;
 import java.lang.reflect.Type;
-import java.security.SecureRandom;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.fineract.infrastructure.campaigns.sms.data.SmsProviderData;
 import org.apache.fineract.infrastructure.campaigns.sms.domain.SmsCampaign;
@@ -45,7 +49,9 @@ import org.apache.fineract.infrastructure.core.exception.ErrorHandler;
 import org.apache.fineract.infrastructure.core.exception.PlatformApiDataValidationException;
 import org.apache.fineract.infrastructure.core.exception.PlatformDataIntegrityException;
 import org.apache.fineract.infrastructure.core.serialization.FromJsonHelper;
+import org.apache.fineract.infrastructure.core.service.DateUtils;
 import org.apache.fineract.infrastructure.core.service.GmailBackedPlatformEmailService;
+import org.apache.fineract.infrastructure.security.service.PlatformPasswordEncoder;
 import org.apache.fineract.infrastructure.sms.domain.SmsMessage;
 import org.apache.fineract.infrastructure.sms.domain.SmsMessageRepository;
 import org.apache.fineract.infrastructure.sms.domain.SmsMessageStatusType;
@@ -58,40 +64,37 @@ import org.apache.fineract.portfolio.group.domain.Group;
 import org.apache.fineract.selfservice.registration.SelfServiceApiConstants;
 import org.apache.fineract.selfservice.registration.domain.SelfServiceRegistration;
 import org.apache.fineract.selfservice.registration.domain.SelfServiceRegistrationRepository;
+import org.apache.fineract.selfservice.registration.domain.SelfServiceRequestType;
 import org.apache.fineract.selfservice.registration.exception.SelfServiceEnrollmentConflictException;
 import org.apache.fineract.selfservice.registration.exception.SelfServiceRegistrationNotFoundException;
 import org.apache.fineract.selfservice.useradministration.domain.AppSelfServiceUser;
-import org.apache.fineract.selfservice.useradministration.domain.AppSelfServiceUserClientMapping;
 import org.apache.fineract.selfservice.useradministration.domain.AppSelfServiceUserClientMappingRepository;
+import org.apache.fineract.selfservice.useradministration.domain.AppSelfServiceUserRepository;
+import org.apache.fineract.selfservice.useradministration.domain.SelfServiceUserDomainService;
+import org.apache.fineract.selfservice.useradministration.service.AppSelfServiceUserReadPlatformService;
+import org.apache.fineract.useradministration.domain.AppUser;
+import org.apache.fineract.useradministration.domain.AppUserRepository;
 import org.apache.fineract.useradministration.domain.PasswordValidationPolicy;
 import org.apache.fineract.useradministration.domain.PasswordValidationPolicyRepository;
 import org.apache.fineract.useradministration.domain.Role;
 import org.apache.fineract.useradministration.domain.RoleRepository;
-import org.apache.fineract.selfservice.useradministration.domain.SelfServiceUserDomainService;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.apache.fineract.useradministration.exception.RoleNotFoundException;
-import org.apache.fineract.selfservice.useradministration.service.AppSelfServiceUserReadPlatformService;
+import org.springframework.core.env.Environment;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.dao.EmptyResultDataAccessException;
-import org.springframework.orm.jpa.JpaSystemException;
-import org.springframework.security.authentication.AuthenticationServiceException;
-import org.springframework.security.core.userdetails.User;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.apache.fineract.useradministration.domain.AppUser;
-import org.apache.fineract.useradministration.domain.AppUserRepository;
-import org.apache.fineract.portfolio.client.service.ClientWritePlatformService;
-import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
-import org.springframework.core.env.Environment;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.orm.jpa.JpaSystemException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.authentication.AuthenticationServiceException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
-import java.util.Collections;
-import org.apache.commons.lang3.StringUtils;
+import org.apache.fineract.portfolio.client.service.ClientWritePlatformService;
+import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -109,12 +112,14 @@ public class SelfServiceRegistrationWritePlatformServiceImpl implements SelfServ
     private final SmsCampaignDropdownReadPlatformService smsCampaignDropdownReadPlatformService;
     private final AppSelfServiceUserReadPlatformService appUserReadPlatformService;
     private final RoleRepository roleRepository;
-    private static final SecureRandom secureRandom = new SecureRandom();
     private final AppSelfServiceUserClientMappingRepository appUserClientMappingRepository;
     private final JdbcTemplate jdbcTemplate;
     private final AppUserRepository appUserRepository;
     private final ClientWritePlatformService clientWritePlatformService;
     private final Environment env;
+    private final PlatformPasswordEncoder platformPasswordEncoder;
+    private final AppSelfServiceUserRepository appSelfServiceUserRepository;
+    private final SelfServiceAuthorizationTokenService selfServiceAuthorizationTokenService;
 
     @Override
     public SelfServiceRegistration createRegistrationRequest(String apiRequestBodyAsJson) {
@@ -171,10 +176,12 @@ public class SelfServiceRegistrationWritePlatformServiceImpl implements SelfServ
 
         throwExceptionIfValidationError(dataValidationErrors, accountNumber, firstName, middleName, lastName, mobileNumber, isEmailAuthenticationMode);
 
-        String authenticationToken = randomAuthorizationTokenGeneration();
+        String authenticationToken = selfServiceAuthorizationTokenService.generateToken();
+        LocalDateTime createdAt = DateUtils.getLocalDateTimeOfSystem();
         Client client = this.clientRepository.getClientByAccountNumber(accountNumber);
         SelfServiceRegistration selfServiceRegistration = SelfServiceRegistration.instance(client, accountNumber, firstName, middleName, lastName,
-                mobileNumber, email, authenticationToken, username, password);
+                mobileNumber, email, authenticationToken, authenticationToken, username, encodePassword(password),
+                SelfServiceRequestType.REGISTRATION, selfServiceAuthorizationTokenService.calculateExpiry(createdAt));
         this.selfServiceRegistrationRepository.saveAndFlush(selfServiceRegistration);
         sendAuthorizationToken(selfServiceRegistration, isEmailAuthenticationMode);
         return selfServiceRegistration;
@@ -199,6 +206,9 @@ public class SelfServiceRegistrationWritePlatformServiceImpl implements SelfServ
         }
     }
 
+
+
+
     private void sendAuthorizationMessage(SelfServiceRegistration selfServiceRegistration) {
         Collection<SmsProviderData> smsProviders = this.smsCampaignDropdownReadPlatformService.retrieveSmsProviders();
         if (smsProviders.isEmpty()) {
@@ -207,8 +217,7 @@ public class SelfServiceRegistrationWritePlatformServiceImpl implements SelfServ
         }
         Long providerId = new ArrayList<>(smsProviders).get(0).getId();
         final String message = "Hola  " + selfServiceRegistration.getFirstName() + "," + "\n\n"
-                + "Para crear un usuario, utilice los siguientes datos \n" + "\nId de Petición : " + selfServiceRegistration.getId()
-                + "\n Código de Autorización : " + selfServiceRegistration.getAuthenticationToken();
+                + "Código de Autorización : " + selfServiceRegistration.getExternalAuthorizationToken();
         String externalId = null;
         Group group = null;
         Staff staff = null;
@@ -222,9 +231,8 @@ public class SelfServiceRegistrationWritePlatformServiceImpl implements SelfServ
 
     private void sendAuthorizationMail(SelfServiceRegistration selfServiceRegistration) {
         final String subject = "Código de Autorización ";
-        final String body = "Hola  " + selfServiceRegistration.getFirstName() + "," + "\n" + "Para crear un usuario, utilice los siguientes datos\n\n"
-                + "\nId de Petición: " + selfServiceRegistration.getId() + "\nCódigo de Autorización : "
-                + selfServiceRegistration.getAuthenticationToken();
+        final String body = "Hola  " + selfServiceRegistration.getFirstName() + "," + "\nCódigo de Autorización : "
+                + selfServiceRegistration.getExternalAuthorizationToken();
 
         final EmailDetail emailDetail = new EmailDetail(subject, body, selfServiceRegistration.getEmail(),
                 selfServiceRegistration.getFirstName());
@@ -243,11 +251,7 @@ public class SelfServiceRegistrationWritePlatformServiceImpl implements SelfServ
         }
     }
 
-    public static String randomAuthorizationTokenGeneration() {
-        Integer randomPIN = (int) (secureRandom.nextDouble() * 9000) + 1000;
-        return randomPIN.toString();
-    }
-
+    @Transactional(rollbackFor = Exception.class)
     @Override
     public AppSelfServiceUser createSelfServiceUser(String apiRequestBodyAsJson) {
         JsonCommand command = null;
@@ -261,23 +265,12 @@ public class SelfServiceRegistrationWritePlatformServiceImpl implements SelfServ
                     SelfServiceApiConstants.CREATE_USER_REQUEST_DATA_PARAMETERS);
             JsonElement element = gson.fromJson(apiRequestBodyAsJson.toString(), JsonElement.class);
 
-            Long id = this.fromApiJsonHelper.extractLongNamed(SelfServiceApiConstants.requestIdParamName, element);
-            baseDataValidator.reset().parameter(SelfServiceApiConstants.requestIdParamName).value(id).notNull().integerGreaterThanZero();
-            command = JsonCommand.fromJsonElement(id, element);
-            String authenticationToken = this.fromApiJsonHelper.extractStringNamed(SelfServiceApiConstants.authenticationTokenParamName,
-                    element);
-            baseDataValidator.reset().parameter(SelfServiceApiConstants.authenticationTokenParamName).value(authenticationToken).notBlank()
-                    .notNull().notExceedingLengthOf(100);
-
+            SelfServiceRegistration selfServiceRegistration = resolveRegistrationRequest(element, baseDataValidator, dataValidationErrors);
             if (!dataValidationErrors.isEmpty()) {
                 throw new PlatformApiDataValidationException(dataValidationErrors);
             }
 
-            SelfServiceRegistration selfServiceRegistration = this.selfServiceRegistrationRepository
-                    .getRequestByIdAndAuthenticationToken(id, authenticationToken);
-            if (selfServiceRegistration == null) {
-                throw new SelfServiceRegistrationNotFoundException(id, authenticationToken);
-            }
+            command = JsonCommand.fromJsonElement(selfServiceRegistration.getId(), element);
             username = selfServiceRegistration.getUsername();
             Client client = selfServiceRegistration.getClient();
             final boolean passwordNeverExpire = true;
@@ -295,18 +288,19 @@ public class SelfServiceRegistrationWritePlatformServiceImpl implements SelfServ
             User user = new User(selfServiceRegistration.getUsername(), selfServiceRegistration.getPassword(), authorities);
             AppSelfServiceUser appUser = new AppSelfServiceUser(client.getOffice(), user, allRoles, selfServiceRegistration.getEmail(), client.getFirstname(),
                     client.getLastname(), null, passwordNeverExpire, isSelfServiceUser, clients, null);
-            AppSelfServiceUserClientMapping appUserClientMapping = this.appUserClientMappingRepository.fetchByClientId(client.getId());
-            this.userDomainService.create(appUser, true);
-            appUserClientMapping = new AppSelfServiceUserClientMapping(appUser,client);
-            this.appUserClientMappingRepository.saveClientUserMapping(appUser.getId(),client.getId());
+            appUser.updatePassword(selfServiceRegistration.getPassword());
+            selfServiceRegistration.markConsumed();
+            this.selfServiceRegistrationRepository.saveAndFlush(selfServiceRegistration);
+            this.appSelfServiceUserRepository.saveAndFlush(appUser);
+            this.appUserClientMappingRepository.saveClientUserMapping(appUser.getId(), client.getId());
             return appUser;
 
         } catch (final JpaSystemException | DataIntegrityViolationException dve) {
             handleDataIntegrityIssues(command, dve.getMostSpecificCause(), dve, username);
             return null;
         } catch (final PersistenceException | AuthenticationServiceException dve) {
-            Throwable throwable = ExceptionUtils.getRootCause(dve.getCause());
-            handleDataIntegrityIssues(command, throwable, dve, username);
+            Throwable throwable = ExceptionUtils.getRootCause(dve);
+            handleDataIntegrityIssues(command, throwable != null ? throwable : dve, dve, username);
             return null;
         }
 
@@ -324,7 +318,8 @@ public class SelfServiceRegistrationWritePlatformServiceImpl implements SelfServ
     @Override
     public AppSelfServiceUser createSelfServiceUserOrEnroll(String apiRequestBodyAsJson) {
         JsonObject json = JsonParser.parseString(apiRequestBodyAsJson).getAsJsonObject();
-        if (json.has(SelfServiceApiConstants.requestIdParamName) || json.has(SelfServiceApiConstants.authenticationTokenParamName)) {
+        if (json.has(SelfServiceApiConstants.requestIdParamName) || json.has(SelfServiceApiConstants.authenticationTokenParamName)
+                || json.has(SelfServiceApiConstants.externalAuthenticationTokenParamName)) {
             return createSelfServiceUser(apiRequestBodyAsJson);
         }
         return selfEnroll(apiRequestBodyAsJson);
@@ -446,17 +441,9 @@ public class SelfServiceRegistrationWritePlatformServiceImpl implements SelfServ
         } catch (PlatformDataIntegrityException pde) {
             throw translateEnrollmentConflict(pde);
         } catch (DataIntegrityViolationException dve) {
-            String msg = dve.getMostSpecificCause().getMessage().toLowerCase();
-            if (msg.contains("username") || msg.contains("username_org")) {
-                throw enrollmentConflict("error.msg.user.duplicate.username", "Username already exists", "username");
-            }
-            if (msg.contains("mobile_no") || msg.contains("mobileno")) {
-                throw enrollmentConflict("error.msg.client.duplicate.mobileNo", "Mobile number already exists", "mobileNo");
-            }
-            if (msg.contains("email")) {
-                throw enrollmentConflict("error.msg.client.duplicate.email", "Email already exists", "email");
-            }
-            throw ErrorHandler.getMappable(dve, "error.msg.unknown.data.integrity.issue", "Unknown data integrity issue");
+            throw translateEnrollmentFailure(dve);
+        } catch (PersistenceException dve) {
+            throw translateEnrollmentFailure(dve);
         }
     }
 
@@ -499,6 +486,28 @@ public class SelfServiceRegistrationWritePlatformServiceImpl implements SelfServ
             return enrollmentConflict(code, exception.getDefaultUserMessage(), "username");
         }
         return exception;
+    }
+
+    private RuntimeException translateEnrollmentFailure(Exception exception) {
+        Throwable rootCause = ExceptionUtils.getRootCause(exception);
+        Throwable mostSpecificCause = rootCause != null ? rootCause : exception;
+        String message = mostSpecificCause.getMessage();
+        if (message == null) {
+            return ErrorHandler.getMappable(exception, "error.msg.unknown.data.integrity.issue", "Unknown data integrity issue");
+        }
+
+        String normalized = message.toLowerCase();
+        if (normalized.contains("username") || normalized.contains("username_org")) {
+            return enrollmentConflict("error.msg.user.duplicate.username", "Username already exists", "username");
+        }
+        if (normalized.contains("mobile_no") || normalized.contains("mobileno")) {
+            return enrollmentConflict("error.msg.client.duplicate.mobileNo", "Mobile number already exists", "mobileNo");
+        }
+        if (normalized.contains("email")) {
+            return enrollmentConflict("error.msg.client.duplicate.email", "Email already exists", "email");
+        }
+
+        return ErrorHandler.getMappable(exception, "error.msg.unknown.data.integrity.issue", "Unknown data integrity issue");
     }
 
     private JsonObject normalizeSelfEnrollmentClientPayload(JsonObject originalJson) {
@@ -585,4 +594,59 @@ public class SelfServiceRegistrationWritePlatformServiceImpl implements SelfServ
         return StringUtils.isNotBlank(value) && value.matches("\\d{4}-\\d{2}-\\d{2}");
     }
 
+    private SelfServiceRegistration resolveRegistrationRequest(JsonElement element, DataValidatorBuilder baseDataValidator,
+            List<ApiParameterError> dataValidationErrors) {
+        String externalToken = this.fromApiJsonHelper.extractStringNamed(SelfServiceApiConstants.externalAuthenticationTokenParamName, element);
+        if (externalToken != null) {
+            baseDataValidator.reset().parameter(SelfServiceApiConstants.externalAuthenticationTokenParamName).value(externalToken).notBlank()
+                    .notExceedingLengthOf(100);
+            if (!dataValidationErrors.isEmpty()) {
+                return null;
+            }
+            SelfServiceRegistration request = this.selfServiceRegistrationRepository.getRequestByExternalAuthorizationToken(externalToken,
+                    SelfServiceRequestType.REGISTRATION);
+            validateRequestState(request, externalToken);
+            return request;
+        }
+
+        Long id = this.fromApiJsonHelper.extractLongNamed(SelfServiceApiConstants.requestIdParamName, element);
+        baseDataValidator.reset().parameter(SelfServiceApiConstants.requestIdParamName).value(id).notNull().integerGreaterThanZero();
+        String authenticationToken = this.fromApiJsonHelper.extractStringNamed(SelfServiceApiConstants.authenticationTokenParamName, element);
+        baseDataValidator.reset().parameter(SelfServiceApiConstants.authenticationTokenParamName).value(authenticationToken).notBlank()
+                .notNull().notExceedingLengthOf(100);
+        if (!dataValidationErrors.isEmpty()) {
+            return null;
+        }
+
+        SelfServiceRegistration request = this.selfServiceRegistrationRepository.getRequestByIdAndAuthenticationToken(id, authenticationToken,
+                SelfServiceRequestType.REGISTRATION);
+        validateRequestState(request, id, authenticationToken);
+        return request;
+    }
+
+    private void validateRequestState(SelfServiceRegistration request, String externalToken) {
+        if (request == null) {
+            throw new SelfServiceRegistrationNotFoundException(externalToken);
+        }
+        if (request.isConsumed() || request.isExpired(DateUtils.getLocalDateTimeOfSystem())) {
+            throw new PlatformDataIntegrityException("error.msg.self.service.request.token.invalid",
+                    "The supplied self-service token is expired or already used.", SelfServiceApiConstants.externalAuthenticationTokenParamName,
+                    externalToken);
+        }
+    }
+
+    private void validateRequestState(SelfServiceRegistration request, Long requestId, String authenticationToken) {
+        if (request == null) {
+            throw new SelfServiceRegistrationNotFoundException(requestId, authenticationToken);
+        }
+        if (request.isConsumed() || request.isExpired(DateUtils.getLocalDateTimeOfSystem())) {
+            throw new PlatformDataIntegrityException("error.msg.self.service.request.token.invalid",
+                    "The supplied self-service token is expired or already used.", SelfServiceApiConstants.authenticationTokenParamName,
+                    authenticationToken);
+        }
+    }
+
+    private String encodePassword(String rawPassword) {
+        return platformPasswordEncoder.encode(new RawPlatformUser(rawPassword));
+    }
 }

--- a/src/main/java/org/apache/fineract/selfservice/registration/starter/SelfRegistrationConfiguration.java
+++ b/src/main/java/org/apache/fineract/selfservice/registration/starter/SelfRegistrationConfiguration.java
@@ -20,6 +20,7 @@ import org.apache.fineract.infrastructure.core.service.GmailBackedPlatformEmailS
 import org.apache.fineract.infrastructure.sms.domain.SmsMessageRepository;
 import org.apache.fineract.infrastructure.sms.scheduler.SmsMessageScheduledJobService;
 import org.apache.fineract.portfolio.client.domain.ClientRepositoryWrapper;
+import org.apache.fineract.portfolio.client.service.ClientWritePlatformService;
 import org.apache.fineract.selfservice.registration.domain.SelfServiceRegistrationRepository;
 import org.apache.fineract.selfservice.registration.service.SelfServiceRegistrationReadPlatformService;
 import org.apache.fineract.selfservice.registration.service.SelfServiceRegistrationReadPlatformServiceImpl;
@@ -28,17 +29,19 @@ import org.apache.fineract.selfservice.registration.service.SelfServiceRegistrat
 import org.apache.fineract.selfservice.registration.service.SelfServiceForgotPassworWritePlatformService;
 import org.apache.fineract.selfservice.registration.service.SelfServiceForgotPasswordWritePlatformServiceImpl;
 import org.apache.fineract.selfservice.useradministration.domain.AppSelfServiceUserClientMappingRepository;
+import org.apache.fineract.selfservice.useradministration.domain.AppSelfServiceUserRepository;
 import org.apache.fineract.useradministration.domain.PasswordValidationPolicyRepository;
 import org.apache.fineract.useradministration.domain.RoleRepository;
 import org.apache.fineract.selfservice.useradministration.domain.SelfServiceUserDomainService;
 import org.apache.fineract.selfservice.useradministration.service.AppSelfServiceUserReadPlatformService;
+import org.apache.fineract.infrastructure.security.service.PlatformPasswordEncoder;
+import org.apache.fineract.selfservice.registration.service.SelfServiceAuthorizationTokenService;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.jdbc.core.JdbcTemplate;
 
 import org.apache.fineract.useradministration.domain.AppUserRepository;
-import org.apache.fineract.portfolio.client.service.ClientWritePlatformService;
 import org.springframework.core.env.Environment;
 
 @Configuration
@@ -48,6 +51,12 @@ public class SelfRegistrationConfiguration {
     @ConditionalOnMissingBean(SelfServiceRegistrationReadPlatformService.class)
     public SelfServiceRegistrationReadPlatformService selfServiceRegistrationReadPlatformService(JdbcTemplate jdbcTemplate) {
         return new SelfServiceRegistrationReadPlatformServiceImpl(jdbcTemplate);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(SelfServiceAuthorizationTokenService.class)
+    public SelfServiceAuthorizationTokenService selfServiceAuthorizationTokenService(Environment env) {
+        return new SelfServiceAuthorizationTokenService(env);
     }
 
     @Bean
@@ -63,12 +72,15 @@ public class SelfRegistrationConfiguration {
             AppSelfServiceUserReadPlatformService appUserReadPlatformService, RoleRepository roleRepository,
             AppSelfServiceUserClientMappingRepository appUserClientMappingRepository,
             JdbcTemplate jdbcTemplate, AppUserRepository appUserRepository, 
-            ClientWritePlatformService clientWritePlatformService, Environment env) {
+            ClientWritePlatformService clientWritePlatformService, Environment env,
+            PlatformPasswordEncoder platformPasswordEncoder, AppSelfServiceUserRepository appSelfServiceUserRepository,
+            SelfServiceAuthorizationTokenService selfServiceAuthorizationTokenService) {
         return new SelfServiceRegistrationWritePlatformServiceImpl(selfServiceRegistrationRepository, fromApiJsonHelper,
                 selfServiceRegistrationReadPlatformService, clientRepository, passwordValidationPolicy, userDomainService,
                 gmailBackedPlatformEmailService, smsMessageRepository, smsMessageScheduledJobService,
                  smsCampaignDropdownReadPlatformService, appUserReadPlatformService, roleRepository, appUserClientMappingRepository,
-                 jdbcTemplate, appUserRepository, clientWritePlatformService, env);
+                 jdbcTemplate, appUserRepository, clientWritePlatformService, env, platformPasswordEncoder, appSelfServiceUserRepository,
+                 selfServiceAuthorizationTokenService);
     }
     
      @Bean
@@ -84,11 +96,14 @@ public class SelfRegistrationConfiguration {
             AppSelfServiceUserReadPlatformService appUserReadPlatformService, RoleRepository roleRepository,
             AppSelfServiceUserClientMappingRepository appUserClientMappingRepository,
             JdbcTemplate jdbcTemplate, AppUserRepository appUserRepository, 
-            ClientWritePlatformService clientWritePlatformService, Environment env) {
+            Environment env,
+            PlatformPasswordEncoder platformPasswordEncoder, AppSelfServiceUserRepository appSelfServiceUserRepository,
+            SelfServiceAuthorizationTokenService selfServiceAuthorizationTokenService) {
         return new SelfServiceForgotPasswordWritePlatformServiceImpl(selfServiceRegistrationRepository, fromApiJsonHelper,
                 selfServiceRegistrationReadPlatformService, clientRepository, passwordValidationPolicy, userDomainService,
                 gmailBackedPlatformEmailService, smsMessageRepository, smsMessageScheduledJobService,
                  smsCampaignDropdownReadPlatformService, appUserReadPlatformService, roleRepository, appUserClientMappingRepository,
-                 jdbcTemplate, appUserRepository, clientWritePlatformService, env);
+                 jdbcTemplate, appUserRepository, env, platformPasswordEncoder, appSelfServiceUserRepository,
+                 selfServiceAuthorizationTokenService);
     }
 }

--- a/src/main/java/org/apache/fineract/selfservice/security/api/SelfForgotPasswordApiResource.java
+++ b/src/main/java/org/apache/fineract/selfservice/security/api/SelfForgotPasswordApiResource.java
@@ -10,6 +10,8 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import lombok.RequiredArgsConstructor;
+import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
+import org.apache.fineract.infrastructure.core.serialization.DefaultToApiJsonSerializer;
 import org.apache.fineract.selfservice.registration.SelfServiceApiConstants;
 import org.apache.fineract.selfservice.registration.service.SelfServiceForgotPassworWritePlatformService;
 
@@ -20,8 +22,7 @@ import org.apache.fineract.selfservice.registration.service.SelfServiceForgotPas
 @RequiredArgsConstructor
 public class SelfForgotPasswordApiResource {
 
-    private final SelfUserApiResource selfUserApiResource;
-    
+    private final DefaultToApiJsonSerializer<CommandProcessingResult> toApiJsonSerializer;
     private final SelfServiceForgotPassworWritePlatformService selfServiceForgotPassworWritePlatformService;
 
     
@@ -37,7 +38,8 @@ public class SelfForgotPasswordApiResource {
     @Path("/renew")
     @Produces({ MediaType.APPLICATION_JSON })
     public String renewPassword(@Parameter(hidden = true) final String apiRequestBodyAsJson) {   
-        return this.selfUserApiResource.update(apiRequestBodyAsJson);             
+        CommandProcessingResult result = this.selfServiceForgotPassworWritePlatformService.renewPassword(apiRequestBodyAsJson);
+        return this.toApiJsonSerializer.serialize(result);
     }
 
 }

--- a/src/main/resources/db/changelog/tenant/module/selfservice/module-changelog-master.xml
+++ b/src/main/resources/db/changelog/tenant/module/selfservice/module-changelog-master.xml
@@ -25,4 +25,5 @@
   <include file="parts/013-grant-selfservice-loan-account-create-account-permissions.xml" relativeToChangelogFile="true"/>      
   <include file="parts/014-grant-selfservice-loan-account-update-account-permissions.xml" relativeToChangelogFile="true"/>      
   <include file="parts/015-grant-selfservice-loan-account-withdrawn-account-permissions.xml" relativeToChangelogFile="true"/>        
+  <include file="parts/016-add-external-authorization-token.xml" relativeToChangelogFile="true"/>        
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/tenant/module/selfservice/parts/016-add-external-authorization-token.xml
+++ b/src/main/resources/db/changelog/tenant/module/selfservice/parts/016-add-external-authorization-token.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">    
+    <changeSet author="fineract" id="ss-0016-1">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="request_audit_table" columnName="external_authorization_token"/>
+            </not>
+        </preConditions>
+        <addColumn tableName="request_audit_table">
+            <column name="external_authorization_token" type="VARCHAR(100)">
+                <constraints nullable="true"/>
+            </column>
+        </addColumn>
+    </changeSet>
+
+    <changeSet author="fineract" id="ss-0016-2">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="request_audit_table" columnName="request_type"/>
+            </not>
+        </preConditions>
+        <addColumn tableName="request_audit_table">
+            <column name="request_type" type="VARCHAR(30)" defaultValue="REGISTRATION">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+    </changeSet>
+
+    <changeSet author="fineract" id="ss-0016-3">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="request_audit_table" columnName="expires_at"/>
+            </not>
+        </preConditions>
+        <addColumn tableName="request_audit_table">
+            <column name="expires_at" type="TIMESTAMP">
+                <constraints nullable="true"/>
+            </column>
+        </addColumn>
+    </changeSet>
+
+    <changeSet author="fineract" id="ss-0016-4">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="request_audit_table" columnName="consumed"/>
+            </not>
+        </preConditions>
+        <addColumn tableName="request_audit_table">
+            <column name="consumed" type="BOOLEAN" defaultValueBoolean="false">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+    </changeSet>
+
+    <changeSet author="fineract" id="ss-0016-5">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <indexExists tableName="request_audit_table" indexName="idx_request_audit_ext_token_type_unique"/>
+            </not>
+            <sqlCheck expectedResult="0">
+                SELECT COUNT(*) FROM (
+                    SELECT external_authorization_token, request_type
+                    FROM request_audit_table
+                    WHERE external_authorization_token IS NOT NULL
+                    GROUP BY external_authorization_token, request_type
+                    HAVING COUNT(*) &gt; 1
+                ) duplicates
+            </sqlCheck>
+        </preConditions>
+        <createIndex tableName="request_audit_table" indexName="idx_request_audit_ext_token_type_unique" unique="true">
+            <column name="external_authorization_token"/>
+            <column name="request_type"/>
+        </createIndex>
+    </changeSet>
+
+    <changeSet author="fineract" id="ss-0016-6">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="request_audit_table" columnName="version"/>
+            </not>
+        </preConditions>
+        <addColumn tableName="request_audit_table">
+            <column name="version" type="BIGINT" defaultValueNumeric="0">
+                <constraints nullable="true"/>
+            </column>
+        </addColumn>
+    </changeSet>
+
+    <changeSet author="fineract" id="ss-0016-7">
+        <preConditions onFail="MARK_RAN">
+            <columnExists tableName="request_audit_table" columnName="version"/>
+        </preConditions>
+        <update tableName="request_audit_table">
+            <column name="version" valueNumeric="0"/>
+            <where>version IS NULL</where>
+        </update>
+        <addNotNullConstraint tableName="request_audit_table" columnName="version" columnDataType="BIGINT"/>
+    </changeSet>
+</databaseChangeLog>

--- a/src/test/java/org/apache/fineract/selfservice/account/api/SelfAccountTransferTPTIntegrationTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/account/api/SelfAccountTransferTPTIntegrationTest.java
@@ -549,6 +549,12 @@ class SelfAccountTransferTPTIntegrationTest extends SelfServiceIntegrationTestBa
     try (Connection conn = DriverManager.getConnection(jdbcUrl, props)) {
       conn.setAutoCommit(false);
       try {
+        try (PreparedStatement ps = conn.prepareStatement(
+            "SELECT setval(pg_get_serial_sequence('m_appuser', 'id'), "
+                + "GREATEST(COALESCE((SELECT MAX(id) FROM m_appuser), 0), COALESCE((SELECT MAX(id) FROM m_appselfservice_user), 0)))")) {
+          ps.execute();
+        }
+
         String insertUser =
             "INSERT INTO m_appuser(office_id, username, password, email, firstname, lastname, "
                 + "is_deleted, nonexpired, nonlocked, nonexpired_credentials, enabled, firsttime_login_remaining) "
@@ -580,6 +586,11 @@ class SelfAccountTransferTPTIntegrationTest extends SelfServiceIntegrationTestBa
                 + "FROM m_appuser WHERE id = ?";
         try (PreparedStatement ps = conn.prepareStatement(insertSelfUser)) {
           ps.setLong(1, appUserId);
+          ps.execute();
+        }
+
+        try (PreparedStatement ps = conn.prepareStatement(
+            "SELECT setval(pg_get_serial_sequence('m_appselfservice_user', 'id'), (SELECT MAX(id) FROM m_appselfservice_user))")) {
           ps.execute();
         }
 

--- a/src/test/java/org/apache/fineract/selfservice/account/api/SelfBeneficiaryTPTIntegrationTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/account/api/SelfBeneficiaryTPTIntegrationTest.java
@@ -155,46 +155,66 @@ public class SelfBeneficiaryTPTIntegrationTest extends SelfServiceIntegrationTes
     String username = "ssuser_" + uniqueSuffix;
 
     try (Connection conn = DriverManager.getConnection(jdbcUrl, props)) {
-      String insertUser = "INSERT INTO m_appuser(office_id, username, password, email, firstname, lastname, "
-          + "is_deleted, nonexpired, nonlocked, nonexpired_credentials, enabled, firsttime_login_remaining) "
-          + "VALUES (1, ?, (SELECT password FROM m_appuser WHERE username='mifos' LIMIT 1), ?, "
-          + "'Beneficiary', 'User', false, true, true, true, true, false) RETURNING id";
-      long appUserId;
-      try (PreparedStatement ps = conn.prepareStatement(insertUser)) {
-        ps.setString(1, username);
-        ps.setString(2, username + "@fineract.org");
-        try (ResultSet rs = ps.executeQuery()) {
-          if (!rs.next()) throw new IllegalStateException("INSERT did not return generated user ID");
-          appUserId = rs.getLong(1);
+      conn.setAutoCommit(false);
+      try {
+        try (PreparedStatement ps = conn.prepareStatement(
+            "SELECT setval(pg_get_serial_sequence('m_appuser', 'id'), "
+                + "GREATEST(COALESCE((SELECT MAX(id) FROM m_appuser), 0), COALESCE((SELECT MAX(id) FROM m_appselfservice_user), 0)))")) {
+          ps.execute();
         }
-      }
 
-      try (PreparedStatement ps = conn.prepareStatement("INSERT INTO m_appuser_role(appuser_id, role_id) VALUES (?, ?)")) {
-        ps.setLong(1, appUserId);
-        ps.setInt(2, roleId);
-        ps.execute();
-      }
+        long userId;
+        String insertAppUser = "INSERT INTO m_appuser(office_id, username, password, email, firstname, lastname, "
+            + "is_deleted, nonexpired, nonlocked, nonexpired_credentials, enabled, firsttime_login_remaining) "
+            + "VALUES (1, ?, (SELECT password FROM m_appuser WHERE username='mifos' LIMIT 1), ?, "
+            + "'Beneficiary', 'User', false, true, true, true, true, false) RETURNING id";
+        try (PreparedStatement ps = conn.prepareStatement(insertAppUser)) {
+          ps.setString(1, username);
+          ps.setString(2, username + "@fineract.org");
+          try (ResultSet rs = ps.executeQuery()) {
+            if (!rs.next()) {
+              throw new IllegalStateException("Could not insert self-service user");
+            }
+            userId = rs.getLong(1);
+          }
+        }
 
-      String insertSelfUser = "INSERT INTO m_appselfservice_user(id, office_id, username, password, email, firstname, lastname, "
-          + "nonexpired, nonlocked, nonexpired_credentials, enabled, firsttime_login_remaining, is_self_service_user, is_deleted) "
-          + "SELECT id, office_id, username, password, email, firstname, lastname, "
-          + "nonexpired, nonlocked, nonexpired_credentials, enabled, firsttime_login_remaining, true, false "
-          + "FROM m_appuser WHERE id = ?";
-      try (PreparedStatement ps = conn.prepareStatement(insertSelfUser)) {
-        ps.setLong(1, appUserId);
-        ps.execute();
-      }
+        try (PreparedStatement ps = conn.prepareStatement("INSERT INTO m_appuser_role(appuser_id, role_id) VALUES (?, ?)")) {
+          ps.setLong(1, userId);
+          ps.setInt(2, roleId);
+          ps.execute();
+        }
 
-      try (PreparedStatement ps = conn.prepareStatement("INSERT INTO m_appselfservice_user_role(appuser_id, role_id) VALUES (?, ?)")) {
-        ps.setLong(1, appUserId);
-        ps.setInt(2, roleId);
-        ps.execute();
-      }
+        String insertSelfUser = "INSERT INTO m_appselfservice_user(id, office_id, username, password, email, firstname, lastname, "
+            + "nonexpired, nonlocked, nonexpired_credentials, enabled, firsttime_login_remaining, is_self_service_user, is_deleted, password_never_expires, password_reset_required) "
+            + "SELECT id, office_id, username, password, email, firstname, lastname, "
+            + "nonexpired, nonlocked, nonexpired_credentials, enabled, firsttime_login_remaining, true, false, false, false "
+            + "FROM m_appuser WHERE id = ?";
+        try (PreparedStatement ps = conn.prepareStatement(insertSelfUser)) {
+          ps.setLong(1, userId);
+          ps.execute();
+        }
 
-      try (PreparedStatement ps = conn.prepareStatement("INSERT INTO m_selfservice_user_client_mapping(appuser_id, client_id) VALUES (?, ?)")) {
-        ps.setLong(1, appUserId);
-        ps.setInt(2, clientId);
-        ps.execute();
+        try (PreparedStatement ps = conn.prepareStatement(
+            "SELECT setval(pg_get_serial_sequence('m_appselfservice_user', 'id'), (SELECT MAX(id) FROM m_appselfservice_user))")) {
+          ps.execute();
+        }
+
+        try (PreparedStatement ps = conn.prepareStatement("INSERT INTO m_appselfservice_user_role(appuser_id, role_id) VALUES (?, ?)")) {
+          ps.setLong(1, userId);
+          ps.setInt(2, roleId);
+          ps.execute();
+        }
+
+        try (PreparedStatement ps = conn.prepareStatement("INSERT INTO m_selfservice_user_client_mapping(appuser_id, client_id) VALUES (?, ?)")) {
+          ps.setLong(1, userId);
+          ps.setInt(2, clientId);
+          ps.execute();
+        }
+        conn.commit();
+      } catch (Exception e) {
+        conn.rollback();
+        throw e;
       }
     } catch (Exception e) {
       throw new RuntimeException("Failed to seed self-service user for beneficiary IT", e);

--- a/src/test/java/org/apache/fineract/selfservice/client/api/SelfClientsApiIntegrationTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/client/api/SelfClientsApiIntegrationTest.java
@@ -13,7 +13,7 @@ import io.restassured.response.Response;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
-import java.sql.Statement;
+import java.sql.PreparedStatement;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -110,7 +110,7 @@ class SelfClientsApiIntegrationTest extends SelfServiceIntegrationTestBase {
         .extract()
         .path("savingsId");
 
-    // 4. Create Self Service User (via JDBC directly to bypass email constraints/setup if any)
+    // 4. Create Self Service User directly in the self-service tables
     String selfUser = "user_" + clientName;
     Properties props = new Properties();
     props.setProperty("user", "postgres");
@@ -121,19 +121,43 @@ class SelfClientsApiIntegrationTest extends SelfServiceIntegrationTestBase {
         .get(SelfServiceTestUtils.CONTEXT_PATH + "/api/v1/roles")
         .jsonPath().getInt("find { it.name == 'Self Service User' }.id");
 
+    assertThat(roleId).as("Self Service User role must exist").isNotNull();
+    assertThat(clientId).as("Created clientId must be present").isNotNull();
+
     try (Connection conn = DriverManager.getConnection(postgres.getJdbcUrl(), props)) {
-        try (Statement st = conn.createStatement()) {
-            String insertUser = "INSERT INTO m_appuser(office_id, username, password, email, firstname, lastname, is_deleted, nonexpired, nonlocked, nonexpired_credentials, enabled, firsttime_login_remaining) " +
-                                "VALUES (1, '" + selfUser + "', (SELECT password FROM m_appuser WHERE username='mifos' LIMIT 1), '" + selfUser + "@fineract.org', 'Tomas', 'Test', false, true, true, true, true, false) RETURNING id";
-            ResultSet rs = st.executeQuery(insertUser);
-            rs.next();
-            long newUserId = rs.getLong(1);
-            
-            st.execute("INSERT INTO m_appuser_role(appuser_id, role_id) VALUES (" + newUserId + ", " + roleId + ")");
-            st.execute("INSERT INTO m_appselfservice_user(id, office_id, username, password, email, firstname, lastname, nonexpired, nonlocked, nonexpired_credentials, enabled, firsttime_login_remaining) " +
-                       "SELECT id, office_id, username, password, email, firstname, lastname, nonexpired, nonlocked, nonexpired_credentials, enabled, firsttime_login_remaining FROM m_appuser WHERE id = " + newUserId);
-            st.execute("INSERT INTO m_appselfservice_user_role(appuser_id, role_id) VALUES (" + newUserId + ", " + roleId + ")");
-            st.execute("INSERT INTO m_selfservice_user_client_mapping(appuser_id, client_id) VALUES (" + newUserId + ", " + clientId + ")");
+        conn.setAutoCommit(false);
+        try {
+            try (PreparedStatement ps = conn.prepareStatement(
+                "INSERT INTO m_appselfservice_user(office_id, username, password, email, firstname, lastname, is_deleted, nonexpired, nonlocked, nonexpired_credentials, enabled, firsttime_login_remaining, password_never_expires, is_self_service_user, password_reset_required) "
+                        + "VALUES (1, ?, (SELECT password FROM m_appuser WHERE username='mifos' LIMIT 1), ?, 'Tomas', 'Test', false, true, true, true, true, false, true, true, false) RETURNING id")) {
+                ps.setString(1, selfUser);
+                ps.setString(2, selfUser + "@fineract.org");
+                long newUserId;
+                try (ResultSet rs = ps.executeQuery()) {
+                    rs.next();
+                    newUserId = rs.getLong(1);
+                }
+
+                try (PreparedStatement roleStatement = conn.prepareStatement(
+                    "INSERT INTO m_appselfservice_user_role(appuser_id, role_id) VALUES (?, ?)")) {
+                    roleStatement.setLong(1, newUserId);
+                    roleStatement.setLong(2, roleId.longValue());
+                    roleStatement.executeUpdate();
+                }
+
+                try (PreparedStatement mappingStatement = conn.prepareStatement(
+                    "INSERT INTO m_selfservice_user_client_mapping(appuser_id, client_id) VALUES (?, ?)")) {
+                    mappingStatement.setLong(1, newUserId);
+                    mappingStatement.setLong(2, clientId.longValue());
+                    mappingStatement.executeUpdate();
+                }
+            }
+            conn.commit();
+        } catch (Exception e) {
+            conn.rollback();
+            throw e;
+        } finally {
+            conn.setAutoCommit(true);
         }
     }
 

--- a/src/test/java/org/apache/fineract/selfservice/client/api/SelfClientsApiResourceTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/client/api/SelfClientsApiResourceTest.java
@@ -162,12 +162,12 @@ class SelfClientsApiResourceTest {
 
   // --- retrieveOne ---
 
-  @Test
-  void retrieveOne_checksPermission() {
-    mockClientMapped();
-    ClientData clientData = mock(ClientData.class);
-    when(selfServiceClientReadPlatformService.retrieveOne(CLIENT_ID)).thenReturn(clientData);
-    when(clientSerializer.serialize(any(), eq(clientData))).thenReturn("{\"id\":5}");
+    @Test
+    void retrieveOne_checksPermission() {
+        mockClientMapped();
+        ClientData clientData = ClientData.emptyInstance(CLIENT_ID);
+        when(selfServiceClientReadPlatformService.retrieveOne(CLIENT_ID)).thenReturn(clientData);
+        when(clientSerializer.serialize(any(), eq(clientData))).thenReturn("{\"id\":5}");
 
     resource.retrieveOne(CLIENT_ID, uriInfo);
 

--- a/src/test/java/org/apache/fineract/selfservice/products/api/SelfSavingsProductsApiResourceTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/products/api/SelfSavingsProductsApiResourceTest.java
@@ -6,10 +6,11 @@
  */
 package org.apache.fineract.selfservice.products.api;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -50,6 +51,11 @@ class SelfSavingsProductsApiResourceTest {
 
   private static final Long PRODUCT_ID = 1L;
 
+  private static SavingsProductData defaultSavingsProductData() {
+    return SavingsProductData.template(null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null,
+        null, null, null, null);
+  }
+
   @BeforeEach
   void setUp() {
     resource =
@@ -67,15 +73,16 @@ class SelfSavingsProductsApiResourceTest {
 
   @Test
   void retrieveAll_authorized_callsReadService() {
-    Collection<SavingsProductData> products = List.of(mock(SavingsProductData.class));
+    Collection<SavingsProductData> products = List.of(defaultSavingsProductData());
     when(savingsProductReadPlatformService.retrieveAll()).thenReturn(products);
     when(toApiJsonSerializer.serialize(any(), any(Collection.class))).thenReturn("[]");
 
     String result = resource.retrieveAll(uriInfo);
 
-    assertNotNull(result);
+    assertEquals("[]", result);
     verify(securityContext).validateHasReadPermission("SAVINGSPRODUCT");
     verify(savingsProductReadPlatformService).retrieveAll();
+    verify(toApiJsonSerializer).serialize(any(), eq(products));
   }
 
   @Test
@@ -90,15 +97,16 @@ class SelfSavingsProductsApiResourceTest {
 
   @Test
   void retrieveOne_authorized_callsReadService() {
-    SavingsProductData product = mock(SavingsProductData.class);
+    SavingsProductData product = defaultSavingsProductData();
     when(savingsProductReadPlatformService.retrieveOne(PRODUCT_ID)).thenReturn(product);
     when(toApiJsonSerializer.serialize(any(), any(SavingsProductData.class))).thenReturn("{}");
 
     String result = resource.retrieveOne(PRODUCT_ID, uriInfo);
 
-    assertNotNull(result);
+    assertEquals("{}", result);
     verify(securityContext).validateHasReadPermission("SAVINGSPRODUCT");
     verify(savingsProductReadPlatformService).retrieveOne(PRODUCT_ID);
+    verify(toApiJsonSerializer).serialize(any(), eq(product));
   }
 
   @Test

--- a/src/test/java/org/apache/fineract/selfservice/registration/SelfServiceApiConstantsTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/registration/SelfServiceApiConstantsTest.java
@@ -40,7 +40,10 @@ class SelfServiceApiConstantsTest {
     assertTrue(
         SelfServiceApiConstants.CREATE_USER_REQUEST_DATA_PARAMETERS.contains(
             "authenticationToken"));
-    assertEquals(2, SelfServiceApiConstants.CREATE_USER_REQUEST_DATA_PARAMETERS.size());
+    assertTrue(
+        SelfServiceApiConstants.CREATE_USER_REQUEST_DATA_PARAMETERS.contains(
+            "externalAuthenticationToken"));
+    assertEquals(3, SelfServiceApiConstants.CREATE_USER_REQUEST_DATA_PARAMETERS.size());
   }
 
   @Test
@@ -53,6 +56,23 @@ class SelfServiceApiConstantsTest {
   @Test
   void selfServiceUserRole_shouldBeCorrect() {
     assertEquals("Self Service User", SelfServiceApiConstants.SELF_SERVICE_USER_ROLE);
+  }
+
+  @Test
+  void forgotPasswordRenewDataParameters_shouldContainRequiredFields() {
+    assertTrue(SelfServiceApiConstants.FORGOT_PASSWORD_RENEW_DATA_PARAMETERS.contains("requestId"));
+    assertTrue(SelfServiceApiConstants.FORGOT_PASSWORD_RENEW_DATA_PARAMETERS.contains("authenticationToken"));
+    assertTrue(SelfServiceApiConstants.FORGOT_PASSWORD_RENEW_DATA_PARAMETERS.contains("externalAuthenticationToken"));
+    assertTrue(SelfServiceApiConstants.FORGOT_PASSWORD_RENEW_DATA_PARAMETERS.contains("password"));
+    assertTrue(SelfServiceApiConstants.FORGOT_PASSWORD_RENEW_DATA_PARAMETERS.contains("repeatPassword"));
+    assertEquals(5, SelfServiceApiConstants.FORGOT_PASSWORD_RENEW_DATA_PARAMETERS.size());
+  }
+
+  @Test
+  void forgotPasswordRenewDataParameters_shouldBeImmutable() {
+    assertThrows(
+        UnsupportedOperationException.class,
+        () -> SelfServiceApiConstants.FORGOT_PASSWORD_RENEW_DATA_PARAMETERS.add("illegal"));
   }
 
   @Test

--- a/src/test/java/org/apache/fineract/selfservice/registration/domain/SelfServiceRegistrationTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/registration/domain/SelfServiceRegistrationTest.java
@@ -9,7 +9,9 @@ package org.apache.fineract.selfservice.registration.domain;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 
+import java.time.LocalDateTime;
 import org.apache.fineract.portfolio.client.domain.Client;
+import org.apache.fineract.selfservice.registration.domain.SelfServiceRequestType;
 import org.junit.jupiter.api.Test;
 
 class SelfServiceRegistrationTest {
@@ -27,8 +29,11 @@ class SelfServiceRegistrationTest {
             "5522649498",
             "pedro@test.com",
             "1234",
+            "external-token",
             "pedro.marmol",
-            "SecurePass123#");
+            "SecurePass123#",
+            SelfServiceRequestType.REGISTRATION,
+            LocalDateTime.now().plusSeconds(30));
 
     assertEquals(client, reg.getClient());
     assertEquals("000000001", reg.getAccountNumber());
@@ -38,8 +43,12 @@ class SelfServiceRegistrationTest {
     assertEquals("5522649498", reg.getMobileNumber());
     assertEquals("pedro@test.com", reg.getEmail());
     assertEquals("1234", reg.getAuthenticationToken());
+    assertEquals("external-token", reg.getExternalAuthorizationToken());
     assertEquals("pedro.marmol", reg.getUsername());
     assertEquals("SecurePass123#", reg.getPassword());
+    assertEquals(SelfServiceRequestType.REGISTRATION, reg.getRequestType());
+    assertFalse(reg.isConsumed());
+    assertNotNull(reg.getExpiresAt());
     assertNotNull(reg.getCreatedDate());
   }
 
@@ -56,8 +65,11 @@ class SelfServiceRegistrationTest {
             null,
             "john@test.com",
             "5678",
+            "other-token",
             "john.doe",
-            "Pass456#");
+            "Pass456#",
+            SelfServiceRequestType.PASSWORD_RESET,
+            LocalDateTime.now().plusSeconds(30));
 
     assertNull(reg.getMiddleName());
     assertNull(reg.getMobileNumber());

--- a/src/test/java/org/apache/fineract/selfservice/registration/service/SelfServiceAuthorizationTokenServiceTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/registration/service/SelfServiceAuthorizationTokenServiceTest.java
@@ -1,0 +1,59 @@
+package org.apache.fineract.selfservice.registration.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.env.Environment;
+
+@ExtendWith(MockitoExtension.class)
+class SelfServiceAuthorizationTokenServiceTest {
+
+    @Mock private Environment env;
+
+    @Test
+    void generateToken_defaultsToUuidV7() {
+        SelfServiceAuthorizationTokenService service = new SelfServiceAuthorizationTokenService(env);
+
+        String token = service.generateToken();
+
+        assertTrue(token.matches("^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"));
+    }
+
+    @Test
+    void generateToken_respectsNumericConfiguration() {
+        when(env.getProperty("mifos.self.service.token.type")).thenReturn("numeric");
+        SelfServiceAuthorizationTokenService service = new SelfServiceAuthorizationTokenService(env);
+
+        String token = service.generateToken();
+
+        assertTrue(token.matches("\\d{8}"));
+    }
+
+    @Test
+    void calculateExpiry_usesConfiguredSeconds() {
+        when(env.getProperty("mifos.self.service.token.expiry.time", Integer.class, 30)).thenReturn(45);
+        SelfServiceAuthorizationTokenService service = new SelfServiceAuthorizationTokenService(env);
+        LocalDateTime createdAt = LocalDateTime.of(2026, 4, 13, 10, 0, 0);
+
+        LocalDateTime expiresAt = service.calculateExpiry(createdAt);
+
+        assertEquals(createdAt.plusSeconds(45), expiresAt);
+    }
+
+    @Test
+    void calculateExpiry_defaultsToThirtySeconds() {
+        when(env.getProperty("mifos.self.service.token.expiry.time", Integer.class, 30)).thenReturn(30);
+        SelfServiceAuthorizationTokenService service = new SelfServiceAuthorizationTokenService(env);
+        LocalDateTime createdAt = LocalDateTime.of(2026, 4, 13, 10, 0, 0);
+
+        LocalDateTime expiresAt = service.calculateExpiry(createdAt);
+
+        assertEquals(createdAt.plusSeconds(30), expiresAt);
+    }
+}

--- a/src/test/java/org/apache/fineract/selfservice/registration/service/SelfServiceForgotPasswordWritePlatformServiceImplTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/registration/service/SelfServiceForgotPasswordWritePlatformServiceImplTest.java
@@ -1,0 +1,179 @@
+package org.apache.fineract.selfservice.registration.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import org.apache.fineract.infrastructure.campaigns.sms.service.SmsCampaignDropdownReadPlatformService;
+import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
+import org.apache.fineract.infrastructure.core.serialization.FromJsonHelper;
+import org.apache.fineract.infrastructure.core.service.GmailBackedPlatformEmailService;
+import org.apache.fineract.infrastructure.security.service.PlatformPasswordEncoder;
+import org.apache.fineract.infrastructure.sms.domain.SmsMessageRepository;
+import org.apache.fineract.infrastructure.sms.scheduler.SmsMessageScheduledJobService;
+import org.apache.fineract.portfolio.client.domain.Client;
+import org.apache.fineract.portfolio.client.domain.ClientRepositoryWrapper;
+import org.apache.fineract.selfservice.registration.SelfServiceApiConstants;
+import org.apache.fineract.selfservice.registration.domain.SelfServiceRegistration;
+import org.apache.fineract.selfservice.registration.domain.SelfServiceRegistrationRepository;
+import org.apache.fineract.selfservice.registration.domain.SelfServiceRequestType;
+import org.apache.fineract.selfservice.useradministration.domain.AppSelfServiceUser;
+import org.apache.fineract.selfservice.useradministration.domain.AppSelfServiceUserClientMapping;
+import org.apache.fineract.selfservice.useradministration.domain.AppSelfServiceUserClientMappingRepository;
+import org.apache.fineract.selfservice.useradministration.domain.AppSelfServiceUserRepository;
+import org.apache.fineract.selfservice.useradministration.domain.SelfServiceUserDomainService;
+import org.apache.fineract.selfservice.useradministration.service.AppSelfServiceUserReadPlatformService;
+import org.apache.fineract.useradministration.domain.AppUserRepository;
+import org.apache.fineract.useradministration.domain.PasswordValidationPolicy;
+import org.apache.fineract.useradministration.domain.PasswordValidationPolicyRepository;
+import org.apache.fineract.useradministration.domain.RoleRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.env.Environment;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+@ExtendWith(MockitoExtension.class)
+class SelfServiceForgotPasswordWritePlatformServiceImplTest {
+
+    @Mock private SelfServiceRegistrationRepository selfServiceRegistrationRepository;
+    @Mock private FromJsonHelper fromApiJsonHelper;
+    @Mock private SelfServiceRegistrationReadPlatformService selfServiceRegistrationReadPlatformService;
+    @Mock private ClientRepositoryWrapper clientRepository;
+    @Mock private PasswordValidationPolicyRepository passwordValidationPolicyRepository;
+    @Mock private SelfServiceUserDomainService userDomainService;
+    @Mock private GmailBackedPlatformEmailService gmailBackedPlatformEmailService;
+    @Mock private SmsMessageRepository smsMessageRepository;
+    @Mock private SmsMessageScheduledJobService smsMessageScheduledJobService;
+    @Mock private SmsCampaignDropdownReadPlatformService smsCampaignDropdownReadPlatformService;
+    @Mock private AppSelfServiceUserReadPlatformService appUserReadPlatformService;
+    @Mock private RoleRepository roleRepository;
+    @Mock private AppSelfServiceUserClientMappingRepository appUserClientMappingRepository;
+    @Mock private JdbcTemplate jdbcTemplate;
+    @Mock private AppUserRepository appUserRepository;
+    @Mock private Environment env;
+    @Mock private PlatformPasswordEncoder platformPasswordEncoder;
+    @Mock private AppSelfServiceUserRepository appSelfServiceUserRepository;
+    @Mock private SelfServiceAuthorizationTokenService selfServiceAuthorizationTokenService;
+
+    private SelfServiceForgotPasswordWritePlatformServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new SelfServiceForgotPasswordWritePlatformServiceImpl(
+                selfServiceRegistrationRepository,
+                fromApiJsonHelper,
+                selfServiceRegistrationReadPlatformService,
+                clientRepository,
+                passwordValidationPolicyRepository,
+                userDomainService,
+                gmailBackedPlatformEmailService,
+                smsMessageRepository,
+                smsMessageScheduledJobService,
+                smsCampaignDropdownReadPlatformService,
+                appUserReadPlatformService,
+                roleRepository,
+                appUserClientMappingRepository,
+                jdbcTemplate,
+                appUserRepository,
+                env,
+                platformPasswordEncoder,
+                appSelfServiceUserRepository,
+                selfServiceAuthorizationTokenService);
+    }
+
+    @Test
+    void createForgotPasswordRequest_persistsPasswordResetRequest() {
+        when(fromApiJsonHelper.extractStringNamed(eq(SelfServiceApiConstants.usernameParamName), any())).thenReturn("jdoe");
+        when(fromApiJsonHelper.extractStringNamed(eq(SelfServiceApiConstants.externalIdParamName), any())).thenReturn(null);
+        when(fromApiJsonHelper.extractStringNamed(eq(SelfServiceApiConstants.externalIDParamName), any())).thenReturn(null);
+        when(fromApiJsonHelper.extractStringNamed(eq(SelfServiceApiConstants.authenticationModeParamName), any())).thenReturn("email");
+        when(appUserReadPlatformService.isUsernameExist("jdoe")).thenReturn(true);
+        when(selfServiceAuthorizationTokenService.generateToken()).thenReturn("123456");
+        LocalDateTime expectedExpiry = LocalDateTime.of(2026, 4, 13, 12, 0, 30);
+        when(selfServiceAuthorizationTokenService.calculateExpiry(any())).thenReturn(expectedExpiry);
+
+        AppSelfServiceUser appUser = mock(AppSelfServiceUser.class);
+        when(appUser.getEmail()).thenReturn("test@test.com");
+        Client client = mock(Client.class);
+        when(client.getAccountNumber()).thenReturn("0001");
+        when(client.getFirstname()).thenReturn("John");
+        when(client.getMiddlename()).thenReturn(null);
+        when(client.getLastname()).thenReturn("Doe");
+        when(client.getMobileNo()).thenReturn("5551234567");
+        AppSelfServiceUserClientMapping mapping = mock(AppSelfServiceUserClientMapping.class);
+        when(mapping.getAppUser()).thenReturn(appUser);
+        when(mapping.getClient()).thenReturn(client);
+        when(appUserClientMappingRepository.fetchByAppuserUsername("jdoe")).thenReturn(mapping);
+
+        SelfServiceRegistration result = service.createForgotPasswordRequest("{}");
+
+        assertNotNull(result);
+        assertEquals(SelfServiceRequestType.PASSWORD_RESET, result.getRequestType());
+        assertEquals("123456", result.getExternalAuthorizationToken());
+        assertEquals(expectedExpiry, result.getExpiresAt());
+        verify(selfServiceRegistrationRepository).saveAndFlush(argThat(request -> expectedExpiry.equals(request.getExpiresAt())));
+    }
+
+    @Test
+    void createForgotPasswordRequest_returnsNoRequestWhenExternalIdDoesNotMatch() {
+        when(fromApiJsonHelper.extractStringNamed(eq(SelfServiceApiConstants.usernameParamName), any())).thenReturn("jdoe");
+        when(fromApiJsonHelper.extractStringNamed(eq(SelfServiceApiConstants.externalIdParamName), any())).thenReturn("wrong-id");
+        when(fromApiJsonHelper.extractStringNamed(eq(SelfServiceApiConstants.authenticationModeParamName), any())).thenReturn("email");
+        when(appUserReadPlatformService.isUsernameExist("jdoe")).thenReturn(true);
+
+        AppSelfServiceUser appUser = mock(AppSelfServiceUser.class);
+        Client client = mock(Client.class);
+        when(client.getExternalId()).thenReturn(new org.apache.fineract.infrastructure.core.domain.ExternalId("expected-id"));
+        AppSelfServiceUserClientMapping mapping = mock(AppSelfServiceUserClientMapping.class);
+        when(mapping.getAppUser()).thenReturn(appUser);
+        when(mapping.getClient()).thenReturn(client);
+        when(appUserClientMappingRepository.fetchByAppuserUsername("jdoe")).thenReturn(mapping);
+
+        assertNull(service.createForgotPasswordRequest("{}"));
+        verify(selfServiceRegistrationRepository, never()).saveAndFlush(any(SelfServiceRegistration.class));
+    }
+
+    @Test
+    void renewPassword_updatesEncodedPasswordFromExternalToken() {
+        when(fromApiJsonHelper.extractStringNamed(eq(SelfServiceApiConstants.passwordParamName), any())).thenReturn("Strong#Abc123");
+        when(fromApiJsonHelper.extractStringNamed(eq(SelfServiceApiConstants.repeatPasswordParamName), any())).thenReturn("Strong#Abc123");
+        when(fromApiJsonHelper.extractStringNamed(eq(SelfServiceApiConstants.externalAuthenticationTokenParamName), any())).thenReturn("external-token");
+        PasswordValidationPolicy policy = mock(PasswordValidationPolicy.class);
+        when(policy.getRegex()).thenReturn(".*");
+        when(policy.getDescription()).thenReturn("any");
+        when(passwordValidationPolicyRepository.findActivePasswordValidationPolicy()).thenReturn(policy);
+
+        SelfServiceRegistration request = mock(SelfServiceRegistration.class);
+        when(request.getUsername()).thenReturn("jdoe");
+        when(request.isConsumed()).thenReturn(false);
+        when(request.isExpired(any())).thenReturn(false);
+        when(selfServiceRegistrationRepository.getRequestByExternalAuthorizationToken("external-token", SelfServiceRequestType.PASSWORD_RESET))
+                .thenReturn(request);
+
+        AppSelfServiceUser appUser = mock(AppSelfServiceUser.class);
+        when(appUser.getId()).thenReturn(7L);
+        when(appSelfServiceUserRepository.findAppSelfServiceUserByName("jdoe")).thenReturn(appUser);
+        when(platformPasswordEncoder.encode(any())).thenReturn("encoded-password");
+
+        CommandProcessingResult result = service.renewPassword("{}");
+
+        assertNotNull(result);
+        assertEquals(7L, result.getResourceId());
+        verify(appUser).updatePassword("encoded-password");
+        verify(appUser).updatePasswordResetRequired(false);
+        verify(appSelfServiceUserRepository).saveAndFlush(appUser);
+        verify(request).markConsumed();
+        verify(selfServiceRegistrationRepository).saveAndFlush(request);
+    }
+}

--- a/src/test/java/org/apache/fineract/selfservice/registration/service/SelfServiceRegistrationWritePlatformServiceImplTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/registration/service/SelfServiceRegistrationWritePlatformServiceImplTest.java
@@ -7,6 +7,7 @@
 package org.apache.fineract.selfservice.registration.service;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
@@ -15,7 +16,10 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.time.LocalDate;
+import java.util.HashMap;
 import org.apache.fineract.infrastructure.campaigns.sms.service.SmsCampaignDropdownReadPlatformService;
+import org.apache.fineract.infrastructure.businessdate.domain.BusinessDateType;
 import org.apache.fineract.infrastructure.core.domain.FineractPlatformTenant;
 import org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil;
 import org.apache.fineract.infrastructure.core.exception.PlatformApiDataValidationException;
@@ -30,19 +34,23 @@ import org.apache.fineract.portfolio.client.exception.ClientNotFoundException;
 import org.apache.fineract.selfservice.registration.SelfServiceApiConstants;
 import org.apache.fineract.selfservice.registration.domain.SelfServiceRegistration;
 import org.apache.fineract.selfservice.registration.domain.SelfServiceRegistrationRepository;
+import org.apache.fineract.selfservice.registration.domain.SelfServiceRequestType;
 import org.apache.fineract.selfservice.registration.exception.SelfServiceRegistrationNotFoundException;
 import org.apache.fineract.selfservice.useradministration.domain.AppSelfServiceUser;
 import org.apache.fineract.selfservice.useradministration.domain.AppSelfServiceUserClientMappingRepository;
+import org.apache.fineract.selfservice.useradministration.domain.AppSelfServiceUserRepository;
 import org.apache.fineract.selfservice.useradministration.domain.SelfServiceUserDomainService;
 import org.apache.fineract.selfservice.useradministration.service.AppSelfServiceUserReadPlatformService;
 import org.apache.fineract.useradministration.domain.PasswordValidationPolicy;
 import org.apache.fineract.useradministration.domain.PasswordValidationPolicyRepository;
 import org.apache.fineract.useradministration.domain.Role;
 import org.apache.fineract.useradministration.domain.RoleRepository;
+import org.apache.fineract.infrastructure.security.service.PlatformPasswordEncoder;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.apache.fineract.useradministration.domain.AppUserRepository;
 import org.apache.fineract.portfolio.client.service.ClientWritePlatformService;
 import org.springframework.core.env.Environment;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -70,6 +78,9 @@ class SelfServiceRegistrationWritePlatformServiceImplTest {
     @Mock private AppUserRepository appUserRepository;
     @Mock private ClientWritePlatformService clientWritePlatformService;
     @Mock private Environment env;
+    @Mock private PlatformPasswordEncoder platformPasswordEncoder;
+    @Mock private AppSelfServiceUserRepository appSelfServiceUserRepository;
+    @Mock private SelfServiceAuthorizationTokenService selfServiceAuthorizationTokenService;
 
     private SelfServiceRegistrationWritePlatformServiceImpl service;
 
@@ -92,8 +103,22 @@ class SelfServiceRegistrationWritePlatformServiceImplTest {
             jdbcTemplate,
             appUserRepository,
             clientWritePlatformService,
-            env
+            env,
+            platformPasswordEncoder,
+            appSelfServiceUserRepository,
+            selfServiceAuthorizationTokenService
         );
+
+        LocalDate businessDate = LocalDate.of(2026, 1, 2);
+        HashMap<BusinessDateType, LocalDate> businessDates = new HashMap<>();
+        businessDates.put(BusinessDateType.BUSINESS_DATE, businessDate);
+        businessDates.put(BusinessDateType.COB_DATE, businessDate.minusDays(1));
+        ThreadLocalContextUtil.setBusinessDates(businessDates);
+    }
+
+    @AfterEach
+    void tearDown() {
+        ThreadLocalContextUtil.reset();
     }
 
     @Test
@@ -147,10 +172,14 @@ class SelfServiceRegistrationWritePlatformServiceImplTest {
         when(selfServiceRegistrationReadPlatformService.isClientExist(anyString(), anyString(), any(), anyString(), any(), anyBoolean())).thenReturn(true);
         Client client = mock(Client.class);
         when(clientRepository.getClientByAccountNumber("12345")).thenReturn(client);
+        when(selfServiceAuthorizationTokenService.generateToken()).thenReturn("123456");
+        when(selfServiceAuthorizationTokenService.calculateExpiry(any())).thenAnswer(invocation -> ((java.time.LocalDateTime) invocation.getArgument(0)).plusSeconds(30));
+        when(platformPasswordEncoder.encode(any())).thenReturn("encoded-password");
         
         SelfServiceRegistration result = service.createRegistrationRequest("{}");
         
         assertNotNull(result);
+        assertEquals("encoded-password", result.getPassword());
     }
 
     @Test
@@ -162,9 +191,10 @@ class SelfServiceRegistrationWritePlatformServiceImplTest {
     @Test
     void createSelfServiceUser_throwsNotFound() {
         when(fromApiJsonHelper.extractLongNamed(eq(SelfServiceApiConstants.requestIdParamName), any())).thenReturn(1L);
+        when(fromApiJsonHelper.extractStringNamed(eq(SelfServiceApiConstants.externalAuthenticationTokenParamName), any())).thenReturn(null);
         when(fromApiJsonHelper.extractStringNamed(eq(SelfServiceApiConstants.authenticationTokenParamName), any())).thenReturn("123456");
         
-        when(selfServiceRegistrationRepository.getRequestByIdAndAuthenticationToken(1L, "123456")).thenReturn(null);
+        when(selfServiceRegistrationRepository.getRequestByIdAndAuthenticationToken(1L, "123456", SelfServiceRequestType.REGISTRATION)).thenReturn(null);
         
         assertThrows(SelfServiceRegistrationNotFoundException.class, () -> service.createSelfServiceUser("{}"));
     }
@@ -172,6 +202,7 @@ class SelfServiceRegistrationWritePlatformServiceImplTest {
     @Test
     void createSelfServiceUser_returnsUserWithId() {
         when(fromApiJsonHelper.extractLongNamed(eq(SelfServiceApiConstants.requestIdParamName), any())).thenReturn(1L);
+        when(fromApiJsonHelper.extractStringNamed(eq(SelfServiceApiConstants.externalAuthenticationTokenParamName), any())).thenReturn(null);
         when(fromApiJsonHelper.extractStringNamed(eq(SelfServiceApiConstants.authenticationTokenParamName), any())).thenReturn("123456");
         
         SelfServiceRegistration registration = mock(SelfServiceRegistration.class);
@@ -185,7 +216,7 @@ class SelfServiceRegistrationWritePlatformServiceImplTest {
         Office office = mock(Office.class);
         when(client.getOffice()).thenReturn(office);
         
-        when(selfServiceRegistrationRepository.getRequestByIdAndAuthenticationToken(1L, "123456")).thenReturn(registration);
+        when(selfServiceRegistrationRepository.getRequestByIdAndAuthenticationToken(1L, "123456", SelfServiceRequestType.REGISTRATION)).thenReturn(registration);
         
         Role role = mock(Role.class);
         when(roleRepository.getRoleByName(SelfServiceApiConstants.SELF_SERVICE_USER_ROLE)).thenReturn(role);
@@ -199,5 +230,47 @@ class SelfServiceRegistrationWritePlatformServiceImplTest {
         } finally {
             ThreadLocalContextUtil.setTenant(null);
         }
+    }
+
+    @Test
+    void createSelfServiceUser_acceptsExternalAuthenticationToken() {
+        when(fromApiJsonHelper.extractStringNamed(eq(SelfServiceApiConstants.externalAuthenticationTokenParamName), any())).thenReturn("external-token");
+
+        SelfServiceRegistration registration = mock(SelfServiceRegistration.class);
+        when(registration.getUsername()).thenReturn("jdoe");
+        when(registration.getPassword()).thenReturn("encoded-pass");
+        when(registration.getEmail()).thenReturn("test@test.com");
+        Client client = mock(Client.class);
+        Office office = mock(Office.class);
+        when(client.getOffice()).thenReturn(office);
+        when(client.getFirstname()).thenReturn("John");
+        when(client.getLastname()).thenReturn("Doe");
+        when(registration.getClient()).thenReturn(client);
+        when(selfServiceRegistrationRepository.getRequestByExternalAuthorizationToken("external-token", SelfServiceRequestType.REGISTRATION))
+                .thenReturn(registration);
+
+        Role role = mock(Role.class);
+        when(roleRepository.getRoleByName(SelfServiceApiConstants.SELF_SERVICE_USER_ROLE)).thenReturn(role);
+
+        FineractPlatformTenant tenant = new FineractPlatformTenant(1L, "default", "Default", "UTC", null);
+        ThreadLocalContextUtil.setTenant(tenant);
+
+        try {
+            AppSelfServiceUser result = service.createSelfServiceUser("{}");
+            assertNotNull(result);
+        } finally {
+            ThreadLocalContextUtil.setTenant(null);
+        }
+    }
+
+    @Test
+    void createSelfServiceUser_throwsWhenConsumedOrExpired() {
+        when(fromApiJsonHelper.extractStringNamed(eq(SelfServiceApiConstants.externalAuthenticationTokenParamName), any())).thenReturn("external-token");
+        SelfServiceRegistration registration = mock(SelfServiceRegistration.class);
+        when(registration.isExpired(any())).thenReturn(true); // Treat as expired
+        when(selfServiceRegistrationRepository.getRequestByExternalAuthorizationToken("external-token", SelfServiceRequestType.REGISTRATION))
+                .thenReturn(registration);
+        
+        assertThrows(org.apache.fineract.infrastructure.core.exception.PlatformDataIntegrityException.class, () -> service.createSelfServiceUser("{}"));
     }
 }

--- a/src/test/java/org/apache/fineract/selfservice/runreport/SelfRunReportIntegrationTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/runreport/SelfRunReportIntegrationTest.java
@@ -103,6 +103,11 @@ public class SelfRunReportIntegrationTest extends SelfServiceIntegrationTestBase
         psSelfUser.execute();
       }
 
+      try (PreparedStatement psSetVal = conn.prepareStatement(
+          "SELECT setval(pg_get_serial_sequence('m_appselfservice_user', 'id'), (SELECT MAX(id) FROM m_appselfservice_user))")) {
+        psSetVal.execute();
+      }
+
       try (PreparedStatement psSelfUserRole = conn.prepareStatement("INSERT INTO m_appselfservice_user_role(appuser_id, role_id) VALUES (?, ?)")) {
         psSelfUserRole.setLong(1, appUserId);
         psSelfUserRole.setInt(2, roleId);

--- a/src/test/java/org/apache/fineract/selfservice/savings/api/SelfSavingsAccountApiResourceTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/savings/api/SelfSavingsAccountApiResourceTest.java
@@ -17,12 +17,16 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import jakarta.ws.rs.core.UriInfo;
+import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.util.HashMap;
+import java.util.List;
 import org.apache.fineract.portfolio.client.exception.ClientNotFoundException;
 import org.apache.fineract.portfolio.savings.api.SavingsAccountChargesApiResource;
 import org.apache.fineract.portfolio.savings.api.SavingsAccountTransactionsApiResource;
 import org.apache.fineract.portfolio.savings.api.SavingsAccountsApiResource;
 import org.apache.fineract.portfolio.savings.data.SavingsAccountData;
+import org.apache.fineract.portfolio.savings.data.SavingsAccountChargeData;
 import org.apache.fineract.portfolio.savings.exception.SavingsAccountNotFoundException;
 import org.apache.fineract.selfservice.client.service.AppSelfServiceUserClientMapperReadService;
 import org.apache.fineract.selfservice.savings.data.SelfSavingsAccountConstants;
@@ -54,6 +58,12 @@ class SelfSavingsAccountApiResourceTest {
     private static final Long USER_ID = 10L;
     private static final Long ACCOUNT_ID = 5L;
     private static final Long CLIENT_ID = 7L;
+
+    private static SavingsAccountData createDefaultSavingsAccountData() {
+        return SavingsAccountData.importInstanceIndividual(CLIENT_ID, ACCOUNT_ID, null, LocalDate.of(2026, 1, 1), BigDecimal.ONE, null, null,
+                null, null, null, null, null, false, null, null, java.util.List.<org.apache.fineract.portfolio.savings.data.SavingsAccountChargeData>of(),
+                false, null, null, null);
+    }
 
     @BeforeEach
     void setUp() {
@@ -99,7 +109,7 @@ class SelfSavingsAccountApiResourceTest {
     @Test
     void retrieveSavings_mappedAccount_returnsData() {
         mockSavingsMapped();
-        SavingsAccountData data = mock(SavingsAccountData.class);
+        SavingsAccountData data = createDefaultSavingsAccountData();
         when(savingsAccountsApiResource.retrieveOne(eq(ACCOUNT_ID), eq(false), eq("all"), eq(""), eq(uriInfo))).thenReturn(data);
 
         SavingsAccountData result = resource.retrieveSavings(ACCOUNT_ID, "all", uriInfo);

--- a/src/test/java/org/apache/fineract/selfservice/security/SelfServiceSecurityFilterChainIntegrationTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/security/SelfServiceSecurityFilterChainIntegrationTest.java
@@ -36,8 +36,9 @@ class SelfServiceSecurityFilterChainIntegrationTest {
     void registrationEndpoint_isPublicAndReturns200() throws Exception {
         // POST /v1/self/registration without any Auth header should not return 401
         ResultMatcher notUnauthorized = result -> {
-            if (result.getResponse().getStatus() == 401) {
-                throw new AssertionError("Expected status not to be 401");
+            int status = result.getResponse().getStatus();
+            if (status == 401 || status == 404) {
+                throw new AssertionError("Expected status not to be 401 or 404, but was " + status);
             }
         };
 
@@ -45,6 +46,26 @@ class SelfServiceSecurityFilterChainIntegrationTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"accountNumber\":\"ACC001\",\"tenantIdentifier\":\"default\"}"))
             .andExpect(notUnauthorized); // May be 404, 400, etc., but not blocked by filter chain
+    }
+
+    @Test
+    void forgotPasswordEndpoints_arePublicAndNotBlockedByAuthentication() throws Exception {
+        ResultMatcher notUnauthorized = result -> {
+            int status = result.getResponse().getStatus();
+            if (status == 401 || status == 403 || status == 404 || (status >= 500 && status < 600)) {
+                throw new AssertionError("Expected forgot-password endpoint to be reachable and not blocked by auth, but was " + status);
+            }
+        };
+
+        mockMvc.perform(post("/v1/self/password/request")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"username\":\"demo\",\"authenticationMode\":\"email\"}"))
+            .andExpect(notUnauthorized);
+
+        mockMvc.perform(post("/v1/self/password/renew")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"externalAuthenticationToken\":\"123456\",\"password\":\"Strong#Abc123\",\"repeatPassword\":\"Strong#Abc123\"}"))
+            .andExpect(notUnauthorized);
     }
 
     @Test

--- a/src/test/java/org/apache/fineract/selfservice/security/SelfServiceSecurityTestConfig.java
+++ b/src/test/java/org/apache/fineract/selfservice/security/SelfServiceSecurityTestConfig.java
@@ -18,6 +18,7 @@ import org.apache.fineract.infrastructure.core.domain.FineractRequestContextHold
 import org.apache.fineract.infrastructure.core.filters.IdempotencyStoreHelper;
 import org.apache.fineract.infrastructure.core.serialization.ToApiJsonSerializer;
 import org.apache.fineract.infrastructure.core.service.MDCWrapper;
+import org.apache.fineract.infrastructure.jobs.filter.ProgressiveLoanModelCheckerHelper;
 import org.apache.fineract.infrastructure.jobs.filter.ProgressiveLoanModelCheckerFilter;
 import org.apache.fineract.infrastructure.security.data.PlatformRequestLog;
 import org.apache.fineract.infrastructure.security.domain.PlatformUserRepository;
@@ -29,6 +30,8 @@ import org.apache.fineract.selfservice.security.domain.PlatformSelfServiceUserRe
 import org.apache.fineract.selfservice.useradministration.service.SelfServiceRoleReadPlatformService;
 import org.apache.fineract.selfservice.security.service.TenantAwareJpaPlatformSelfServiceUserDetailsService;
 import org.apache.fineract.selfservice.security.starter.SelfServiceSecurityConfiguration;
+import org.apache.fineract.portfolio.loanaccount.domain.LoanRepository;
+import org.apache.fineract.portfolio.loanaccount.service.ProgressiveLoanModelProcessingService;
 import org.springframework.boot.autoconfigure.web.ServerProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -102,7 +105,7 @@ public class SelfServiceSecurityTestConfig {
 
     @Bean
     public FineractRequestContextHolder fineractRequestContextHolder() {
-        return mock(FineractRequestContextHolder.class);
+        return new FineractRequestContextHolder();
     }
 
     @Bean
@@ -116,8 +119,26 @@ public class SelfServiceSecurityTestConfig {
     }
 
     @Bean
-    public ProgressiveLoanModelCheckerFilter progressiveLoanModelCheckerFilter() {
-        return mock(ProgressiveLoanModelCheckerFilter.class);
+    public ProgressiveLoanModelCheckerFilter progressiveLoanModelCheckerFilter(LoanRepository loanRepository,
+            ProgressiveLoanModelProcessingService progressiveLoanModelProcessingService,
+            ProgressiveLoanModelCheckerHelper progressiveLoanModelCheckerHelper) {
+        return new ProgressiveLoanModelCheckerFilter(loanRepository, progressiveLoanModelProcessingService,
+                progressiveLoanModelCheckerHelper);
+    }
+
+    @Bean
+    public LoanRepository loanRepository() {
+        return mock(LoanRepository.class);
+    }
+
+    @Bean
+    public ProgressiveLoanModelProcessingService progressiveLoanModelProcessingService() {
+        return mock(ProgressiveLoanModelProcessingService.class);
+    }
+
+    @Bean
+    public ProgressiveLoanModelCheckerHelper progressiveLoanModelCheckerHelper() {
+        return mock(ProgressiveLoanModelCheckerHelper.class);
     }
 
     @Bean

--- a/src/test/java/org/apache/fineract/selfservice/security/api/SelfForgotPasswordApiResourceIntegrationTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/security/api/SelfForgotPasswordApiResourceIntegrationTest.java
@@ -1,0 +1,144 @@
+package org.apache.fineract.selfservice.security.api;
+
+import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import io.restassured.response.Response;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicLong;
+import org.apache.fineract.selfservice.testing.support.SelfServiceIntegrationTestBase;
+import org.apache.fineract.selfservice.testing.support.SelfServiceTestUtils;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class SelfForgotPasswordApiResourceIntegrationTest extends SelfServiceIntegrationTestBase {
+
+    private static final AtomicLong UNIQUE_ID_SEQUENCE = new AtomicLong(System.nanoTime());
+
+    private static String numericId() {
+        return String.format("%08d", Math.floorMod(UNIQUE_ID_SEQUENCE.incrementAndGet(), 100000000));
+    }
+
+    private String enrollUser(String username, String password, String email, String mobileNumber) {
+        String payload = """
+            {
+              "username": "%s",
+              "password": "%s",
+              "firstName": "Reset",
+              "lastName": "Target",
+              "mobileNumber": "%s",
+              "email": "%s",
+              "authenticationMode": "email",
+              "active": true
+            }
+            """.formatted(username, password, mobileNumber, email);
+
+        Response response = given(SelfServiceTestUtils.requestSpec(getFineractPort()))
+                .body(payload)
+                .when()
+                .post("/fineract-provider/api/v1/self/registration/client-user")
+                .then()
+                .extract().response();
+
+        assertEquals(200, response.getStatusCode(), "Enrollment must succeed before password reset testing");
+        return response.body().asString();
+    }
+
+    private String querySingleValue(String sql, String parameter) {
+        Properties properties = new Properties();
+        properties.setProperty("user", postgres.getUsername());
+        properties.setProperty("password", postgres.getPassword());
+        try (Connection connection = DriverManager.getConnection(postgres.getJdbcUrl(), properties);
+                PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setString(1, parameter);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                if (!resultSet.next()) {
+                    return "";
+                }
+                String value = resultSet.getString(1);
+                return value != null ? value.trim() : "";
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to query test database", e);
+        }
+    }
+
+    @Test
+    @DisplayName("Forgot password request and renew resets the self-service password")
+    void requestAndRenewPassword_endToEnd() {
+        String suffix = numericId();
+        String username = "reset_user_" + suffix;
+        String oldPassword = "Strong#Abc123";
+        String newPassword = "Stronger#Def456";
+        String email = "reset" + suffix + "@fineract.test";
+        String mobile = "555" + suffix;
+
+        enrollUser(username, oldPassword, email, mobile);
+
+        Response requestResponse = given(SelfServiceTestUtils.requestSpec(getFineractPort()))
+                .body("""
+                    {
+                      "username": "%s",
+                      "authenticationMode": "email"
+                    }
+                    """.formatted(username))
+                .when()
+                .post(SelfServiceTestUtils.SELF_PASSWORD_REQUEST_PATH)
+                .then()
+                .extract().response();
+
+        int requestStatus = requestResponse.getStatusCode();
+        assertEquals(200, requestStatus, "Forgot-password request must succeed. Body: " + requestResponse.body().asString());
+
+        String externalToken = querySingleValue(
+                "select external_authorization_token from request_audit_table "
+                        + "where username = ? and request_type = 'PASSWORD_RESET' order by id desc limit 1",
+                username);
+        assertNotNull(externalToken);
+        assertFalse(externalToken.isBlank());
+
+        Response renewResponse = given(SelfServiceTestUtils.requestSpec(getFineractPort()))
+                .body("""
+                    {
+                      "externalAuthenticationToken": "%s",
+                      "password": "%s",
+                      "repeatPassword": "%s"
+                    }
+                    """.formatted(externalToken, newPassword, newPassword))
+                .when()
+                .post(SelfServiceTestUtils.SELF_PASSWORD_RENEW_PATH)
+                .then()
+                .extract().response();
+
+        assertEquals(200, renewResponse.getStatusCode(), "Renew must succeed");
+
+        Response oldAuth = SelfServiceTestUtils.authenticate(getFineractPort(), username, oldPassword);
+        assertEquals(401, oldAuth.getStatusCode(), "Old password must no longer authenticate");
+
+        Response newAuth = SelfServiceTestUtils.authenticate(getFineractPort(), username, newPassword);
+        assertEquals(200, newAuth.getStatusCode(), "New password must authenticate");
+
+        Response reuseResponse = given(SelfServiceTestUtils.requestSpec(getFineractPort()))
+                .body("""
+                    {
+                      "externalAuthenticationToken": "%s",
+                      "password": "%s",
+                      "repeatPassword": "%s"
+                    }
+                    """.formatted(externalToken, newPassword, newPassword))
+                .when()
+                .post(SelfServiceTestUtils.SELF_PASSWORD_RENEW_PATH)
+                .then()
+                .extract().response();
+
+        assertEquals(403, reuseResponse.getStatusCode(),
+                "Consumed password-reset token must be rejected. Body: " + reuseResponse.body().asString());
+    }
+}

--- a/src/test/java/org/apache/fineract/selfservice/security/api/SelfServicePermissionEnforcementIntegrationTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/security/api/SelfServicePermissionEnforcementIntegrationTest.java
@@ -7,10 +7,12 @@
 package org.apache.fineract.selfservice.security.api;
 
 import static io.restassured.RestAssured.given;
+
 import io.restassured.response.Response;
-import java.util.UUID;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Properties;
+import java.util.UUID;
 import org.apache.fineract.selfservice.testing.support.SelfServiceIntegrationTestBase;
 import org.apache.fineract.selfservice.testing.support.SelfServiceTestUtils;
 import org.junit.jupiter.api.DisplayName;
@@ -87,40 +89,82 @@ public class SelfServicePermissionEnforcementIntegrationTest extends SelfService
     // So actually, let's mock or use the AppUser route... wait, if the transaction rolls back, we can't extract the token!
     // BUT we CAN just INSERT the AppSelfServiceUser directly using JDBC!
 
-    java.util.Properties props = new java.util.Properties();
+    Properties props = new Properties();
     props.setProperty("user", "postgres");
     props.setProperty("password", "postgres");
 
     String jdbcUrl = postgres.getJdbcUrl();
 
     try (java.sql.Connection conn = java.sql.DriverManager.getConnection(jdbcUrl, props)) {
-        // Find the generated hashed password from 'mifos' to copy it
-        try (java.sql.Statement st = conn.createStatement()) {
-            // Insert into m_appuser
-            String insertUser = "INSERT INTO m_appuser(office_id, username, password, email, firstname, lastname, is_deleted, nonexpired, nonlocked, nonexpired_credentials, enabled, firsttime_login_remaining) " +
-                                "VALUES (1, 'tomas', (SELECT password FROM m_appuser WHERE username='mifos' LIMIT 1), 'tomas@fineract.org', 'Tomas', 'Test', false, true, true, true, true, false) RETURNING id";
-            
-            java.sql.ResultSet rs = st.executeQuery(insertUser);
-            rs.next();
-            long newUserId = rs.getLong(1);
-            
-            // Map AppUser to Role
-            st.execute("INSERT INTO m_appuser_role(appuser_id, role_id) VALUES (" + newUserId + ", " + roleId + ")");
-            
-            // Insert into plugin m_appselfservice_user
-            st.execute("INSERT INTO m_appselfservice_user(id, office_id, username, password, email, firstname, lastname, nonexpired, nonlocked, nonexpired_credentials, enabled, firsttime_login_remaining) " +
-                       "SELECT id, office_id, username, password, email, firstname, lastname, nonexpired, nonlocked, nonexpired_credentials, enabled, firsttime_login_remaining FROM m_appuser WHERE id = " + newUserId);
-            
-            // Map SelfService User to Role
-            st.execute("INSERT INTO m_appselfservice_user_role(appuser_id, role_id) VALUES (" + newUserId + ", " + roleId + ")");
-            
-            // Map SelfService User to Client
-            st.execute("INSERT INTO m_selfservice_user_client_mapping(appuser_id, client_id) VALUES (" + newUserId + ", " + clientId + ")");
+        conn.setAutoCommit(false);
+        try {
+            long userId;
+            try (java.sql.PreparedStatement ps = conn.prepareStatement(
+                    "SELECT setval(pg_get_serial_sequence('m_appuser', 'id'), "
+                            + "GREATEST(COALESCE((SELECT MAX(id) FROM m_appuser), 0), COALESCE((SELECT MAX(id) FROM m_appselfservice_user), 0)))")) {
+                ps.execute();
+            }
+
+            try (java.sql.PreparedStatement ps = conn.prepareStatement(
+                    "INSERT INTO m_appuser(office_id, username, password, email, firstname, lastname, is_deleted, nonexpired, nonlocked, nonexpired_credentials, enabled, firsttime_login_remaining) "
+                            + "VALUES (1, ?, (SELECT password FROM m_appuser WHERE username='mifos' LIMIT 1), ?, 'Tomas', 'Test', false, true, true, true, true, false) RETURNING id")) {
+                ps.setString(1, username);
+                ps.setString(2, username + "@fineract.org");
+                try (java.sql.ResultSet rs = ps.executeQuery()) {
+                    rs.next();
+                    userId = rs.getLong(1);
+                }
+            }
+
+            try (java.sql.PreparedStatement ps = conn.prepareStatement(
+                    "INSERT INTO m_appuser_role(appuser_id, role_id) VALUES (?, ?)")) {
+                ps.setLong(1, userId);
+                ps.setInt(2, roleId);
+                ps.executeUpdate();
+            }
+
+            try (java.sql.PreparedStatement ps = conn.prepareStatement(
+                    "INSERT INTO m_appselfservice_user(id, office_id, username, password, email, firstname, lastname, nonexpired, nonlocked, nonexpired_credentials, enabled, firsttime_login_remaining, password_never_expires, is_self_service_user, password_reset_required) "
+                            + "SELECT id, office_id, username, password, email, firstname, lastname, nonexpired, nonlocked, nonexpired_credentials, enabled, firsttime_login_remaining, true, true, false FROM m_appuser WHERE id = ?")) {
+                ps.setLong(1, userId);
+                ps.executeUpdate();
+            }
+
+            try (java.sql.PreparedStatement ps = conn.prepareStatement(
+                    "SELECT setval(pg_get_serial_sequence('m_appuser', 'id'), (SELECT MAX(id) FROM m_appuser))")) {
+                ps.execute();
+            }
+
+            try (java.sql.PreparedStatement ps = conn.prepareStatement(
+                    "SELECT setval(pg_get_serial_sequence('m_appselfservice_user', 'id'), (SELECT MAX(id) FROM m_appselfservice_user))")) {
+                ps.execute();
+            }
+
+            try (java.sql.PreparedStatement ps = conn.prepareStatement(
+                    "INSERT INTO m_appselfservice_user_role(appuser_id, role_id) VALUES (?, ?)")) {
+                ps.setLong(1, userId);
+                ps.setInt(2, roleId);
+                ps.executeUpdate();
+            }
+
+            try (java.sql.PreparedStatement ps = conn.prepareStatement(
+                    "INSERT INTO m_selfservice_user_client_mapping(appuser_id, client_id) VALUES (?, ?)")) {
+                ps.setLong(1, userId);
+                ps.setInt(2, clientId);
+                ps.executeUpdate();
+            }
+
+            conn.commit();
+        } catch (Exception e) {
+            conn.rollback();
+            throw e;
+        } finally {
+            conn.setAutoCommit(true);
         }
     }
 
     // 4. Test the API without the permission: Expect 403
-    given(SelfServiceTestUtils.requestSpecWithAuth(getFineractPort(), "tomas", "password"))
+    given(SelfServiceTestUtils.requestSpecWithAuth(getFineractPort(), username, "password"))
         .when()
         .get(SelfServiceTestUtils.CONTEXT_PATH + "/api/v1/self/savingsproducts")
         .then()
@@ -139,7 +183,7 @@ public class SelfServicePermissionEnforcementIntegrationTest extends SelfService
         .then()
         .statusCode(200);
 
-    given(SelfServiceTestUtils.requestSpecWithAuth(getFineractPort(), "tomas", "password"))
+    given(SelfServiceTestUtils.requestSpecWithAuth(getFineractPort(), username, "password"))
         .when()
         .get(SelfServiceTestUtils.CONTEXT_PATH + "/api/v1/self/savingsproducts")
         .then()
@@ -157,7 +201,7 @@ public class SelfServicePermissionEnforcementIntegrationTest extends SelfService
         .statusCode(200);
 
     // 6. Test the API with the permission: Expect 200
-    given(SelfServiceTestUtils.requestSpecWithAuth(getFineractPort(), "tomas", "password"))
+    given(SelfServiceTestUtils.requestSpecWithAuth(getFineractPort(), username, "password"))
         .when()
         .get(SelfServiceTestUtils.CONTEXT_PATH + "/api/v1/self/savingsproducts")
         .then()
@@ -174,7 +218,7 @@ public class SelfServicePermissionEnforcementIntegrationTest extends SelfService
         .statusCode(200);
 
     // 8. Test the API without the permission: Expect 403 immediately
-    given(SelfServiceTestUtils.requestSpecWithAuth(getFineractPort(), "tomas", "password"))
+    given(SelfServiceTestUtils.requestSpecWithAuth(getFineractPort(), username, "password"))
         .when()
         .get(SelfServiceTestUtils.CONTEXT_PATH + "/api/v1/self/savingsproducts")
         .then()

--- a/src/test/java/org/apache/fineract/selfservice/testing/support/SelfServiceTestUtils.java
+++ b/src/test/java/org/apache/fineract/selfservice/testing/support/SelfServiceTestUtils.java
@@ -29,6 +29,8 @@ public final class SelfServiceTestUtils {
   /** API path constants used across integration test classes. */
   public static final String SELF_AUTH_PATH = CONTEXT_PATH + "/api/v1/self/authentication";
   public static final String SELF_REGISTRATION_PATH = CONTEXT_PATH + "/api/v1/self/registration";
+  public static final String SELF_PASSWORD_REQUEST_PATH = CONTEXT_PATH + "/api/v1/self/password/request";
+  public static final String SELF_PASSWORD_RENEW_PATH = CONTEXT_PATH + "/api/v1/self/password/renew";
   public static final String SELF_CLIENTS_PATH = CONTEXT_PATH + "/api/v1/self/clients";
   public static final String SELF_SAVINGS_PATH = CONTEXT_PATH + "/api/v1/self/savingsaccounts";
   public static final String SELF_LOANS_PATH = CONTEXT_PATH + "/api/v1/self/loans";

--- a/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-subclass


### PR DESCRIPTION
## Summary

  This PR secures self-service registration and password reset by introducing configurable
  external authorization tokens, expiry, request typing, and one-time-use validation.

  It also implements forgot-password, renew, validates optional `externalId`, stores staged
  passwords encoded instead of cleartext, and adds/updates unit and integration coverage across
  the affected self-service flows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now request password resets using email or SMS authentication
  * Password renewal functionality available with secure, time-limited authorization tokens
  * Enhanced security with automatic token expiration and single-use enforcement to prevent token reuse

<!-- end of auto-generated comment: release notes by coderabbit.ai -->