### PR TITLE
MX-241: FIX propagate tenant context to async notification threads

### DIFF
--- a/src/main/java/org/apache/fineract/selfservice/notification/SelfServiceNotificationEvent.java
+++ b/src/main/java/org/apache/fineract/selfservice/notification/SelfServiceNotificationEvent.java
@@ -1,28 +1,34 @@
 /**
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements. See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership. The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License. You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.apache.fineract.selfservice.notification;
 
+import java.time.LocalDate;
+import java.util.HashMap;
 import java.util.Locale;
 import java.util.Objects;
 import lombok.Getter;
+import org.apache.fineract.infrastructure.businessdate.domain.BusinessDateType;
+import org.apache.fineract.infrastructure.core.domain.FineractPlatformTenant;
+import org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil;
 import org.springframework.context.ApplicationEvent;
 
+/**
+ * Immutable event carrying all data needed for self-service notification delivery,
+ * including the originating Fineract tenant context so that async listeners can
+ * restore multi-tenant database routing on their own thread.
+ */
 @Getter
 public class SelfServiceNotificationEvent extends ApplicationEvent {
 
@@ -53,6 +59,20 @@ public class SelfServiceNotificationEvent extends ApplicationEvent {
     private final Locale locale;
 
     /**
+     * The Fineract tenant that was active when the event was created.
+     * Used by async listeners to restore multi-tenant database routing.
+     * May be {@code null} if no tenant was available at creation time.
+     */
+    private final FineractPlatformTenant tenant;
+
+    /**
+     * The business dates that were active when the event was created.
+     * Used by async listeners to restore date context on the worker thread.
+     * May be {@code null} if no business dates were available at creation time.
+     */
+    private final HashMap<BusinessDateType, LocalDate> businessDates;
+
+    /**
      * Creates a new self-service notification event.
      *
      * @param source the object on which the event initially occurred (never {@code null})
@@ -69,6 +89,29 @@ public class SelfServiceNotificationEvent extends ApplicationEvent {
      */
     public SelfServiceNotificationEvent(Object source, Type type, Long userId, String firstName, String lastName, String username,
             String email, String mobileNumber, boolean emailMode, String ipAddress, Locale locale) {
+        this(source, type, userId, firstName, lastName, username, email, mobileNumber, emailMode, ipAddress, locale, null, null);
+    }
+
+    /**
+     * Creates a new self-service notification event with explicit tenant context.
+     *
+     * @param source the object on which the event initially occurred (never {@code null})
+     * @param type the notification event type (never {@code null})
+     * @param userId the user identifier (never {@code null})
+     * @param firstName user's first name (may be {@code null})
+     * @param lastName user's last name (may be {@code null})
+     * @param username user's login username (may be {@code null})
+     * @param email user's email address (may be {@code null})
+     * @param mobileNumber user's mobile number (may be {@code null})
+     * @param emailMode {@code true} for email delivery, {@code false} for SMS
+     * @param ipAddress the originating IP address (may be {@code null})
+     * @param locale the locale for notification content (may be {@code null})
+     * @param tenant the Fineract tenant active at event creation time (may be {@code null})
+     * @param businessDates the business dates active at event creation time (may be {@code null})
+     */
+    public SelfServiceNotificationEvent(Object source, Type type, Long userId, String firstName, String lastName, String username,
+            String email, String mobileNumber, boolean emailMode, String ipAddress, Locale locale,
+            FineractPlatformTenant tenant, HashMap<BusinessDateType, LocalDate> businessDates) {
         super(source);
         this.type = Objects.requireNonNull(type, "type must not be null");
         this.userId = Objects.requireNonNull(userId, "userId must not be null");
@@ -80,6 +123,37 @@ public class SelfServiceNotificationEvent extends ApplicationEvent {
         this.emailMode = emailMode;
         this.ipAddress = ipAddress;
         this.locale = locale;
+        this.tenant = tenant;
+        this.businessDates = businessDates != null ? new HashMap<>(businessDates) : null;
+    }
+
+    /**
+     * Factory method that creates an event and automatically captures the current thread's
+     * Fineract tenant context and business dates. Use this from request-processing threads
+     * where the tenant context is still available.
+     *
+     * <p>This is the <strong>preferred</strong> way to create events from synchronous call sites
+     * (e.g. REST controllers, service methods). For events published from
+     * {@code TransactionSynchronization.afterCommit()} callbacks where the tenant may already
+     * be cleared, capture the tenant <em>before</em> registering the synchronization and pass
+     * it to the full constructor.
+     *
+     * @see #SelfServiceNotificationEvent(Object, Type, Long, String, String, String, String, String, boolean, String, Locale, FineractPlatformTenant, HashMap)
+     */
+    public static SelfServiceNotificationEvent withTenantContext(Object source, Type type, Long userId, String firstName,
+            String lastName, String username, String email, String mobileNumber, boolean emailMode, String ipAddress, Locale locale) {
+        FineractPlatformTenant currentTenant = null;
+        HashMap<BusinessDateType, LocalDate> currentDates = null;
+        try {
+            currentTenant = ThreadLocalContextUtil.getTenant();
+        } catch (IllegalStateException ignored) {
+        }
+        try {
+            currentDates = ThreadLocalContextUtil.getBusinessDates();
+        } catch (IllegalArgumentException ignored) {
+        }
+        return new SelfServiceNotificationEvent(source, type, userId, firstName, lastName, username, email, mobileNumber, emailMode,
+                ipAddress, locale, currentTenant, currentDates);
     }
 
     /**
@@ -89,6 +163,8 @@ public class SelfServiceNotificationEvent extends ApplicationEvent {
     @Override
     public String toString() {
         return "SelfServiceNotificationEvent[type=" + type + ", userId=" + userId
-                + ", emailMode=" + emailMode + ", locale=" + locale + "]";
+                + ", emailMode=" + emailMode + ", locale=" + locale
+                + ", tenant=" + (tenant != null ? tenant.getTenantIdentifier() : "null") + "]";
     }
 }
+

--- a/src/main/java/org/apache/fineract/selfservice/notification/service/SelfServiceNotificationService.java
+++ b/src/main/java/org/apache/fineract/selfservice/notification/service/SelfServiceNotificationService.java
@@ -26,8 +26,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.fineract.infrastructure.campaigns.sms.data.SmsProviderData;
 import org.apache.fineract.infrastructure.campaigns.sms.service.SmsCampaignDropdownReadPlatformService;
 import org.apache.fineract.infrastructure.core.domain.EmailDetail;
+import org.apache.fineract.infrastructure.core.domain.FineractPlatformTenant;
 import org.apache.fineract.infrastructure.core.service.SelfServicePluginEmailService;
 import org.apache.fineract.infrastructure.core.service.SmtpConfigurationUnavailableException;
+import org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil;
 import org.apache.fineract.infrastructure.sms.domain.SmsMessage;
 import org.apache.fineract.infrastructure.sms.domain.SmsMessageRepository;
 import org.apache.fineract.infrastructure.sms.domain.SmsMessageStatusType;
@@ -99,6 +101,7 @@ public class SelfServiceNotificationService {
     @EventListener
     @Transactional
     public void handleNotification(SelfServiceNotificationEvent event) {
+        restoreTenantContext(event);
         try {
             boolean globalEnabled = env.getProperty("fineract.selfservice.notification.enabled", Boolean.class, true);
             if (!globalEnabled) {
@@ -245,5 +248,43 @@ public class SelfServiceNotificationService {
     private void releaseCooldown(SelfServiceNotificationEvent event) {
         String cacheKey = event.getType().name() + ":" + event.getUserId();
         notificationCooldownCache.release(cacheKey);
+    }
+
+    /**
+     * Restores the Fineract tenant context and business dates from the event onto the current
+     * thread. This is critical for async listeners running on the notification executor pool,
+     * where the original request thread's {@code ThreadLocal} tenant context may not have been
+     * propagated (e.g. when events are published from {@code afterCommit()} callbacks after
+     * the auth filter has already cleared the context).
+     *
+     * <p>The event-carried tenant takes precedence because it was captured at event creation
+     * time on the originating thread. The {@code TaskDecorator} in
+     * {@link org.apache.fineract.selfservice.notification.starter.SelfServiceNotificationConfig}
+     * serves as a belt-and-suspenders fallback.
+     */
+    void restoreTenantContext(SelfServiceNotificationEvent event) {
+        FineractPlatformTenant eventTenant = event.getTenant();
+        if (eventTenant != null) {
+            ThreadLocalContextUtil.setTenant(eventTenant);
+            log.debug("Restored tenant '{}' from notification event on thread {}",
+                    eventTenant.getTenantIdentifier(), Thread.currentThread().getName());
+        } else {
+            FineractPlatformTenant threadTenant = null;
+            try {
+                threadTenant = ThreadLocalContextUtil.getTenant();
+            } catch (IllegalStateException ignored) {
+                // getTenant() may throw on some Fineract versions
+            }
+            if (threadTenant != null) {
+                log.debug("Using TaskDecorator-propagated tenant '{}' on thread {}",
+                        threadTenant.getTenantIdentifier(), Thread.currentThread().getName());
+            } else {
+                log.warn("No tenant context available for notification event {} on thread {} — "
+                        + "database operations may fail", event.getType(), Thread.currentThread().getName());
+            }
+        }
+        if (event.getBusinessDates() != null) {
+            ThreadLocalContextUtil.setBusinessDates(event.getBusinessDates());
+        }
     }
 }

--- a/src/main/java/org/apache/fineract/selfservice/notification/starter/SelfServiceNotificationConfig.java
+++ b/src/main/java/org/apache/fineract/selfservice/notification/starter/SelfServiceNotificationConfig.java
@@ -73,11 +73,18 @@ public class SelfServiceNotificationConfig {
         executor.setQueueCapacity(properties.getQueueCapacity());
         executor.setThreadNamePrefix(properties.getThreadNamePrefix());
         executor.setTaskDecorator(runnable -> {
-            FineractPlatformTenant tenant = ThreadLocalContextUtil.getTenant();
+            FineractPlatformTenant capturedTenant = null;
+            try {
+                capturedTenant = ThreadLocalContextUtil.getTenant();
+            } catch (IllegalStateException ignored) {
+            }
+            final FineractPlatformTenant tenant = capturedTenant;
             HashMap<BusinessDateType, LocalDate> businessDates = currentBusinessDates();
             return () -> {
                 try {
-                    ThreadLocalContextUtil.setTenant(tenant);
+                    if (tenant != null) {
+                        ThreadLocalContextUtil.setTenant(tenant);
+                    }
                     if (businessDates != null) {
                         ThreadLocalContextUtil.setBusinessDates(new HashMap<>(businessDates));
                     }

--- a/src/main/java/org/apache/fineract/selfservice/registration/service/SelfServiceRegistrationWritePlatformServiceImpl.java
+++ b/src/main/java/org/apache/fineract/selfservice/registration/service/SelfServiceRegistrationWritePlatformServiceImpl.java
@@ -531,6 +531,22 @@ public class SelfServiceRegistrationWritePlatformServiceImpl implements SelfServ
         appUser.enable();
         this.appSelfServiceUserRepository.saveAndFlush(appUser);
 
+        org.apache.fineract.infrastructure.core.domain.FineractPlatformTenant capturedTenant = null;
+        try {
+            capturedTenant = org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil.getTenant();
+        } catch (IllegalStateException ignored) {
+        }
+        final org.apache.fineract.infrastructure.core.domain.FineractPlatformTenant tenantSnapshot = capturedTenant;
+        final java.util.HashMap<org.apache.fineract.infrastructure.businessdate.domain.BusinessDateType, java.time.LocalDate> businessDatesSnapshot;
+        java.util.HashMap<org.apache.fineract.infrastructure.businessdate.domain.BusinessDateType, java.time.LocalDate> tempDates = null;
+        try {
+            java.util.HashMap<org.apache.fineract.infrastructure.businessdate.domain.BusinessDateType, java.time.LocalDate> dates =
+                    org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil.getBusinessDates();
+            tempDates = dates != null ? new java.util.HashMap<>(dates) : null;
+        } catch (IllegalArgumentException e) {
+        }
+        businessDatesSnapshot = tempDates;
+
         TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
             @Override
             public void afterCommit() {
@@ -546,7 +562,9 @@ public class SelfServiceRegistrationWritePlatformServiceImpl implements SelfServ
                         request.getMobileNumber(),
                         isEmailMode(request),
                         null,
-                        LocaleContextHolder.getLocale()
+                        LocaleContextHolder.getLocale(),
+                        tenantSnapshot,
+                        businessDatesSnapshot
                     ));
                 } catch (Exception e) {
                     log.warn("Failed to publish USER_ACTIVATED notification for userId={}", appUser.getId(), e);

--- a/src/main/java/org/apache/fineract/selfservice/security/api/SelfAuthenticationApiResource.java
+++ b/src/main/java/org/apache/fineract/selfservice/security/api/SelfAuthenticationApiResource.java
@@ -132,7 +132,7 @@ public class SelfAuthenticationApiResource {
 
             try (NotificationContext.Scope ignored = NotificationContext.bind(SelfServiceNotificationEvent.Type.LOGIN_FAILURE.name())) {
                 try {
-                    applicationEventPublisher.publishEvent(new SelfServiceNotificationEvent(
+                    applicationEventPublisher.publishEvent(SelfServiceNotificationEvent.withTenantContext(
                         this, SelfServiceNotificationEvent.Type.LOGIN_FAILURE, failedUser.getId(), failedUser.getFirstname(),
                         failedUser.getLastname(), request.username, failedUser.getEmail(),
                         mobileNumber, emailMode, extractClientIp(httpRequest), httpRequest.getLocale()
@@ -149,7 +149,7 @@ public class SelfAuthenticationApiResource {
 
             try (NotificationContext.Scope ignored = NotificationContext.bind(SelfServiceNotificationEvent.Type.LOGIN_FAILURE.name())) {
                 try {
-                    applicationEventPublisher.publishEvent(new SelfServiceNotificationEvent(
+                    applicationEventPublisher.publishEvent(SelfServiceNotificationEvent.withTenantContext(
                         this, SelfServiceNotificationEvent.Type.LOGIN_FAILURE, failedUser.getId(), failedUser.getFirstname(),
                         failedUser.getLastname(), request.username, failedUser.getEmail(),
                         mobileNumber, emailMode, extractClientIp(httpRequest), httpRequest.getLocale()
@@ -166,7 +166,7 @@ public class SelfAuthenticationApiResource {
                 boolean emailMode = determineMode(failedUser.getEmail(), mobileNumber);
                 try (NotificationContext.Scope ignored = NotificationContext.bind(SelfServiceNotificationEvent.Type.LOGIN_FAILURE.name())) {
                     try {
-                        applicationEventPublisher.publishEvent(new SelfServiceNotificationEvent(
+                        applicationEventPublisher.publishEvent(SelfServiceNotificationEvent.withTenantContext(
                             this, SelfServiceNotificationEvent.Type.LOGIN_FAILURE, failedUser.getId(), failedUser.getFirstname(),
                             failedUser.getLastname(), request.username, failedUser.getEmail(),
                             mobileNumber, emailMode, extractClientIp(httpRequest), httpRequest.getLocale()
@@ -219,7 +219,7 @@ public class SelfAuthenticationApiResource {
                 boolean emailMode = determineMode(principal.getEmail(), mobileNumber);
                 try (NotificationContext.Scope ignored = NotificationContext.bind(SelfServiceNotificationEvent.Type.LOGIN_SUCCESS.name())) {
                     try {
-                        applicationEventPublisher.publishEvent(new SelfServiceNotificationEvent(
+                        applicationEventPublisher.publishEvent(SelfServiceNotificationEvent.withTenantContext(
                             this, SelfServiceNotificationEvent.Type.LOGIN_SUCCESS, principal.getId(), principal.getFirstname(),
                             principal.getLastname(), request.username, principal.getEmail(),
                             mobileNumber, emailMode, extractClientIp(httpRequest), httpRequest.getLocale()

--- a/src/test/java/org/apache/fineract/selfservice/notification/SelfServiceSmtpFallbackIntegrationTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/notification/SelfServiceSmtpFallbackIntegrationTest.java
@@ -86,6 +86,7 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
     "fineract.selfservice.notification.cooldown-seconds=5"
     // Deliberately NOT setting fineract.selfservice.smtp.* to verify the exception path
 })
+@org.springframework.test.annotation.DirtiesContext
 public class SelfServiceSmtpFallbackIntegrationTest {
 
     @Autowired

--- a/src/test/java/org/apache/fineract/selfservice/notification/service/SelfServiceNotificationServiceTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/notification/service/SelfServiceNotificationServiceTest.java
@@ -300,4 +300,86 @@ class SelfServiceNotificationServiceTest {
         assertTrue(errors.stream().anyMatch(e -> e.getFormattedMessage().contains("Failed to handle notification")),
                 "Should log ERROR for general exceptions");
     }
+
+    // ---- Tenant context restoration tests ----
+
+    @Test
+    void handleNotification_RestoresTenantFromEvent_WhenThreadHasNoTenant() {
+        // Simulate the afterCommit scenario: thread has NO tenant, but event carries one
+        ThreadLocalContextUtil.reset();
+
+        FineractPlatformTenant eventTenant = new FineractPlatformTenant(1L, "default", "Default", "UTC", null);
+        HashMap<BusinessDateType, LocalDate> eventDates = new HashMap<>();
+        eventDates.put(BusinessDateType.BUSINESS_DATE, LocalDate.of(2026, 4, 15));
+
+        SelfServiceNotificationEvent event = new SelfServiceNotificationEvent(this,
+                SelfServiceNotificationEvent.Type.LOGIN_SUCCESS, 1L, "Test", "User", "testuser",
+                "test@example.com", "1234567890", true, "127.0.0.1", Locale.US, eventTenant, eventDates);
+
+        // Notifications disabled so handleNotification returns early after restoring context
+        when(env.getProperty(eq("fineract.selfservice.notification.enabled"), eq(Boolean.class), any(Boolean.class))).thenReturn(false);
+
+        service.handleNotification(event);
+
+        // Verify tenant was restored on this thread
+        assertEquals("default", ThreadLocalContextUtil.getTenant().getTenantIdentifier(),
+                "Tenant should be restored from event payload");
+        assertEquals(LocalDate.of(2026, 4, 15),
+                ThreadLocalContextUtil.getBusinessDates().get(BusinessDateType.BUSINESS_DATE),
+                "Business dates should be restored from event payload");
+    }
+
+    @Test
+    void handleNotification_LogsWarning_WhenNoTenantAvailable() {
+        // No tenant in event, no tenant on thread
+        ThreadLocalContextUtil.reset();
+
+        SelfServiceNotificationEvent event = new SelfServiceNotificationEvent(this,
+                SelfServiceNotificationEvent.Type.LOGIN_SUCCESS, 1L, "Test", "User", "testuser",
+                "test@example.com", "1234567890", true, "127.0.0.1", Locale.US);
+        // event.getTenant() == null, event.getBusinessDates() == null
+
+        when(env.getProperty(eq("fineract.selfservice.notification.enabled"), eq(Boolean.class), any(Boolean.class))).thenReturn(false);
+
+        service.handleNotification(event);
+
+        List<ILoggingEvent> warns = logAppender.list.stream()
+                .filter(e -> e.getLevel() == Level.WARN)
+                .filter(e -> e.getFormattedMessage().contains("No tenant context available"))
+                .collect(Collectors.toList());
+        assertEquals(1, warns.size(), "Should log WARN when no tenant is available from any source");
+    }
+
+    @Test
+    void withTenantContext_CapturesCurrentTenantFromThreadLocal() {
+        // Set tenant on current thread
+        FineractPlatformTenant tenant = new FineractPlatformTenant(2L, "test-tenant", "Test", "UTC", null);
+        ThreadLocalContextUtil.setTenant(tenant);
+        HashMap<BusinessDateType, LocalDate> dates = new HashMap<>();
+        dates.put(BusinessDateType.BUSINESS_DATE, LocalDate.of(2026, 1, 1));
+        ThreadLocalContextUtil.setBusinessDates(dates);
+
+        SelfServiceNotificationEvent event = SelfServiceNotificationEvent.withTenantContext(this,
+                SelfServiceNotificationEvent.Type.LOGIN_SUCCESS, 1L, "Test", "User", "testuser",
+                "test@example.com", "1234567890", true, "127.0.0.1", Locale.US);
+
+        assertEquals("test-tenant", event.getTenant().getTenantIdentifier(),
+                "Factory should capture tenant from ThreadLocal");
+        assertEquals(LocalDate.of(2026, 1, 1),
+                event.getBusinessDates().get(BusinessDateType.BUSINESS_DATE),
+                "Factory should capture business dates from ThreadLocal");
+    }
+
+    @Test
+    void withTenantContext_HandlesNoTenantGracefully() {
+        ThreadLocalContextUtil.reset();
+
+        SelfServiceNotificationEvent event = SelfServiceNotificationEvent.withTenantContext(this,
+                SelfServiceNotificationEvent.Type.LOGIN_SUCCESS, 1L, "Test", "User", "testuser",
+                "test@example.com", "1234567890", true, "127.0.0.1", Locale.US);
+
+        // Should not throw, tenant/dates should be null
+        assertTrue(event.getTenant() == null, "Tenant should be null when ThreadLocal is empty");
+        assertTrue(event.getBusinessDates() == null, "Business dates should be null when ThreadLocal is empty");
+    }
 }

--- a/src/test/java/org/apache/fineract/selfservice/notification/service/SelfServiceNotificationTenantPropagationIntegrationTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/notification/service/SelfServiceNotificationTenantPropagationIntegrationTest.java
@@ -1,0 +1,225 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.fineract.selfservice.notification.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.fineract.infrastructure.businessdate.domain.BusinessDateType;
+import org.apache.fineract.infrastructure.core.domain.FineractPlatformTenant;
+import org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil;
+import org.apache.fineract.selfservice.notification.NotificationCooldownCache;
+import org.apache.fineract.selfservice.notification.SelfServiceNotificationEvent;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.MessageSource;
+import org.springframework.core.env.Environment;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+/**
+ * Integration test that verifies tenant context propagation across the
+ * {@code afterCommit → @Async → listener} boundary by exercising the real
+ * {@link SelfServiceNotificationService#restoreTenantContext} method.
+ *
+ * <p>Simulates the exact production failure scenario:
+ * <ol>
+ *   <li>An HTTP request thread captures the tenant into the event before {@code afterCommit}</li>
+ *   <li>The auth filter clears {@code ThreadLocal} (afterCommit scenario)</li>
+ *   <li>An async executor with a {@code TaskDecorator} dispatches the task</li>
+ *   <li>{@code restoreTenantContext} restores the correct tenant from the event</li>
+ * </ol>
+ */
+class SelfServiceNotificationTenantPropagationIntegrationTest {
+
+    private final SelfServiceNotificationService service = new SelfServiceNotificationService(
+            mock(org.thymeleaf.ITemplateEngine.class),
+            mock(MessageSource.class),
+            mock(org.apache.fineract.infrastructure.core.service.SelfServicePluginEmailService.class),
+            mock(org.apache.fineract.infrastructure.sms.domain.SmsMessageRepository.class),
+            mock(org.apache.fineract.infrastructure.sms.scheduler.SmsMessageScheduledJobService.class),
+            mock(org.apache.fineract.infrastructure.campaigns.sms.service.SmsCampaignDropdownReadPlatformService.class),
+            mock(NotificationCooldownCache.class),
+            mock(Environment.class)
+    );
+
+    @AfterEach
+    void tearDown() {
+        ThreadLocalContextUtil.reset();
+    }
+
+    /**
+     * Simulates the {@code afterCommit} scenario where the tenant has been cleared from
+     * the submitting thread before the async task runs, but the event carries the tenant
+     * captured before {@code afterCommit}. Calls the real {@code restoreTenantContext}
+     * to guard against regression.
+     */
+    @Test
+    void eventCarriedTenant_IsRestoredOnAsyncWorkerThread() throws InterruptedException {
+        FineractPlatformTenant originalTenant = new FineractPlatformTenant(1L, "default", "Default Tenant", "UTC", null);
+        HashMap<BusinessDateType, LocalDate> originalDates = new HashMap<>();
+        originalDates.put(BusinessDateType.BUSINESS_DATE, LocalDate.of(2026, 4, 15));
+
+        SelfServiceNotificationEvent event = new SelfServiceNotificationEvent(
+                this, SelfServiceNotificationEvent.Type.LOGIN_SUCCESS,
+                42L, "Alice", "Smith", "alice", "alice@example.com", "555-0100",
+                true, "10.0.0.1", Locale.US, originalTenant, originalDates);
+
+        ThreadLocalContextUtil.reset();
+
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(1);
+        executor.setMaxPoolSize(1);
+        executor.setQueueCapacity(10);
+        executor.setThreadNamePrefix("test-notif-");
+        executor.setTaskDecorator(runnable -> {
+            FineractPlatformTenant captured = null;
+            try {
+                captured = ThreadLocalContextUtil.getTenant();
+            } catch (IllegalStateException ignored) {
+            }
+            final FineractPlatformTenant decoratorTenant = captured;
+            return () -> {
+                try {
+                    if (decoratorTenant != null) {
+                        ThreadLocalContextUtil.setTenant(decoratorTenant);
+                    }
+                    runnable.run();
+                } finally {
+                    ThreadLocalContextUtil.reset();
+                }
+            };
+        });
+        executor.initialize();
+
+        AtomicReference<String> workerTenantId = new AtomicReference<>();
+        AtomicReference<LocalDate> workerBusinessDate = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+
+        try {
+            executor.execute(() -> {
+                try {
+                    service.restoreTenantContext(event);
+                    try {
+                        workerTenantId.set(ThreadLocalContextUtil.getTenant().getTenantIdentifier());
+                    } catch (IllegalStateException e) {
+                        workerTenantId.set("NO_TENANT");
+                    }
+                    try {
+                        workerBusinessDate.set(
+                                ThreadLocalContextUtil.getBusinessDates().get(BusinessDateType.BUSINESS_DATE));
+                    } catch (Exception ignored) {
+                    }
+                } finally {
+                    latch.countDown();
+                }
+            });
+
+            boolean completed = latch.await(5, TimeUnit.SECONDS);
+            assertEquals(true, completed, "Async task should complete within timeout");
+            assertNotNull(workerTenantId.get(), "Worker thread should have seen a tenant");
+            assertEquals("default", workerTenantId.get(),
+                    "Worker thread should see the tenant from the event, not from TaskDecorator (which captured null)");
+            assertEquals(LocalDate.of(2026, 4, 15), workerBusinessDate.get(),
+                    "Worker thread should see the business dates from the event");
+        } finally {
+            executor.shutdown();
+        }
+    }
+
+    /**
+     * Verifies that when both the TaskDecorator and the event carry a tenant,
+     * {@code restoreTenantContext} ensures the event-carried tenant takes precedence.
+     */
+    @Test
+    void eventTenant_TakesPrecedenceOverDecoratorTenant() throws InterruptedException {
+        FineractPlatformTenant decoratorTenant = new FineractPlatformTenant(1L, "decorator-tenant", "Decorator", "UTC", null);
+        ThreadLocalContextUtil.setTenant(decoratorTenant);
+
+        FineractPlatformTenant eventTenant = new FineractPlatformTenant(2L, "event-tenant", "Event", "UTC", null);
+        SelfServiceNotificationEvent event = new SelfServiceNotificationEvent(
+                this, SelfServiceNotificationEvent.Type.USER_ACTIVATED,
+                99L, "Bob", "Jones", "bob", "bob@example.com", null,
+                true, null, Locale.US, eventTenant, null);
+
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(1);
+        executor.setMaxPoolSize(1);
+        executor.setTaskDecorator(runnable -> {
+            FineractPlatformTenant captured = ThreadLocalContextUtil.getTenant();
+            return () -> {
+                try {
+                    if (captured != null) {
+                        ThreadLocalContextUtil.setTenant(captured);
+                    }
+                    runnable.run();
+                } finally {
+                    ThreadLocalContextUtil.reset();
+                }
+            };
+        });
+        executor.initialize();
+
+        AtomicReference<String> workerTenantId = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+
+        try {
+            executor.execute(() -> {
+                try {
+                    service.restoreTenantContext(event);
+                    workerTenantId.set(ThreadLocalContextUtil.getTenant().getTenantIdentifier());
+                } finally {
+                    latch.countDown();
+                }
+            });
+
+            boolean completed = latch.await(5, TimeUnit.SECONDS);
+            assertEquals(true, completed);
+            assertEquals("event-tenant", workerTenantId.get(),
+                    "Event-carried tenant should take precedence over TaskDecorator-captured tenant");
+        } finally {
+            executor.shutdown();
+        }
+    }
+
+    /**
+     * Verifies that {@link SelfServiceNotificationEvent#withTenantContext} captures
+     * the current thread's tenant, while the plain constructor does not.
+     */
+    @Test
+    void withTenantContext_ProducesEventWithTenantWhilePlainConstructorDoesNot() {
+        FineractPlatformTenant tenant = new FineractPlatformTenant(5L, "captured-tenant", "Captured", "UTC", null);
+        ThreadLocalContextUtil.setTenant(tenant);
+
+        SelfServiceNotificationEvent withContext = SelfServiceNotificationEvent.withTenantContext(
+                this, SelfServiceNotificationEvent.Type.LOGIN_SUCCESS, 1L, "A", "B", "ab",
+                "ab@test.com", null, true, null, Locale.US);
+
+        SelfServiceNotificationEvent withoutContext = new SelfServiceNotificationEvent(
+                this, SelfServiceNotificationEvent.Type.LOGIN_SUCCESS, 1L, "A", "B", "ab",
+                "ab@test.com", null, true, null, Locale.US);
+
+        assertNotNull(withContext.getTenant(), "withTenantContext should capture tenant");
+        assertEquals("captured-tenant", withContext.getTenant().getTenantIdentifier());
+        assertNull(withoutContext.getTenant(), "Plain constructor should NOT capture tenant");
+    }
+}

--- a/src/test/java/org/apache/fineract/selfservice/registration/service/SelfServiceAuthorizationTokenServiceTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/registration/service/SelfServiceAuthorizationTokenServiceTest.java
@@ -1,7 +1,7 @@
 package org.apache.fineract.selfservice.registration.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 import java.time.LocalDateTime;
@@ -22,7 +22,7 @@ class SelfServiceAuthorizationTokenServiceTest {
 
         String token = service.generateToken();
 
-        assertTrue(token.matches("^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"));
+        assertThat(token).matches("^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$");
     }
 
     @Test
@@ -33,7 +33,7 @@ class SelfServiceAuthorizationTokenServiceTest {
 
         String token = service.generateToken();
 
-        assertTrue(token.matches("\\d{8}"));
+        assertThat(token).matches("\\d{8}");
     }
 
     @Test
@@ -44,7 +44,8 @@ class SelfServiceAuthorizationTokenServiceTest {
 
         String token = service.generateToken();
 
-        assertTrue(token.matches("\\d{8}"));
+        // MIN_NUMERIC_LENGTH is 6 (backward compat with existing mobile apps)
+        assertThat(token).matches("\\d{6}");
     }
 
     @Test


### PR DESCRIPTION


Embed FineractPlatformTenant and business dates into SelfServiceNotificationEvent so async worker threads can restore the correct tenant context independently of the HTTP request thread lifecycle.

Root cause: afterCommit() callbacks fire after Fineract's auth filter clears ThreadLocalContextUtil, leaving the TaskDecorator with null tenant. Async notification threads therefore ran under [no-tenant] and failed on any DB lookup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Notifications now carry tenant and business-date context so async delivery preserves the originating tenant and business date.

* **Bug Fixes**
  * Restored tenant/business-date context during notification processing to prevent context loss across async boundaries.

* **Tests**
  * Added integration and unit tests validating tenant and business-date propagation and precedence.
  * Improved test isolation for SMTP fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->