### PR TITLE
MX-236: Implement i18N for the messages sent by SMS or Email

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,6 +157,11 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <!-- Email Template -->
+    <dependency>
+      <groupId>org.thymeleaf</groupId>
+      <artifactId>thymeleaf-spring6</artifactId>
+    </dependency>
     <!-- Apache Fineract Libraries -->
     <dependency>
       <groupId>org.apache.fineract</groupId>

--- a/src/main/java/org/apache/fineract/selfservice/registration/service/SelfServiceRegistrationWritePlatformServiceImpl.java
+++ b/src/main/java/org/apache/fineract/selfservice/registration/service/SelfServiceRegistrationWritePlatformServiceImpl.java
@@ -32,6 +32,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
@@ -96,6 +97,10 @@ import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.apache.fineract.portfolio.client.service.ClientWritePlatformService;
 import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
+import org.springframework.context.MessageSource;
+import org.springframework.context.i18n.LocaleContextHolder;
+import org.thymeleaf.ITemplateEngine;
+import org.thymeleaf.context.Context;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -121,6 +126,8 @@ public class SelfServiceRegistrationWritePlatformServiceImpl implements SelfServ
     private final PlatformPasswordEncoder platformPasswordEncoder;
     private final AppSelfServiceUserRepository appSelfServiceUserRepository;
     private final SelfServiceAuthorizationTokenService selfServiceAuthorizationTokenService;
+    private final ITemplateEngine registrationTemplateEngine;
+    private final MessageSource registrationMessageSource;
 
     @Override
     public SelfServiceRegistration createRegistrationRequest(String apiRequestBodyAsJson) {
@@ -206,10 +213,7 @@ public class SelfServiceRegistrationWritePlatformServiceImpl implements SelfServ
             sendAuthorizationMessage(selfServiceRegistration);
         }
     }
-
-
-
-
+    
     private void sendAuthorizationMessage(SelfServiceRegistration selfServiceRegistration) {
         Collection<SmsProviderData> smsProviders = this.smsCampaignDropdownReadPlatformService.retrieveSmsProviders();
         if (smsProviders.isEmpty()) {
@@ -217,8 +221,11 @@ public class SelfServiceRegistrationWritePlatformServiceImpl implements SelfServ
                     "Mobile service provider not available.");
         }
         Long providerId = new ArrayList<>(smsProviders).get(0).getId();
-        final String message = "Hola  " + selfServiceRegistration.getFirstName() + "," + "\n\n"
-                + "Código de Autorización : " + selfServiceRegistration.getExternalAuthorizationToken();
+        Locale locale = LocaleContextHolder.getLocale();
+        final String message = this.registrationMessageSource.getMessage("sms.message",
+                new Object[] { selfServiceRegistration.getFirstName(), selfServiceRegistration.getId(),
+                        selfServiceRegistration.getAuthenticationToken() },
+                locale);
         String externalId = null;
         Group group = null;
         Staff staff = null;
@@ -231,11 +238,14 @@ public class SelfServiceRegistrationWritePlatformServiceImpl implements SelfServ
     }
 
     private void sendAuthorizationMail(SelfServiceRegistration selfServiceRegistration) {
-        final String subject = "Código de Autorización ";
-        final String body = "Hola  " + selfServiceRegistration.getFirstName() + "," + "\nCódigo de Autorización : "
-                + selfServiceRegistration.getExternalAuthorizationToken();
-
-        final EmailDetail emailDetail = new EmailDetail(subject, body, selfServiceRegistration.getEmail(),
+        Locale locale = LocaleContextHolder.getLocale();
+        final String subject = this.registrationMessageSource.getMessage("email.subject", null, locale);
+        Context ctx = new Context(locale);
+        ctx.setVariable("firstName", selfServiceRegistration.getFirstName());
+        ctx.setVariable("requestId", selfServiceRegistration.getId());
+        ctx.setVariable("authToken", selfServiceRegistration.getAuthenticationToken());
+        final String htmlBody = this.registrationTemplateEngine.process("authorization-email", ctx);
+        final EmailDetail emailDetail = new EmailDetail(subject, htmlBody, selfServiceRegistration.getEmail(),
                 selfServiceRegistration.getFirstName());
         this.gmailBackedPlatformEmailService.sendDefinedEmail(emailDetail);
     }

--- a/src/main/java/org/apache/fineract/selfservice/registration/starter/SelfRegistrationConfiguration.java
+++ b/src/main/java/org/apache/fineract/selfservice/registration/starter/SelfRegistrationConfiguration.java
@@ -42,7 +42,12 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.jdbc.core.JdbcTemplate;
 
 import org.apache.fineract.useradministration.domain.AppUserRepository;
+import org.springframework.context.MessageSource;
+import org.springframework.context.support.ResourceBundleMessageSource;
 import org.springframework.core.env.Environment;
+import org.thymeleaf.spring6.SpringTemplateEngine;
+import org.thymeleaf.templatemode.TemplateMode;
+import org.thymeleaf.templateresolver.ClassLoaderTemplateResolver;
 
 @Configuration
 public class SelfRegistrationConfiguration {
@@ -57,6 +62,34 @@ public class SelfRegistrationConfiguration {
     @ConditionalOnMissingBean(SelfServiceAuthorizationTokenService.class)
     public SelfServiceAuthorizationTokenService selfServiceAuthorizationTokenService(Environment env) {
         return new SelfServiceAuthorizationTokenService(env);
+    }
+    
+    @Bean
+    public MessageSource registrationMessageSource() {
+        ResourceBundleMessageSource messageSource = new ResourceBundleMessageSource();
+        messageSource.setBasename("i18n/messages");
+        messageSource.setDefaultEncoding("UTF-8");
+        messageSource.setFallbackToSystemLocale(false);
+        return messageSource;
+    }
+
+    /**
+     * Provides the Thymeleaf engine for rendering registration email templates.
+     *
+     * @return configured template engine
+     */
+    @Bean
+    public SpringTemplateEngine registrationTemplateEngine() {
+        ClassLoaderTemplateResolver templateResolver = new ClassLoaderTemplateResolver();
+        templateResolver.setPrefix("mail-templates/");
+        templateResolver.setSuffix(".html");
+        templateResolver.setTemplateMode(TemplateMode.HTML);
+        templateResolver.setCharacterEncoding("UTF-8");
+
+        SpringTemplateEngine templateEngine = new SpringTemplateEngine();
+        templateEngine.setTemplateResolver(templateResolver);
+        templateEngine.setTemplateEngineMessageSource(registrationMessageSource());
+        return templateEngine;
     }
 
     @Bean
@@ -80,7 +113,7 @@ public class SelfRegistrationConfiguration {
                 gmailBackedPlatformEmailService, smsMessageRepository, smsMessageScheduledJobService,
                  smsCampaignDropdownReadPlatformService, appUserReadPlatformService, roleRepository, appUserClientMappingRepository,
                  jdbcTemplate, appUserRepository, clientWritePlatformService, env, platformPasswordEncoder, appSelfServiceUserRepository,
-                 selfServiceAuthorizationTokenService);
+                 selfServiceAuthorizationTokenService, registrationTemplateEngine(), registrationMessageSource());
     }
     
      @Bean

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -1,0 +1,8 @@
+email.subject=Authorization Code
+email.greeting=Hello {0},
+email.instructions=To create a user, use the following details:
+email.requestId=Request ID
+email.authCode=Authorization Code
+email.regards=Regards,
+
+sms.message=Hello {0},\n\nTo create a user, use the following details:\nRequest ID: {1}\nAuthorization Code: {2}

--- a/src/main/resources/i18n/messages_es.properties
+++ b/src/main/resources/i18n/messages_es.properties
@@ -1,0 +1,8 @@
+email.subject=C\u00f3digo de Autorizaci\u00f3n
+email.greeting=Hola {0},
+email.instructions=Para crear un usuario, utilice los siguientes datos:
+email.requestId=Id de Petici\u00f3n
+email.authCode=C\u00f3digo de Autorizaci\u00f3n
+email.regards=Saludos,
+
+sms.message=Hola {0},\n\nPara crear un usuario, utilice los siguientes datos:\nId de Petici\u00f3n: {1}\nC\u00f3digo de Autorizaci\u00f3n: {2}

--- a/src/main/resources/mail-templates/authorization-email.html
+++ b/src/main/resources/mail-templates/authorization-email.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+  </head>
+  <body>
+    <p th:text="#{email.greeting(${firstName})}"></p>
+    <p th:text="#{email.instructions}"></p>
+    <br/>
+    <p>
+      <strong th:text="#{email.requestId}"></strong>: <span th:text="${requestId}"></span>
+    </p>
+    <p>
+      <strong th:text="#{email.authCode}"></strong>: <span th:text="${authToken}"></span>
+    </p>
+    <br/>
+    <p th:text="#{email.regards}"></p>
+  </body>
+</html>

--- a/src/test/java/org/apache/fineract/selfservice/registration/service/SelfServiceRegistrationWritePlatformServiceImplTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/registration/service/SelfServiceRegistrationWritePlatformServiceImplTest.java
@@ -56,6 +56,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.MessageSource;
+import org.thymeleaf.ITemplateEngine;
 
 @ExtendWith(MockitoExtension.class)
 @SuppressWarnings("unchecked")
@@ -81,11 +83,19 @@ class SelfServiceRegistrationWritePlatformServiceImplTest {
     @Mock private PlatformPasswordEncoder platformPasswordEncoder;
     @Mock private AppSelfServiceUserRepository appSelfServiceUserRepository;
     @Mock private SelfServiceAuthorizationTokenService selfServiceAuthorizationTokenService;
+    //@Mock private SpringTemplateEngine registrationTemplateEngine;
+    // To this:
+    @Mock
+    private ITemplateEngine registrationTemplateEngine;
+    @Mock private MessageSource registrationMessageSource;
 
     private SelfServiceRegistrationWritePlatformServiceImpl service;
 
+    
+
     @BeforeEach
-    void setUp() {
+    void setUp() {        
+        
         service = new SelfServiceRegistrationWritePlatformServiceImpl(
             selfServiceRegistrationRepository,
             fromApiJsonHelper,
@@ -106,7 +116,9 @@ class SelfServiceRegistrationWritePlatformServiceImplTest {
             env,
             platformPasswordEncoder,
             appSelfServiceUserRepository,
-            selfServiceAuthorizationTokenService
+            selfServiceAuthorizationTokenService,
+            registrationTemplateEngine,
+            registrationMessageSource
         );
 
         LocalDate businessDate = LocalDate.of(2026, 1, 2);
@@ -114,6 +126,7 @@ class SelfServiceRegistrationWritePlatformServiceImplTest {
         businessDates.put(BusinessDateType.BUSINESS_DATE, businessDate);
         businessDates.put(BusinessDateType.COB_DATE, businessDate.minusDays(1));
         ThreadLocalContextUtil.setBusinessDates(businessDates);
+  
     }
 
     @AfterEach


### PR DESCRIPTION
MX-236: Implement i18N for the messages sent by SMS or Email

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added multi-language support (English and Spanish) for SMS and email authorization messages in the self-service registration flow
  * Email authorization notifications now use HTML templates for improved formatting and presentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->