### PR TITLE
MX-239: add confirmation flow for client-user endpoint

### DIFF
--- a/src/main/java/org/apache/fineract/selfservice/registration/api/SelfServiceConfirmationRequest.java
+++ b/src/main/java/org/apache/fineract/selfservice/registration/api/SelfServiceConfirmationRequest.java
@@ -1,0 +1,41 @@
+package org.apache.fineract.selfservice.registration.api;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Swagger schema representing the JSON payload for self-service enrollment confirmation.
+ */
+public class SelfServiceConfirmationRequest {
+    @Schema(description = "The token sent to the user via email or SMS.", example = "12345678-1234-5678-1234-567812345678")
+    private String externalAuthenticationToken;
+
+    @Schema(description = "Legacy request identifier (used only if externalAuthenticationToken is not provided).", example = "123")
+    private Long requestId;
+
+    @Schema(description = "Legacy authentication token (used only if externalAuthenticationToken is not provided).", example = "a1b2c3d4")
+    private String authenticationToken;
+
+    public String getExternalAuthenticationToken() {
+        return externalAuthenticationToken;
+    }
+
+    public void setExternalAuthenticationToken(String externalAuthenticationToken) {
+        this.externalAuthenticationToken = externalAuthenticationToken;
+    }
+
+    public Long getRequestId() {
+        return requestId;
+    }
+
+    public void setRequestId(Long requestId) {
+        this.requestId = requestId;
+    }
+
+    public String getAuthenticationToken() {
+        return authenticationToken;
+    }
+
+    public void setAuthenticationToken(String authenticationToken) {
+        this.authenticationToken = authenticationToken;
+    }
+}

--- a/src/main/java/org/apache/fineract/selfservice/registration/api/SelfServiceRegistrationApiResource.java
+++ b/src/main/java/org/apache/fineract/selfservice/registration/api/SelfServiceRegistrationApiResource.java
@@ -76,16 +76,17 @@ public class SelfServiceRegistrationApiResource {
     }
 
     /**
-     * Creates a client and linked self-service user in a single request.
+     * Creates a client and linked disabled self-service user, then sends an enrollment confirmation token.
+     * The user must confirm the token via {@code POST /self/registration/client-user/confirm} to activate.
      *
      * @param apiRequestBodyAsJson request payload as raw JSON
-     * @return serialized command result containing the created user identifier
+     * @return success message indicating the enrollment request was created
      */
     @POST
     @Path("client-user")
     @Consumes({MediaType.APPLICATION_JSON})
     @Produces({MediaType.APPLICATION_JSON})
-    @Operation(summary = "Self Enrollment Flow", description = "Creates a Fineract Client and Self Service User in one shot.")
+    @Operation(summary = "Self Enrollment Flow", description = "Creates a Fineract Client and a disabled Self Service User. Returns a success message (token is sent via email/SMS).")
     @RequestBody(required = true, content = @Content(schema = @Schema(implementation = SelfServiceEnrollmentRequest.class)))
     @ApiResponses({
         @ApiResponse(responseCode = "200", description = "OK"),
@@ -93,7 +94,29 @@ public class SelfServiceRegistrationApiResource {
         @ApiResponse(responseCode = "409", description = "Conflict (Duplicate Username, Email, etc)")
     })
     public String selfEnroll(final String apiRequestBodyAsJson) {
-        AppSelfServiceUser user = this.selfServiceRegistrationWritePlatformService.selfEnroll(apiRequestBodyAsJson);
+        this.selfServiceRegistrationWritePlatformService.selfEnroll(apiRequestBodyAsJson);
+        return SelfServiceApiConstants.createRequestSuccessMessage;
+    }
+
+    /**
+     * Confirms a self-enrollment token and activates the disabled user.
+     *
+     * @param apiRequestBodyAsJson request payload containing the enrollment confirmation token
+     * @return serialized command result containing the activated user identifier
+     */
+    @POST
+    @Path("client-user/confirm")
+    @Consumes({MediaType.APPLICATION_JSON})
+    @Produces({MediaType.APPLICATION_JSON})
+    @Operation(summary = "Confirm Self Enrollment", description = "Validates the enrollment token and activates the self-service user.")
+    @RequestBody(required = true, content = @Content(schema = @Schema(implementation = SelfServiceConfirmationRequest.class)))
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "OK"),
+        @ApiResponse(responseCode = "403", description = "Token expired or already consumed"),
+        @ApiResponse(responseCode = "404", description = "Token not found")
+    })
+    public String confirmEnrollment(final String apiRequestBodyAsJson) {
+        AppSelfServiceUser user = this.selfServiceRegistrationWritePlatformService.confirmEnrollment(apiRequestBodyAsJson);
         return this.toApiJsonSerializer.serialize(CommandProcessingResult.resourceResult(user.getId()));
     }
 }

--- a/src/main/java/org/apache/fineract/selfservice/registration/domain/SelfServiceRequestType.java
+++ b/src/main/java/org/apache/fineract/selfservice/registration/domain/SelfServiceRequestType.java
@@ -15,6 +15,13 @@ public enum SelfServiceRequestType {
     REGISTRATION,
 
     /**
+     * Request created for self-enrollment confirmation.
+     *
+     * <p>Use this for tokens that activate a disabled user created during one-shot self-enrollment.
+     */
+    ENROLLMENT,
+
+    /**
      * Request created for self-service password reset.
      *
      * <p>Use this for tokens that authorize renewal of an existing self-service password.

--- a/src/main/java/org/apache/fineract/selfservice/registration/service/SelfServiceRegistrationWritePlatformService.java
+++ b/src/main/java/org/apache/fineract/selfservice/registration/service/SelfServiceRegistrationWritePlatformService.java
@@ -45,10 +45,20 @@ public interface SelfServiceRegistrationWritePlatformService {
     AppSelfServiceUser createSelfServiceUserOrEnroll(String apiRequestBodyAsJson);
 
     /**
-     * Executes atomic one-shot self-enrollment by provisioning a Client and User.
-     * 
+     * Creates a Client and a disabled self-service User, stores an enrollment confirmation token,
+     * and sends the token via email or SMS. The user must be activated via {@link #confirmEnrollment}.
+     *
      * @param apiRequestBodyAsJson The incoming request containing enrollment data matching {@code SelfServiceEnrollmentRequest}.
-     * @return The freshly created AppSelfServiceUser object.
+     * @return The registration record containing the enrollment token.
      */
-    AppSelfServiceUser selfEnroll(String apiRequestBodyAsJson);
+    SelfServiceRegistration selfEnroll(String apiRequestBodyAsJson);
+
+    /**
+     * Confirms a self-enrollment token, enabling the disabled user created by {@link #selfEnroll}.
+     *
+     * @param apiRequestBodyAsJson JSON containing the token fields ({@code externalAuthenticationToken}
+     *     or legacy {@code requestId}/{@code authenticationToken})
+     * @return The activated self-service user.
+     */
+    AppSelfServiceUser confirmEnrollment(String apiRequestBodyAsJson);
 }

--- a/src/main/java/org/apache/fineract/selfservice/registration/service/SelfServiceRegistrationWritePlatformServiceImpl.java
+++ b/src/main/java/org/apache/fineract/selfservice/registration/service/SelfServiceRegistrationWritePlatformServiceImpl.java
@@ -83,6 +83,7 @@ import org.apache.fineract.useradministration.exception.RoleNotFoundException;
 import org.springframework.core.env.Environment;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.orm.jpa.JpaSystemException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -317,12 +318,7 @@ public class SelfServiceRegistrationWritePlatformServiceImpl implements SelfServ
     @Transactional(rollbackFor = Exception.class)
     @Override
     public AppSelfServiceUser createSelfServiceUserOrEnroll(String apiRequestBodyAsJson) {
-        JsonObject json = JsonParser.parseString(apiRequestBodyAsJson).getAsJsonObject();
-        if (json.has(SelfServiceApiConstants.requestIdParamName) || json.has(SelfServiceApiConstants.authenticationTokenParamName)
-                || json.has(SelfServiceApiConstants.externalAuthenticationTokenParamName)) {
-            return createSelfServiceUser(apiRequestBodyAsJson);
-        }
-        return selfEnroll(apiRequestBodyAsJson);
+        return createSelfServiceUser(apiRequestBodyAsJson);
     }
 
     private void handleDataIntegrityIssues(final JsonCommand command, final Throwable realCause, final Exception dve, String username) {
@@ -344,7 +340,7 @@ public class SelfServiceRegistrationWritePlatformServiceImpl implements SelfServ
      */
     @Transactional(rollbackFor = Exception.class)
     @Override
-    public AppSelfServiceUser selfEnroll(String apiRequestBodyAsJson) {
+    public SelfServiceRegistration selfEnroll(String apiRequestBodyAsJson) {
         Gson gson = new Gson();
         final Type typeOfMap = new TypeToken<Map<String, Object>>() {}.getType();
         final List<ApiParameterError> dataValidationErrors = new ArrayList<>();
@@ -425,7 +421,8 @@ public class SelfServiceRegistrationWritePlatformServiceImpl implements SelfServ
             Collection<SimpleGrantedAuthority> authorities = new ArrayList<>();
             authorities.add(new SimpleGrantedAuthority("DUMMY_ROLE_NOT_USED_OR_PERSISTED_TO_AVOID_EXCEPTION"));
 
-            User springConfigUser = new User(username, password, authorities);
+            // Create user as DISABLED — will be enabled on enrollment confirmation
+            User springConfigUser = new User(username, password, false, true, true, true, authorities);
             AppSelfServiceUser appUser = new AppSelfServiceUser(
                 client.getOffice(), springConfigUser, Collections.singleton(ssRole),
                 email, client.getFirstname(), client.getLastname(), null,
@@ -435,8 +432,24 @@ public class SelfServiceRegistrationWritePlatformServiceImpl implements SelfServ
             userDomainService.create(appUser, false);
             appUserClientMappingRepository.saveClientUserMapping(appUser.getId(), client.getId());
 
-            log.info("Self-enrollment successful: clientId={}", newClientId);
-            return appUser;
+            // Create enrollment confirmation token
+            String authenticationToken = selfServiceAuthorizationTokenService.generateToken();
+            LocalDateTime createdAt = DateUtils.getLocalDateTimeOfSystem();
+            SelfServiceRegistration registration = SelfServiceRegistration.instance(
+                    client, client.getAccountNumber(), client.getFirstname(), client.getMiddlename(),
+                    client.getLastname(), mobileNumber, email, authenticationToken, authenticationToken,
+                    username, encodePassword(password), SelfServiceRequestType.ENROLLMENT,
+                    selfServiceAuthorizationTokenService.calculateExpiry(createdAt));
+            this.selfServiceRegistrationRepository.saveAndFlush(registration);
+            try {
+                sendAuthorizationToken(registration, isEmailAuthenticationMode);
+            } catch (RuntimeException e) {
+                log.error("Failed to deliver enrollment confirmation token for clientId={}, userId={}", newClientId, appUser.getId(), e);
+                // Swallowed intentionally: the enrollment record is persisted for retry/audit.
+            }
+
+            log.info("Self-enrollment created (pending confirmation): clientId={}, userId={}", newClientId, appUser.getId());
+            return registration;
 
         } catch (PlatformDataIntegrityException pde) {
             throw translateEnrollmentConflict(pde);
@@ -445,6 +458,74 @@ public class SelfServiceRegistrationWritePlatformServiceImpl implements SelfServ
         } catch (PersistenceException dve) {
             throw translateEnrollmentFailure(dve);
         }
+    }
+
+    @Transactional(rollbackFor = Exception.class)
+    @Override
+    public AppSelfServiceUser confirmEnrollment(String apiRequestBodyAsJson) {
+        Gson gson = new Gson();
+        final Type typeOfMap = new TypeToken<Map<String, Object>>() {}.getType();
+        final List<ApiParameterError> dataValidationErrors = new ArrayList<>();
+        final DataValidatorBuilder baseDataValidator = new DataValidatorBuilder(dataValidationErrors).resource("user");
+        this.fromApiJsonHelper.checkForUnsupportedParameters(typeOfMap, apiRequestBodyAsJson,
+                SelfServiceApiConstants.CREATE_USER_REQUEST_DATA_PARAMETERS);
+        JsonElement element = gson.fromJson(apiRequestBodyAsJson, JsonElement.class);
+
+        SelfServiceRegistration request = resolveEnrollmentRequest(element, baseDataValidator, dataValidationErrors);
+        if (!dataValidationErrors.isEmpty()) {
+            throw new PlatformApiDataValidationException(dataValidationErrors);
+        }
+
+        AppSelfServiceUser appUser = this.appSelfServiceUserRepository.findAppSelfServiceUserByName(request.getUsername());
+        if (appUser == null) {
+            throw new PlatformDataIntegrityException("error.msg.user.notfound.username",
+                    "User with username " + request.getUsername() + " not found.",
+                    SelfServiceApiConstants.usernameParamName, request.getUsername());
+        }
+
+        appUser.enable();
+        this.appSelfServiceUserRepository.saveAndFlush(appUser);
+        request.markConsumed();
+        try {
+            this.selfServiceRegistrationRepository.saveAndFlush(request);
+        } catch (OptimisticLockingFailureException e) {
+            throw new PlatformDataIntegrityException("error.msg.self.service.request.token.invalid",
+                    "The supplied self-service token is expired or already used.",
+                    SelfServiceApiConstants.externalAuthenticationTokenParamName);
+        }
+
+        log.info("Self-enrollment confirmed: userId={}", appUser.getId());
+        return appUser;
+    }
+
+    private SelfServiceRegistration resolveEnrollmentRequest(JsonElement element, DataValidatorBuilder baseDataValidator,
+            List<ApiParameterError> dataValidationErrors) {
+        String externalToken = this.fromApiJsonHelper.extractStringNamed(SelfServiceApiConstants.externalAuthenticationTokenParamName, element);
+        if (externalToken != null) {
+            baseDataValidator.reset().parameter(SelfServiceApiConstants.externalAuthenticationTokenParamName).value(externalToken).notBlank()
+                    .notExceedingLengthOf(100);
+            if (!dataValidationErrors.isEmpty()) {
+                return null;
+            }
+            SelfServiceRegistration request = this.selfServiceRegistrationRepository.getRequestByExternalAuthorizationToken(externalToken,
+                    SelfServiceRequestType.ENROLLMENT);
+            validateRequestState(request, externalToken);
+            return request;
+        }
+
+        Long id = this.fromApiJsonHelper.extractLongNamed(SelfServiceApiConstants.requestIdParamName, element);
+        baseDataValidator.reset().parameter(SelfServiceApiConstants.requestIdParamName).value(id).notNull().integerGreaterThanZero();
+        String authenticationToken = this.fromApiJsonHelper.extractStringNamed(SelfServiceApiConstants.authenticationTokenParamName, element);
+        baseDataValidator.reset().parameter(SelfServiceApiConstants.authenticationTokenParamName).value(authenticationToken).notBlank()
+                .notNull().notExceedingLengthOf(100);
+        if (!dataValidationErrors.isEmpty()) {
+            return null;
+        }
+
+        SelfServiceRegistration request = this.selfServiceRegistrationRepository.getRequestByIdAndAuthenticationToken(id, authenticationToken,
+                SelfServiceRequestType.ENROLLMENT);
+        validateRequestState(request, id, authenticationToken);
+        return request;
     }
 
     private AppUser resolveEnrollmentAuditUser(String auditUsername) {

--- a/src/main/java/org/apache/fineract/selfservice/security/starter/SelfServiceSecurityConfiguration.java
+++ b/src/main/java/org/apache/fineract/selfservice/security/starter/SelfServiceSecurityConfiguration.java
@@ -122,9 +122,11 @@ public class SelfServiceSecurityConfiguration {
                 .requestMatchers(HttpMethod.POST, "/api/v1/self/registration").permitAll()
                 .requestMatchers(HttpMethod.POST, "/api/v1/self/registration/user").permitAll()
                 .requestMatchers(HttpMethod.POST, "/api/v1/self/registration/client-user").permitAll()
+                .requestMatchers(HttpMethod.POST, "/api/v1/self/registration/client-user/confirm").permitAll()
                 .requestMatchers(HttpMethod.POST, "/v1/self/registration").permitAll()
                 .requestMatchers(HttpMethod.POST, "/v1/self/registration/user").permitAll()
                 .requestMatchers(HttpMethod.POST, "/v1/self/registration/client-user").permitAll()
+                .requestMatchers(HttpMethod.POST, "/v1/self/registration/client-user/confirm").permitAll()
 
                 // Self authentication (login)
                 .requestMatchers(HttpMethod.POST, "/api/v1/self/authentication").permitAll()

--- a/src/main/java/org/apache/fineract/selfservice/useradministration/domain/AppSelfServiceUser.java
+++ b/src/main/java/org/apache/fineract/selfservice/useradministration/domain/AppSelfServiceUser.java
@@ -461,6 +461,13 @@ public class AppSelfServiceUser extends AbstractPersistableCustom<Long> implemen
         return this.credentialsNonExpired;
     }
 
+    /**
+     * Activates a previously disabled self-service user after enrollment confirmation.
+     */
+    public void enable() {
+        this.enabled = true;
+    }
+
     @Override
     public boolean isEnabled() {
         return this.enabled;

--- a/src/test/java/org/apache/fineract/selfservice/registration/api/SelfServiceEnrollmentIntegrationTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/registration/api/SelfServiceEnrollmentIntegrationTest.java
@@ -8,12 +8,18 @@ package org.apache.fineract.selfservice.registration.api;
 
 import static io.restassured.RestAssured.given;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import io.restassured.response.Response;
-import java.io.IOException;
-import java.util.UUID;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -24,14 +30,19 @@ import org.apache.fineract.selfservice.testing.support.SelfServiceIntegrationTes
 import org.apache.fineract.selfservice.testing.support.SelfServiceTestUtils;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.containers.Container;
+
 
 /**
- * Integration tests for the self-enrollment endpoint that creates a client and self-service user.
+ * Integration tests for the two-step self-enrollment flow:
+ * <ol>
+ *   <li>{@code POST /self/registration/client-user} — creates client + disabled user + sends token</li>
+ *   <li>{@code POST /self/registration/client-user/confirm} — validates token and enables user</li>
+ * </ol>
  */
 public class SelfServiceEnrollmentIntegrationTest extends SelfServiceIntegrationTestBase {
 
     private static final String ENROLLMENT_PATH = "/fineract-provider/api/v1/self/registration/client-user";
+    private static final String CONFIRM_PATH = "/fineract-provider/api/v1/self/registration/client-user/confirm";
     private static final long CONCURRENT_ENROLLMENT_START_TIMEOUT_SECONDS = 5;
     private static final AtomicLong UNIQUE_ID_SEQUENCE = new AtomicLong(System.nanoTime());
 
@@ -43,26 +54,6 @@ public class SelfServiceEnrollmentIntegrationTest extends SelfServiceIntegration
         return String.format("%08d", Math.floorMod(UNIQUE_ID_SEQUENCE.incrementAndGet(), 100000000));
     }
 
-    /**
-     * Builds a unique enrollment payload for success-path assertions.
-     *
-     * @return request JSON with unique username, mobile number, and email
-     */
-    private String generateUniquePayload() {
-        String id = numericId();
-        return """
-            {
-              "username": "user_%s",
-              "password": "Strong#Abc123",
-              "firstName": "Test",
-              "lastName": "User",
-              "mobileNumber": "555%s",
-              "email": "test%s@fineract.test",
-              "authenticationMode": "email",
-              "active": true
-            }
-            """.formatted(id, id, id);
-    }
 
     /**
      * Builds an enrollment payload that reuses a specific mobile suffix to trigger duplicate-number scenarios.
@@ -84,6 +75,50 @@ public class SelfServiceEnrollmentIntegrationTest extends SelfServiceIntegration
               "active": true
             }
             """.formatted(id, phone, id);
+    }
+
+    /**
+     * Executes a scalar query against the test database using a single string parameter.
+     */
+    private String querySingleValue(String sql, String parameter) {
+        Properties properties = new Properties();
+        properties.setProperty("user", postgres.getUsername());
+        properties.setProperty("password", postgres.getPassword());
+        try (Connection connection = DriverManager.getConnection(postgres.getJdbcUrl(), properties);
+                PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setString(1, parameter);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                if (resultSet.next()) {
+                    return resultSet.getString(1);
+                }
+                return "";
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException("Test database query failed: " + sql, e);
+        }
+    }
+
+    /**
+     * Queries the enrollment token for a given username from the request_audit_table.
+     */
+    private String queryEnrollmentToken(String username) {
+        String sql = "SELECT external_authorization_token FROM request_audit_table "
+                + "WHERE username = ? AND request_type = 'ENROLLMENT' ORDER BY id DESC LIMIT 1";
+        return querySingleValue(sql, username);
+    }
+
+    /**
+     * Confirms an enrollment token and returns the response.
+     */
+    private Response confirmEnrollment(String token) {
+        return given(SelfServiceTestUtils.requestSpec(getFineractPort()))
+            .body("""
+                { "externalAuthenticationToken": "%s" }
+                """.formatted(token))
+            .when()
+            .post(CONFIRM_PATH)
+            .then()
+            .extract().response();
     }
 
     /**
@@ -116,42 +151,79 @@ public class SelfServiceEnrollmentIntegrationTest extends SelfServiceIntegration
      * Runs a scalar count query against the test database using a single string parameter.
      *
      * @param sql SQL containing a single {@code ?} placeholder
-     * @param parameter value to inject into the placeholder after SQL-escaping single quotes
+     * @param parameter value to inject into the placeholder
      * @return the parsed count returned by PostgreSQL
      */
     private long queryCount(String sql, String parameter) {
-        try {
-            String sanitizedParam = parameter.replace("'", "''");
-            Container.ExecResult result = postgres.execInContainer(
-                "psql", "-U", "postgres", "-d", "fineract_default", "-t", "-A", "-c",
-                sql.replace("?", "'" + sanitizedParam + "'")
-            );
-            return Long.parseLong(result.getStdout().trim());
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new RuntimeException("Failed to query test database", e);
-        } catch (IOException e) {
-            throw new RuntimeException("Failed to query test database", e);
+        String result = querySingleValue(sql, parameter);
+        if (result != null && !result.isBlank()) {
+            return Long.parseLong(result.trim());
         }
+        return 0L;
     }
 
     /**
-     * Verifies that a valid self-enrollment request creates both resources successfully.
+     * Verifies the full 2-step enrollment flow:
+     * 1. POST /client-user → 200 + disabled user created
+     * 2. Query token from DB
+     * 3. User cannot login (disabled)
+     * 4. POST /client-user/confirm → 200 + user enabled
+     * 5. User can login
      */
     @Test
-    @DisplayName("Successfully enrolls an atomic Client and User")
-    void testSuccessfulSelfEnrollment() {
-        String payload = generateUniquePayload();
-        Response response = given(SelfServiceTestUtils.requestSpec(getFineractPort()))
+    @DisplayName("Two-step enrollment: create disabled user, confirm token, then login")
+    void testSuccessfulTwoStepEnrollment() {
+        String id = numericId();
+        String username = "user_" + id;
+        String password = "Strong#Abc123";
+        String payload = """
+            {
+              "username": "%s",
+              "password": "%s",
+              "firstName": "Test",
+              "lastName": "User",
+              "mobileNumber": "555%s",
+              "email": "test%s@fineract.test",
+              "authenticationMode": "email",
+              "active": true
+            }
+            """.formatted(username, password, id, id);
+
+        // Step 1: Enroll — should succeed but user is disabled
+        Response enrollResponse = given(SelfServiceTestUtils.requestSpec(getFineractPort()))
             .body(payload)
             .when()
             .post(ENROLLMENT_PATH)
             .then()
-            .log().body()
             .extract().response();
 
-        assertEquals(200, response.getStatusCode(),
-            "Expected successful enrollment. Body: " + response.body().asString());
+        assertEquals(200, enrollResponse.getStatusCode(),
+            "Enrollment request must succeed. Body: " + enrollResponse.body().asString());
+
+        // User should NOT be able to login yet (disabled)
+        Response disabledLogin = SelfServiceTestUtils.authenticate(getFineractPort(), username, password);
+        assertEquals(401, disabledLogin.getStatusCode(),
+            "Disabled user must not be able to authenticate");
+
+        // Step 2: Query the enrollment token from DB
+        String token = queryEnrollmentToken(username);
+        assertNotNull(token, "Enrollment token must exist in request_audit_table");
+        assertFalse(token.isBlank(), "Enrollment token must not be blank");
+
+        // Step 3: Confirm enrollment — enables the user
+        Response confirmResponse = confirmEnrollment(token);
+        assertEquals(200, confirmResponse.getStatusCode(),
+            "Enrollment confirmation must succeed. Body: " + confirmResponse.body().asString());
+
+        // Step 4: User can now login
+        Response enabledLogin = SelfServiceTestUtils.authenticate(getFineractPort(), username, password);
+        assertEquals(200, enabledLogin.getStatusCode(),
+            "Enabled user must be able to authenticate after confirmation");
+
+        // Step 5: Token replay must be rejected
+        Response replayResponse = confirmEnrollment(token);
+        assertEquals(403, replayResponse.getStatusCode(),
+            "Consumed enrollment token must be rejected. Body: " + replayResponse.body().asString());
     }
 
     /**
@@ -181,7 +253,7 @@ public class SelfServiceEnrollmentIntegrationTest extends SelfServiceIntegration
             "First enrollment should succeed. Body: " + response1.body().asString());
 
         String payload2 = generateDuplicateMobilePayload(phone);
-        
+
         // Second enroll should fail with 409 constraint violation
         Response response2 = executeSelfEnrollment(payload2, null);
         assertEquals(409, response2.getStatusCode(), "Expected 409 conflict for duplicate mobile number");
@@ -218,8 +290,8 @@ public class SelfServiceEnrollmentIntegrationTest extends SelfServiceIntegration
 
             // At least one succeeds or fails, but BOTH cannot succeed
             assertTrue(
-                (status1 == 200 && status2 == 409) || 
-                (status1 == 409 && status2 == 200) || 
+                (status1 == 200 && status2 == 409) ||
+                (status1 == 409 && status2 == 200) ||
                 (status1 == 409 && status2 == 409),
                 "Expected race condition to resolve as atomic commit/fail. Got statuses: " + status1 + " and " + status2
             );

--- a/src/test/java/org/apache/fineract/selfservice/security/api/SelfForgotPasswordApiResourceIntegrationTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/security/api/SelfForgotPasswordApiResourceIntegrationTest.java
@@ -26,7 +26,7 @@ class SelfForgotPasswordApiResourceIntegrationTest extends SelfServiceIntegratio
         return String.format("%08d", Math.floorMod(UNIQUE_ID_SEQUENCE.incrementAndGet(), 100000000));
     }
 
-    private String enrollUser(String username, String password, String email, String mobileNumber) {
+    private void enrollUser(String username, String password, String email, String mobileNumber) {
         String payload = """
             {
               "username": "%s",
@@ -40,15 +40,36 @@ class SelfForgotPasswordApiResourceIntegrationTest extends SelfServiceIntegratio
             }
             """.formatted(username, password, mobileNumber, email);
 
-        Response response = given(SelfServiceTestUtils.requestSpec(getFineractPort()))
+        // Step 1: Create client + disabled user
+        Response enrollResponse = given(SelfServiceTestUtils.requestSpec(getFineractPort()))
                 .body(payload)
                 .when()
                 .post("/fineract-provider/api/v1/self/registration/client-user")
                 .then()
                 .extract().response();
 
-        assertEquals(200, response.getStatusCode(), "Enrollment must succeed before password reset testing");
-        return response.body().asString();
+        assertEquals(200, enrollResponse.getStatusCode(),
+                "Enrollment must succeed before password reset testing. Body: " + enrollResponse.body().asString());
+
+        // Step 2: Query enrollment token and confirm
+        String enrollmentToken = querySingleValue(
+                "select external_authorization_token from request_audit_table "
+                        + "where username = ? and request_type = 'ENROLLMENT' order by id desc limit 1",
+                username);
+        assertNotNull(enrollmentToken, "Enrollment token must exist");
+        assertFalse(enrollmentToken.isBlank(), "Enrollment token must not be blank");
+
+        Response confirmResponse = given(SelfServiceTestUtils.requestSpec(getFineractPort()))
+                .body("""
+                    { "externalAuthenticationToken": "%s" }
+                    """.formatted(enrollmentToken))
+                .when()
+                .post("/fineract-provider/api/v1/self/registration/client-user/confirm")
+                .then()
+                .extract().response();
+
+        assertEquals(200, confirmResponse.getStatusCode(),
+                "Enrollment confirmation must succeed. Body: " + confirmResponse.body().asString());
     }
 
     private String querySingleValue(String sql, String parameter) {


### PR DESCRIPTION
- selfEnroll creates client + disabled user (enabled=false)
- Enrollment token stored in request_audit_table with type ENROLLMENT
- New POST /self/registration/client-user/confirm endpoint validates token and enables the user via AppSelfServiceUser.enable()
- User cannot login until enrollment is confirmed
- Token replay protection via markConsumed() + optimistic locking
- Updated enrollment + forgot-password tests for 2-step flow
- Wrapped token delivery in try-catch (swallowed for audit/retry)
- Added BEGIN/COMMIT transaction wrapper to executeSqlInPostgres()

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Self-enrollment now implements a two-step verification process: account creation followed by email or SMS token confirmation for activation.
  * New enrollment confirmation endpoint to activate accounts after token verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->