### PR TITLE
MX-244: fix tenant context and SMTP fallback test assertions

### DIFF
--- a/src/test/java/org/apache/fineract/selfservice/notification/SelfServiceSmtpFallbackIntegrationTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/notification/SelfServiceSmtpFallbackIntegrationTest.java
@@ -148,20 +148,38 @@ public class SelfServiceSmtpFallbackIntegrationTest {
         assertTrue(completionListener.awaitCompletion(1),
                 "Second notification should complete within timeout");
 
-        // Assert log-once behavior
-        List<ILoggingEvent> smtpLogs = notificationLogAppender.list.stream()
-                .filter(e -> e.getFormattedMessage().contains("SMTP configuration unavailable"))
-                .collect(Collectors.toList());
+        // Poll for expected logs with a timeout. completionListener.awaitCompletion() only
+        // guarantees the sibling listener finished, not that the notification handler has
+        // emitted all logs. Both listeners run independently on the same thread pool, so
+        // under slow execution or high load the logs may not be present yet.
+        List<ILoggingEvent> smtpLogs = java.util.Collections.emptyList();
+        long warnCount = 0;
+        long debugCount = 0;
+        boolean warnMentionsSuppression = false;
+        long deadlineNanos = System.nanoTime() + TimeUnit.SECONDS.toNanos(3);
+        do {
+            smtpLogs = new java.util.ArrayList<>(notificationLogAppender.list).stream()
+                    .filter(e -> e.getFormattedMessage().contains("SMTP configuration unavailable"))
+                    .collect(Collectors.toList());
+            warnCount = smtpLogs.stream().filter(e -> e.getLevel() == Level.WARN).count();
+            debugCount = smtpLogs.stream().filter(e -> e.getLevel() == Level.DEBUG).count();
+            warnMentionsSuppression = smtpLogs.stream()
+                    .filter(e -> e.getLevel() == Level.WARN)
+                    .anyMatch(e -> e.getFormattedMessage().contains("Further config errors"));
+            if (smtpLogs.size() >= 2 && warnCount == 1 && debugCount >= 1 && warnMentionsSuppression) {
+                break;
+            }
+            Thread.sleep(25);
+        } while (System.nanoTime() < deadlineNanos);
 
         assertTrue(smtpLogs.size() >= 2, "Expected at least 2 SMTP config log events, got " + smtpLogs.size());
 
-        assertEquals(Level.WARN, smtpLogs.get(0).getLevel(),
-                "First SMTP config error should be logged at WARN");
-        assertTrue(smtpLogs.get(0).getFormattedMessage().contains("Further config errors"),
-                "First WARN should indicate suppression of future errors");
-
-        assertEquals(Level.DEBUG, smtpLogs.get(1).getLevel(),
-                "Subsequent SMTP config errors should be logged at DEBUG");
+        assertEquals(1, warnCount,
+                "Exactly one SMTP config error should be logged at WARN (the first to hit compareAndSet)");
+        assertTrue(warnMentionsSuppression,
+                "The WARN log should indicate suppression of future errors");
+        assertTrue(debugCount >= 1,
+                "Subsequent SMTP config errors should be logged at DEBUG, got " + debugCount);
     }
 
     @Test

--- a/src/test/java/org/apache/fineract/selfservice/notification/service/SelfServiceNotificationServiceTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/notification/service/SelfServiceNotificationServiceTest.java
@@ -321,12 +321,25 @@ class SelfServiceNotificationServiceTest {
 
         service.handleNotification(event);
 
-        // Verify tenant was restored on this thread
-        assertEquals("default", ThreadLocalContextUtil.getTenant().getTenantIdentifier(),
-                "Tenant should be restored from event payload");
-        assertEquals(LocalDate.of(2026, 4, 15),
-                ThreadLocalContextUtil.getBusinessDates().get(BusinessDateType.BUSINESS_DATE),
-                "Business dates should be restored from event payload");
+        // The finally block in handleNotification() correctly resets ThreadLocal to prevent
+        // tenant context leakage in the thread pool, so we verify the restore-then-cleanup
+        // lifecycle via log output instead of post-call ThreadLocal state.
+
+        // 1. Verify tenant was restored from the event during execution
+        List<ILoggingEvent> restoredLogs = logAppender.list.stream()
+                .filter(e -> e.getLevel() == Level.DEBUG)
+                .filter(e -> e.getFormattedMessage().contains("Restored tenant 'default' from notification event"))
+                .collect(Collectors.toList());
+        assertEquals(1, restoredLogs.size(),
+                "Should log that tenant was restored from event payload");
+
+        // 2. Verify cleanup happened (prevents thread pool context leakage)
+        List<ILoggingEvent> resetLogs = logAppender.list.stream()
+                .filter(e -> e.getLevel() == Level.DEBUG)
+                .filter(e -> e.getFormattedMessage().contains("Reset tenant context"))
+                .collect(Collectors.toList());
+        assertEquals(1, resetLogs.size(),
+                "Should log that tenant context was reset after processing");
     }
 
     @Test


### PR DESCRIPTION
Fix RestoresTenantFromEvent test to verify tenant restoration via log output instead of post-call ThreadLocal state, since the finally block correctly resets context to prevent thread pool leakage.

Also fix SmtpFallbackIntegrationTest to use count-based assertions instead of positional log ordering, since async threads can interleave non-deterministically on the 2-thread notification pool.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test robustness for SMTP notification logging by refactoring log assertions to be order-independent and aggregate count-based instead of positional.
  * Enhanced tenant restoration test to verify behavior through log message validation rather than direct state inspection, accounting for asynchronous processing patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->