### PR TITLE
MX-249: add scheduled job to purge expired 2FA tokens

### DIFF
--- a/src/main/java/org/apache/fineract/selfservice/registration/domain/SelfServiceRegistrationRepository.java
+++ b/src/main/java/org/apache/fineract/selfservice/registration/domain/SelfServiceRegistrationRepository.java
@@ -14,10 +14,13 @@
  */
 package org.apache.fineract.selfservice.registration.domain;
 
+import java.time.LocalDateTime;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface SelfServiceRegistrationRepository
     extends JpaRepository<SelfServiceRegistration, Long>,
@@ -70,4 +73,20 @@ public interface SelfServiceRegistrationRepository
   SelfServiceRegistration getRequestByExternalAuthorizationToken(
       @Param("externalAuthorizationToken") String externalAuthorizationToken,
       @Param("requestType") SelfServiceRequestType requestType);
+
+  /**
+   * Deletes all self-service registration requests whose expiry timestamp is strictly before the
+   * supplied cutoff.
+   *
+   * <p>This covers all request types (REGISTRATION, ENROLLMENT, PASSWORD_RESET) regardless of
+   * their consumed status — an expired token is unusable whether or not it was consumed.
+   *
+   * @param cutoff reference timestamp; rows with {@code expiresAt < cutoff} are deleted
+   * @return number of rows deleted
+   */
+  @Modifying
+  @Transactional
+  @Query(
+      "DELETE FROM SelfServiceRegistration r WHERE r.expiresAt IS NOT NULL AND r.expiresAt < :cutoff")
+  int deleteExpiredRequests(@Param("cutoff") LocalDateTime cutoff);
 }

--- a/src/main/java/org/apache/fineract/selfservice/registration/service/ExpiredTokenPurgeScheduler.java
+++ b/src/main/java/org/apache/fineract/selfservice/registration/service/ExpiredTokenPurgeScheduler.java
@@ -1,0 +1,135 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.fineract.selfservice.registration.service;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.fineract.infrastructure.core.config.FineractProperties;
+import org.apache.fineract.infrastructure.core.domain.FineractPlatformTenant;
+import org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil;
+import org.apache.fineract.infrastructure.core.service.tenant.TenantDetailsService;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.core.env.Environment;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * Scheduled task that purges expired self-service and 2FA tokens across all tenants.
+ *
+ * <p>Enabled by default; disable entirely via {@code mifos.self.service.token.purge.enabled=false}.
+ *
+ * <p><strong>Instance type awareness:</strong> Per Fineract's instance type architecture, batch
+ * jobs should only run on batch-enabled instances. This scheduler checks {@link
+ * FineractProperties.FineractModeProperties#isBatchWorkerEnabled()} at runtime and skips execution
+ * on read-only or write-only instances. See <a
+ * href="https://fineract.apache.org/docs/current/#_configuring_instance_type_via_environment_variables">
+ * Fineract Instance Types</a>.
+ *
+ * <p><strong>Multi-instance safety:</strong> The purge queries are idempotent {@code DELETE WHERE
+ * expired < cutoff} statements. If multiple batch instances load this plugin, concurrent
+ * execution is safe — worst case some queries delete 0 rows.
+ *
+ * <p><strong>Tenant context:</strong> Each tenant is processed in its own {@code try/finally} block
+ * that sets and clears {@link ThreadLocalContextUtil}. This is mandatory because Spring's
+ * {@code @Scheduled} thread pool reuses threads — a leaked tenant context would silently corrupt
+ * subsequent executions on the same thread.
+ */
+@Component
+@Slf4j
+@RequiredArgsConstructor
+@ConditionalOnProperty(
+    name = "mifos.self.service.token.purge.enabled",
+    havingValue = "true",
+    matchIfMissing = true)
+public class ExpiredTokenPurgeScheduler {
+
+  private final TenantDetailsService tenantDetailsService;
+  private final ExpiredTokenPurgeService purgeService;
+  private final Environment env;
+  private final FineractProperties fineractProperties;
+
+  /**
+   * Entry point invoked by Spring's task scheduler at the configured cron interval.
+   *
+   * <p>Default cron: every hour on the hour ({@code 0 0 * * * *}).
+   */
+  @Scheduled(cron = "${mifos.self.service.token.purge.cron:0 0 * * * *}")
+  public void purgeExpiredTokens() {
+    if (!isBatchInstance()) {
+      log.debug("Skipping expired token purge — this instance is not batch-enabled");
+      return;
+    }
+    log.info("Starting expired token purge cycle");
+    List<FineractPlatformTenant> tenants = tenantDetailsService.findAllTenants();
+
+    for (FineractPlatformTenant tenant : tenants) {
+      try {
+        ThreadLocalContextUtil.setTenant(tenant);
+
+        purgeService.purgeExpiredSelfServiceTokens();
+
+        if (isTwoFactorPurgeEnabled()) {
+          purgeService.purgeExpiredTwoFactorAccessTokens();
+        }
+      } catch (Exception e) {
+        log.error(
+            "Expired token purge failed for tenant: {}", tenant.getTenantIdentifier(), e);
+        // Continue to next tenant — one failure must not block others
+      } finally {
+        ThreadLocalContextUtil.clearTenant();
+      }
+    }
+    log.info("Expired token purge cycle completed for {} tenant(s)", tenants.size());
+  }
+
+  /**
+   * 2FA purge requires <strong>both</strong> conditions to be true:
+   *
+   * <ol>
+   *   <li>Fineract core has 2FA enabled ({@code fineract.security.2fa.enabled=true}) — if core 2FA
+   *       is disabled, the {@code twofactor_access_token} table is not populated and purging it is
+   *       a no-op.
+   *   <li>The plugin's own 2FA purge switch is not explicitly disabled ({@code
+   *       mifos.self.service.token.purge.2fa.enabled != false}) — allows operators to manage
+   *       cleanup externally if desired.
+   * </ol>
+   */
+  boolean isTwoFactorPurgeEnabled() {
+    boolean coreTwoFactorEnabled =
+        Boolean.TRUE.equals(env.getProperty("fineract.security.2fa.enabled", Boolean.class, false));
+    if (!coreTwoFactorEnabled) {
+      return false;
+    }
+    boolean pluginTwoFactorPurgeEnabled =
+        !Boolean.FALSE.equals(
+            env.getProperty("mifos.self.service.token.purge.2fa.enabled", Boolean.class, true));
+    return pluginTwoFactorPurgeEnabled;
+  }
+
+  /**
+   * Returns {@code true} if this Fineract instance is configured for batch processing.
+   *
+   * <p>Per Fineract's instance type architecture, scheduled jobs should only run on
+   * batch-worker-enabled or batch-manager-enabled instances. Read-only and write-only instances
+   * must not execute background jobs.
+   *
+   * @see FineractProperties.FineractModeProperties
+   */
+  boolean isBatchInstance() {
+    FineractProperties.FineractModeProperties mode = fineractProperties.getMode();
+    return mode != null && (mode.isBatchWorkerEnabled() || mode.isBatchManagerEnabled());
+  }
+}

--- a/src/main/java/org/apache/fineract/selfservice/registration/service/ExpiredTokenPurgeService.java
+++ b/src/main/java/org/apache/fineract/selfservice/registration/service/ExpiredTokenPurgeService.java
@@ -1,0 +1,90 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.fineract.selfservice.registration.service;
+
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.fineract.infrastructure.core.service.DateUtils;
+import org.apache.fineract.selfservice.registration.domain.SelfServiceRegistrationRepository;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Purges expired tokens from both the plugin-owned {@code request_audit_table} and the Fineract
+ * core-owned {@code twofactor_access_token} table.
+ *
+ * <p><strong>Data access strategy:</strong>
+ *
+ * <ul>
+ *   <li>{@code request_audit_table} — uses JPQL via {@link SelfServiceRegistrationRepository}
+ *       because the plugin owns the {@code SelfServiceRegistration} entity.
+ *   <li>{@code twofactor_access_token} — uses raw SQL via {@link JdbcTemplate} because the {@code
+ *       TFAccessToken} entity is owned by the {@code fineract-security} module and declaring a
+ *       duplicate mapping would cause classloader conflicts at runtime.
+ * </ul>
+ *
+ * <p>The injected {@link JdbcTemplate} <strong>must</strong> be backed by Fineract's {@code
+ * AbstractRoutingDataSource} (the routing datasource) so that {@code
+ * ThreadLocalContextUtil.setTenant()} routes SQL to the correct tenant schema.
+ */
+@Slf4j
+@RequiredArgsConstructor
+public class ExpiredTokenPurgeService {
+
+  private final SelfServiceRegistrationRepository selfServiceRegistrationRepository;
+  private final JdbcTemplate jdbcTemplate;
+
+  /**
+   * Deletes all rows from {@code request_audit_table} where {@code expires_at < cutoff}.
+   *
+   * <p>Uses {@link DateUtils#getLocalDateTimeOfSystem()} as the cutoff — the same clock source used
+   * by {@link org.apache.fineract.selfservice.registration.domain.SelfServiceRegistration#isExpired(LocalDateTime)}
+   * and throughout the registration service when creating tokens. This eliminates timezone
+   * divergence between token creation and purge evaluation.
+   *
+   * @return number of rows deleted
+   */
+  @Transactional
+  public int purgeExpiredSelfServiceTokens() {
+    LocalDateTime cutoff = DateUtils.getLocalDateTimeOfSystem();
+    int deleted = selfServiceRegistrationRepository.deleteExpiredRequests(cutoff);
+    if (deleted > 0) {
+      log.info("Purged {} expired self-service token(s) from request_audit_table", deleted);
+    } else {
+      log.debug("No expired self-service tokens to purge");
+    }
+    return deleted;
+  }
+
+  /**
+   * Deletes all rows from {@code twofactor_access_token} where {@code valid_to < NOW()}.
+   *
+   * <p>Uses database-side {@code NOW()} to match Fineract core's {@code TFAccessToken.isValid()}
+   * which delegates to the database server's clock via {@code DateUtils.getLocalDateTimeOfTenant()}.
+   * This avoids Java-to-DB clock skew.
+   *
+   * @return number of rows deleted
+   */
+  public int purgeExpiredTwoFactorAccessTokens() {
+    int deleted = jdbcTemplate.update("DELETE FROM twofactor_access_token WHERE valid_to < NOW()");
+    if (deleted > 0) {
+      log.info("Purged {} expired 2FA access token(s) from twofactor_access_token", deleted);
+    } else {
+      log.debug("No expired 2FA access tokens to purge");
+    }
+    return deleted;
+  }
+}

--- a/src/main/java/org/apache/fineract/selfservice/registration/starter/ExpiredTokenPurgeConfiguration.java
+++ b/src/main/java/org/apache/fineract/selfservice/registration/starter/ExpiredTokenPurgeConfiguration.java
@@ -1,0 +1,67 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.fineract.selfservice.registration.starter;
+
+import org.apache.fineract.infrastructure.core.config.FineractProperties;
+import org.apache.fineract.infrastructure.core.service.tenant.TenantDetailsService;
+import org.apache.fineract.selfservice.registration.domain.SelfServiceRegistrationRepository;
+import org.apache.fineract.selfservice.registration.service.ExpiredTokenPurgeScheduler;
+import org.apache.fineract.selfservice.registration.service.ExpiredTokenPurgeService;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+/**
+ * Spring configuration for the expired token purge subsystem.
+ *
+ * <p>Activates {@link EnableScheduling} so that {@link ExpiredTokenPurgeScheduler}'s
+ * {@code @Scheduled} method is picked up by the Spring task scheduler.
+ *
+ * <p><strong>DataSource routing contract:</strong> The {@link JdbcTemplate} bean injected into
+ * {@link ExpiredTokenPurgeService} must be backed by Fineract's {@code AbstractRoutingDataSource}
+ * (the routing datasource) so that {@code ThreadLocalContextUtil.setTenant()} routes SQL to the
+ * correct tenant schema. In Fineract's standard auto-configuration, the primary {@code DataSource}
+ * bean is already the routing datasource, so {@code @Autowired JdbcTemplate} resolves correctly.
+ */
+@Configuration
+@EnableScheduling
+public class ExpiredTokenPurgeConfiguration {
+
+  @Bean
+  @ConditionalOnMissingBean(ExpiredTokenPurgeService.class)
+  public ExpiredTokenPurgeService expiredTokenPurgeService(
+      SelfServiceRegistrationRepository repository, JdbcTemplate jdbcTemplate) {
+    return new ExpiredTokenPurgeService(repository, jdbcTemplate);
+  }
+
+  @Bean
+  @ConditionalOnMissingBean(ExpiredTokenPurgeScheduler.class)
+  @ConditionalOnProperty(
+      name = "mifos.self.service.token.purge.enabled",
+      havingValue = "true",
+      matchIfMissing = true)
+  public ExpiredTokenPurgeScheduler expiredTokenPurgeScheduler(
+      TenantDetailsService tenantDetailsService,
+      ExpiredTokenPurgeService purgeService,
+      Environment env,
+      FineractProperties fineractProperties) {
+    return new ExpiredTokenPurgeScheduler(
+        tenantDetailsService, purgeService, env, fineractProperties);
+  }
+}

--- a/src/test/java/org/apache/fineract/selfservice/registration/service/ExpiredTokenPurgeSchedulerTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/registration/service/ExpiredTokenPurgeSchedulerTest.java
@@ -1,0 +1,429 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.fineract.selfservice.registration.service;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.apache.fineract.infrastructure.core.config.FineractProperties;
+import org.apache.fineract.infrastructure.core.domain.FineractPlatformTenant;
+import org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil;
+import org.apache.fineract.infrastructure.core.service.tenant.TenantDetailsService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.env.Environment;
+
+/**
+ * Unit tests for {@link ExpiredTokenPurgeScheduler}.
+ *
+ * <p>These tests call the real {@link ThreadLocalContextUtil} static methods (set/clear) rather
+ * than attempting static mocking, which is consistent with the testing pattern used across this
+ * codebase (see {@code SelfServiceRegistrationWritePlatformServiceImplTest},
+ * {@code AppSelfServiceUserTest}, etc.).
+ *
+ * <p>After each test, the {@code @AfterEach} method resets the ThreadLocal to prevent leaking state
+ * into subsequent tests.
+ */
+@ExtendWith(MockitoExtension.class)
+class ExpiredTokenPurgeSchedulerTest {
+
+  @Mock private TenantDetailsService tenantDetailsService;
+  @Mock private ExpiredTokenPurgeService purgeService;
+  @Mock private Environment env;
+  @Mock private FineractProperties fineractProperties;
+  @Mock private FineractProperties.FineractModeProperties modeProperties;
+
+  private ExpiredTokenPurgeScheduler scheduler;
+
+  @BeforeEach
+  void setUp() {
+    scheduler =
+        new ExpiredTokenPurgeScheduler(tenantDetailsService, purgeService, env, fineractProperties);
+    // Default: batch-enabled instance (the normal case for running scheduled jobs).
+    // Lenient because tests that only exercise helper methods (e.g. isTwoFactorPurgeEnabled)
+    // never call purgeExpiredTokens() and therefore never consume these stubs.
+    lenient().when(fineractProperties.getMode()).thenReturn(modeProperties);
+    lenient().when(modeProperties.isBatchWorkerEnabled()).thenReturn(true);
+  }
+
+  @AfterEach
+  void tearDown() {
+    // Safety: ensure no leaked tenant context from tests
+    try {
+      ThreadLocalContextUtil.reset();
+    } catch (Exception ignored) {
+    }
+  }
+
+  // ── Tenant iteration ──────────────────────────────────────────────────────
+
+  @Test
+  void purgeExpiredTokens_iteratesAllTenants() {
+    FineractPlatformTenant tenant1 = createTenant("tenant1");
+    FineractPlatformTenant tenant2 = createTenant("tenant2");
+    FineractPlatformTenant tenant3 = createTenant("tenant3");
+    when(tenantDetailsService.findAllTenants())
+        .thenReturn(Arrays.asList(tenant1, tenant2, tenant3));
+
+    when(purgeService.purgeExpiredSelfServiceTokens()).thenReturn(0);
+
+    scheduler.purgeExpiredTokens();
+
+    // Self-service purge invoked once per tenant
+    verify(purgeService, times(3)).purgeExpiredSelfServiceTokens();
+  }
+
+  @Test
+  void purgeExpiredTokens_handlesEmptyTenantList() {
+    when(tenantDetailsService.findAllTenants()).thenReturn(Collections.emptyList());
+
+    assertDoesNotThrow(() -> scheduler.purgeExpiredTokens());
+
+    verify(purgeService, never()).purgeExpiredSelfServiceTokens();
+    verify(purgeService, never()).purgeExpiredTwoFactorAccessTokens();
+  }
+
+  @Test
+  void purgeExpiredTokens_handlesSingleTenant() {
+    FineractPlatformTenant tenant = createTenant("only-tenant");
+    when(tenantDetailsService.findAllTenants()).thenReturn(List.of(tenant));
+
+    when(purgeService.purgeExpiredSelfServiceTokens()).thenReturn(5);
+
+    scheduler.purgeExpiredTokens();
+
+    verify(purgeService, times(1)).purgeExpiredSelfServiceTokens();
+  }
+
+  // ── Error isolation ───────────────────────────────────────────────────────
+
+  @Test
+  void purgeExpiredTokens_continuesOnTenantFailure() {
+    FineractPlatformTenant tenant1 = createTenant("tenant1");
+    FineractPlatformTenant tenant2 = createTenant("tenant2");
+    FineractPlatformTenant tenant3 = createTenant("tenant3");
+    when(tenantDetailsService.findAllTenants())
+        .thenReturn(Arrays.asList(tenant1, tenant2, tenant3));
+
+    // Sequential stubbing: tenant1 succeeds, tenant2 fails, tenant3 succeeds
+    when(purgeService.purgeExpiredSelfServiceTokens())
+        .thenReturn(1)
+        .thenThrow(new RuntimeException("DB connection lost"))
+        .thenReturn(3);
+
+    assertDoesNotThrow(() -> scheduler.purgeExpiredTokens());
+
+    // All three tenants attempted despite tenant2 failure
+    verify(purgeService, times(3)).purgeExpiredSelfServiceTokens();
+  }
+
+  @Test
+  void purgeExpiredTokens_continuesWhen2faPurgeFails() {
+    FineractPlatformTenant tenant1 = createTenant("tenant1");
+    FineractPlatformTenant tenant2 = createTenant("tenant2");
+    when(tenantDetailsService.findAllTenants()).thenReturn(Arrays.asList(tenant1, tenant2));
+
+    // Enable 2FA purge
+    when(env.getProperty("fineract.security.2fa.enabled", Boolean.class, false)).thenReturn(true);
+    when(env.getProperty("mifos.self.service.token.purge.2fa.enabled", Boolean.class, true))
+        .thenReturn(true);
+
+    // Self-service purge always succeeds
+    when(purgeService.purgeExpiredSelfServiceTokens()).thenReturn(0);
+    // 2FA purge: tenant1 fails, tenant2 succeeds
+    when(purgeService.purgeExpiredTwoFactorAccessTokens())
+        .thenThrow(new RuntimeException("twofactor_access_token table missing"))
+        .thenReturn(5);
+
+    assertDoesNotThrow(() -> scheduler.purgeExpiredTokens());
+
+    // Self-service purge attempted for both tenants
+    verify(purgeService, times(2)).purgeExpiredSelfServiceTokens();
+    // 2FA purge attempted for both tenants (first fails, second succeeds)
+    verify(purgeService, times(2)).purgeExpiredTwoFactorAccessTokens();
+  }
+
+  @Test
+  void purgeExpiredTokens_doesNotAbortOnFirstTenantException() {
+    FineractPlatformTenant tenant1 = createTenant("bad");
+    FineractPlatformTenant tenant2 = createTenant("good");
+    when(tenantDetailsService.findAllTenants()).thenReturn(Arrays.asList(tenant1, tenant2));
+
+    // First tenant always throws
+    when(purgeService.purgeExpiredSelfServiceTokens())
+        .thenThrow(new RuntimeException("bad tenant"))
+        .thenReturn(10);
+
+    assertDoesNotThrow(() -> scheduler.purgeExpiredTokens());
+
+    verify(purgeService, times(2)).purgeExpiredSelfServiceTokens();
+  }
+
+  // ── Tenant context lifecycle (try/finally) ────────────────────────────────
+
+  @Test
+  void purgeExpiredTokens_clearsTenantContextAfterSuccess() {
+    FineractPlatformTenant tenant = createTenant("clean-tenant");
+    when(tenantDetailsService.findAllTenants()).thenReturn(List.of(tenant));
+    when(purgeService.purgeExpiredSelfServiceTokens()).thenReturn(0);
+
+    scheduler.purgeExpiredTokens();
+
+    // After the scheduler completes, the tenant context should be cleared.
+    // ThreadLocalContextUtil.getTenant() would throw or return null.
+    try {
+      FineractPlatformTenant leakedTenant = ThreadLocalContextUtil.getTenant();
+      // If we get here without exception, the context was NOT cleared properly
+      assertNull(leakedTenant, "Tenant context should be cleared after purge");
+    } catch (IllegalStateException e) {
+      // Expected — getTenant() throws when no tenant is set = context was cleared
+    }
+  }
+
+  @Test
+  void purgeExpiredTokens_clearsTenantContextAfterException() {
+    FineractPlatformTenant tenant = createTenant("failing-tenant");
+    when(tenantDetailsService.findAllTenants()).thenReturn(List.of(tenant));
+    when(purgeService.purgeExpiredSelfServiceTokens())
+        .thenThrow(new RuntimeException("unexpected"));
+
+    assertDoesNotThrow(() -> scheduler.purgeExpiredTokens());
+
+    // Tenant context must still be cleared (try/finally contract)
+    try {
+      FineractPlatformTenant leakedTenant = ThreadLocalContextUtil.getTenant();
+      assertNull(leakedTenant, "Tenant context should be cleared even after exception");
+    } catch (IllegalStateException e) {
+      // Expected — means context was properly cleared
+    }
+  }
+
+  // ── 2FA conditional logic (isTwoFactorPurgeEnabled) ───────────────────────
+
+  @Test
+  void isTwoFactorPurgeEnabled_returnsTrueWhenBothEnabled() {
+    when(env.getProperty("fineract.security.2fa.enabled", Boolean.class, false)).thenReturn(true);
+    when(env.getProperty("mifos.self.service.token.purge.2fa.enabled", Boolean.class, true))
+        .thenReturn(true);
+
+    assertTrue(scheduler.isTwoFactorPurgeEnabled());
+  }
+
+  @Test
+  void isTwoFactorPurgeEnabled_returnsFalseWhenCoreDisabled() {
+    when(env.getProperty("fineract.security.2fa.enabled", Boolean.class, false)).thenReturn(false);
+
+    assertFalse(scheduler.isTwoFactorPurgeEnabled());
+  }
+
+  @Test
+  void isTwoFactorPurgeEnabled_returnsFalseWhenPluginOptOut() {
+    when(env.getProperty("fineract.security.2fa.enabled", Boolean.class, false)).thenReturn(true);
+    when(env.getProperty("mifos.self.service.token.purge.2fa.enabled", Boolean.class, true))
+        .thenReturn(false);
+
+    assertFalse(scheduler.isTwoFactorPurgeEnabled());
+  }
+
+  @Test
+  void isTwoFactorPurgeEnabled_returnsFalseWhenBothDisabled() {
+    when(env.getProperty("fineract.security.2fa.enabled", Boolean.class, false)).thenReturn(false);
+
+    assertFalse(scheduler.isTwoFactorPurgeEnabled());
+  }
+
+  @Test
+  void isTwoFactorPurgeEnabled_coreDisabledTrumpsPluginEnabled() {
+    // Even if plugin says "enable 2FA purge", core being disabled means no tokens exist
+    when(env.getProperty("fineract.security.2fa.enabled", Boolean.class, false)).thenReturn(false);
+
+    assertFalse(scheduler.isTwoFactorPurgeEnabled());
+    // Plugin property should not even be checked when core is disabled
+  }
+
+  // ── 2FA conditional in scheduler flow ─────────────────────────────────────
+
+  @Test
+  void purgeExpiredTokens_skips2faWhenCoreDisabled() {
+    FineractPlatformTenant tenant = createTenant("tenant");
+    when(tenantDetailsService.findAllTenants()).thenReturn(List.of(tenant));
+    when(purgeService.purgeExpiredSelfServiceTokens()).thenReturn(0);
+
+    // Core 2FA disabled
+    when(env.getProperty("fineract.security.2fa.enabled", Boolean.class, false)).thenReturn(false);
+
+    scheduler.purgeExpiredTokens();
+
+    verify(purgeService, never()).purgeExpiredTwoFactorAccessTokens();
+    verify(purgeService, times(1)).purgeExpiredSelfServiceTokens();
+  }
+
+  @Test
+  void purgeExpiredTokens_skips2faWhenPluginOptOut() {
+    FineractPlatformTenant tenant = createTenant("tenant");
+    when(tenantDetailsService.findAllTenants()).thenReturn(List.of(tenant));
+    when(purgeService.purgeExpiredSelfServiceTokens()).thenReturn(0);
+
+    // Core enabled but plugin opt-out
+    when(env.getProperty("fineract.security.2fa.enabled", Boolean.class, false)).thenReturn(true);
+    when(env.getProperty("mifos.self.service.token.purge.2fa.enabled", Boolean.class, true))
+        .thenReturn(false);
+
+    scheduler.purgeExpiredTokens();
+
+    verify(purgeService, never()).purgeExpiredTwoFactorAccessTokens();
+    verify(purgeService, times(1)).purgeExpiredSelfServiceTokens();
+  }
+
+  @Test
+  void purgeExpiredTokens_purges2faWhenBothEnabled() {
+    FineractPlatformTenant tenant = createTenant("tenant");
+    when(tenantDetailsService.findAllTenants()).thenReturn(List.of(tenant));
+    when(purgeService.purgeExpiredSelfServiceTokens()).thenReturn(0);
+    when(purgeService.purgeExpiredTwoFactorAccessTokens()).thenReturn(0);
+
+    // Both flags enabled
+    when(env.getProperty("fineract.security.2fa.enabled", Boolean.class, false)).thenReturn(true);
+    when(env.getProperty("mifos.self.service.token.purge.2fa.enabled", Boolean.class, true))
+        .thenReturn(true);
+
+    scheduler.purgeExpiredTokens();
+
+    verify(purgeService, times(1)).purgeExpiredTwoFactorAccessTokens();
+    verify(purgeService, times(1)).purgeExpiredSelfServiceTokens();
+  }
+
+  @Test
+  void purgeExpiredTokens_skips2faWhenBothDisabled() {
+    FineractPlatformTenant tenant = createTenant("tenant");
+    when(tenantDetailsService.findAllTenants()).thenReturn(List.of(tenant));
+    when(purgeService.purgeExpiredSelfServiceTokens()).thenReturn(0);
+
+    when(env.getProperty("fineract.security.2fa.enabled", Boolean.class, false)).thenReturn(false);
+
+    scheduler.purgeExpiredTokens();
+
+    verify(purgeService, never()).purgeExpiredTwoFactorAccessTokens();
+  }
+
+  // ── Multi-tenant + 2FA combined ───────────────────────────────────────────
+
+  @Test
+  void purgeExpiredTokens_purgesBothTablesForEveryTenantWhen2faEnabled() {
+    FineractPlatformTenant t1 = createTenant("t1");
+    FineractPlatformTenant t2 = createTenant("t2");
+    when(tenantDetailsService.findAllTenants()).thenReturn(Arrays.asList(t1, t2));
+
+    when(env.getProperty("fineract.security.2fa.enabled", Boolean.class, false)).thenReturn(true);
+    when(env.getProperty("mifos.self.service.token.purge.2fa.enabled", Boolean.class, true))
+        .thenReturn(true);
+
+    when(purgeService.purgeExpiredSelfServiceTokens()).thenReturn(2).thenReturn(0);
+    when(purgeService.purgeExpiredTwoFactorAccessTokens()).thenReturn(5).thenReturn(3);
+
+    scheduler.purgeExpiredTokens();
+
+    verify(purgeService, times(2)).purgeExpiredSelfServiceTokens();
+    verify(purgeService, times(2)).purgeExpiredTwoFactorAccessTokens();
+  }
+
+  @Test
+  void purgeExpiredTokens_selfServiceOnlyForEveryTenantWhen2faDisabled() {
+    FineractPlatformTenant t1 = createTenant("t1");
+    FineractPlatformTenant t2 = createTenant("t2");
+    FineractPlatformTenant t3 = createTenant("t3");
+    when(tenantDetailsService.findAllTenants()).thenReturn(Arrays.asList(t1, t2, t3));
+
+    when(env.getProperty("fineract.security.2fa.enabled", Boolean.class, false)).thenReturn(false);
+
+    when(purgeService.purgeExpiredSelfServiceTokens()).thenReturn(0);
+
+    scheduler.purgeExpiredTokens();
+
+    verify(purgeService, times(3)).purgeExpiredSelfServiceTokens();
+    verify(purgeService, never()).purgeExpiredTwoFactorAccessTokens();
+  }
+
+  // ── Instance type awareness (isBatchInstance) ─────────────────────────────
+
+  @Test
+  void isBatchInstance_returnsTrueWhenBatchWorkerEnabled() {
+    when(modeProperties.isBatchWorkerEnabled()).thenReturn(true);
+    // isBatchManagerEnabled not stubbed — || short-circuits when worker is true
+
+    assertTrue(scheduler.isBatchInstance());
+  }
+
+  @Test
+  void isBatchInstance_returnsTrueWhenBatchManagerEnabled() {
+    when(modeProperties.isBatchWorkerEnabled()).thenReturn(false);
+    when(modeProperties.isBatchManagerEnabled()).thenReturn(true);
+
+    assertTrue(scheduler.isBatchInstance());
+  }
+
+  @Test
+  void isBatchInstance_returnsFalseWhenNeitherEnabled() {
+    when(modeProperties.isBatchWorkerEnabled()).thenReturn(false);
+    when(modeProperties.isBatchManagerEnabled()).thenReturn(false);
+
+    assertFalse(scheduler.isBatchInstance());
+  }
+
+  @Test
+  void isBatchInstance_returnsFalseWhenModeIsNull() {
+    when(fineractProperties.getMode()).thenReturn(null);
+
+    assertFalse(scheduler.isBatchInstance());
+  }
+
+  @Test
+  void purgeExpiredTokens_skipsWhenNotBatchInstance() {
+    // Override the default batch-enabled setup
+    when(modeProperties.isBatchWorkerEnabled()).thenReturn(false);
+    when(modeProperties.isBatchManagerEnabled()).thenReturn(false);
+
+    scheduler.purgeExpiredTokens();
+
+    verify(tenantDetailsService, never()).findAllTenants();
+    verify(purgeService, never()).purgeExpiredSelfServiceTokens();
+    verify(purgeService, never()).purgeExpiredTwoFactorAccessTokens();
+  }
+
+  // ── Helpers ───────────────────────────────────────────────────────────────
+
+  /**
+   * Creates a real {@link FineractPlatformTenant} instance suitable for setting on
+   * {@link ThreadLocalContextUtil}. Uses "UTC" as the timezone, matching the pattern in
+   * {@code SelfServiceRegistrationWritePlatformServiceImplTest}.
+   */
+  private FineractPlatformTenant createTenant(String identifier) {
+    return new FineractPlatformTenant(1L, identifier, identifier, "UTC", null);
+  }
+}

--- a/src/test/java/org/apache/fineract/selfservice/registration/service/ExpiredTokenPurgeServiceTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/registration/service/ExpiredTokenPurgeServiceTest.java
@@ -1,0 +1,168 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.fineract.selfservice.registration.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import org.apache.fineract.selfservice.registration.domain.SelfServiceRegistrationRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+@ExtendWith(MockitoExtension.class)
+class ExpiredTokenPurgeServiceTest {
+
+  @Mock private SelfServiceRegistrationRepository selfServiceRegistrationRepository;
+  @Mock private JdbcTemplate jdbcTemplate;
+  @Captor private ArgumentCaptor<LocalDateTime> cutoffCaptor;
+  @Captor private ArgumentCaptor<String> sqlCaptor;
+
+  private ExpiredTokenPurgeService service;
+
+  @BeforeEach
+  void setUp() {
+    service = new ExpiredTokenPurgeService(selfServiceRegistrationRepository, jdbcTemplate);
+  }
+
+  // ── Self-service token purge ──────────────────────────────────────────────
+
+  @Test
+  void purgeExpiredSelfServiceTokens_deletesExpiredRows() {
+    when(selfServiceRegistrationRepository.deleteExpiredRequests(any(LocalDateTime.class)))
+        .thenReturn(5);
+
+    int deleted = service.purgeExpiredSelfServiceTokens();
+
+    assertEquals(5, deleted);
+    verify(selfServiceRegistrationRepository).deleteExpiredRequests(cutoffCaptor.capture());
+
+    // The cutoff must be close to "now" — allow 5 seconds tolerance
+    LocalDateTime capturedCutoff = cutoffCaptor.getValue();
+    LocalDateTime now = LocalDateTime.now();
+    assertEquals(
+        true,
+        capturedCutoff.isBefore(now.plusSeconds(1)) && capturedCutoff.isAfter(now.minusSeconds(5)),
+        "Cutoff should be approximately 'now', got: " + capturedCutoff);
+  }
+
+  @Test
+  void purgeExpiredSelfServiceTokens_returnsZeroWhenNothingExpired() {
+    when(selfServiceRegistrationRepository.deleteExpiredRequests(any(LocalDateTime.class)))
+        .thenReturn(0);
+
+    int deleted = service.purgeExpiredSelfServiceTokens();
+
+    assertEquals(0, deleted);
+    verify(selfServiceRegistrationRepository).deleteExpiredRequests(any(LocalDateTime.class));
+  }
+
+  @Test
+  void purgeExpiredSelfServiceTokens_passesNonNullCutoff() {
+    when(selfServiceRegistrationRepository.deleteExpiredRequests(any(LocalDateTime.class)))
+        .thenReturn(0);
+
+    service.purgeExpiredSelfServiceTokens();
+
+    verify(selfServiceRegistrationRepository).deleteExpiredRequests(cutoffCaptor.capture());
+    LocalDateTime cutoff = cutoffCaptor.getValue();
+    assertEquals(true, cutoff != null, "Cutoff must not be null");
+  }
+
+  @Test
+  void purgeExpiredSelfServiceTokens_doesNotTouch2faTable() {
+    when(selfServiceRegistrationRepository.deleteExpiredRequests(any(LocalDateTime.class)))
+        .thenReturn(3);
+
+    service.purgeExpiredSelfServiceTokens();
+
+    verify(jdbcTemplate, never()).update(any(String.class));
+  }
+
+  // ── 2FA token purge ───────────────────────────────────────────────────────
+
+  @Test
+  void purgeExpiredTwoFactorAccessTokens_executesCorrectSql() {
+    when(jdbcTemplate.update(any(String.class))).thenReturn(10);
+
+    int deleted = service.purgeExpiredTwoFactorAccessTokens();
+
+    assertEquals(10, deleted);
+    verify(jdbcTemplate).update(sqlCaptor.capture());
+    assertEquals(
+        "DELETE FROM twofactor_access_token WHERE valid_to < NOW()", sqlCaptor.getValue());
+  }
+
+  @Test
+  void purgeExpiredTwoFactorAccessTokens_returnsZeroWhenNothingExpired() {
+    when(jdbcTemplate.update(any(String.class))).thenReturn(0);
+
+    int deleted = service.purgeExpiredTwoFactorAccessTokens();
+
+    assertEquals(0, deleted);
+  }
+
+  @Test
+  void purgeExpiredTwoFactorAccessTokens_propagatesDeleteCount() {
+    when(jdbcTemplate.update(any(String.class))).thenReturn(42);
+
+    int deleted = service.purgeExpiredTwoFactorAccessTokens();
+
+    assertEquals(42, deleted);
+  }
+
+  @Test
+  void purgeExpiredTwoFactorAccessTokens_doesNotTouchSelfServiceTable() {
+    when(jdbcTemplate.update(any(String.class))).thenReturn(1);
+
+    service.purgeExpiredTwoFactorAccessTokens();
+
+    verify(selfServiceRegistrationRepository, never())
+        .deleteExpiredRequests(any(LocalDateTime.class));
+  }
+
+  // ── Independence: calling one method does not invoke the other ────────────
+
+  @Test
+  void methodsAreIndependent_selfServiceDoesNotTrigger2fa() {
+    when(selfServiceRegistrationRepository.deleteExpiredRequests(any(LocalDateTime.class)))
+        .thenReturn(1);
+
+    service.purgeExpiredSelfServiceTokens();
+
+    verify(jdbcTemplate, never()).update(any(String.class));
+    verify(selfServiceRegistrationRepository).deleteExpiredRequests(any(LocalDateTime.class));
+  }
+
+  @Test
+  void methodsAreIndependent_2faDoesNotTriggerSelfService() {
+    when(jdbcTemplate.update(any(String.class))).thenReturn(1);
+
+    service.purgeExpiredTwoFactorAccessTokens();
+
+    verify(selfServiceRegistrationRepository, never())
+        .deleteExpiredRequests(any(LocalDateTime.class));
+    verify(jdbcTemplate).update(any(String.class));
+  }
+}

--- a/src/test/java/org/apache/fineract/selfservice/testing/support/SelfServiceIntegrationTestBase.java
+++ b/src/test/java/org/apache/fineract/selfservice/testing/support/SelfServiceIntegrationTestBase.java
@@ -9,15 +9,20 @@ package org.apache.fineract.selfservice.testing.support;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.Container;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.MountableFile;
 
 public abstract class SelfServiceIntegrationTestBase {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SelfServiceIntegrationTestBase.class);
 
     private static final Network network = Network.newNetwork();
 
@@ -106,6 +111,10 @@ public abstract class SelfServiceIntegrationTestBase {
                     );
                     cmd.withCmd();
                 })
+                        
+                // Stream container stdout/stderr to test output for diagnostic visibility.
+                // This reveals the actual failure reason instead of generic ContainerLaunchException.
+                .withLogConsumer(new Slf4jLogConsumer(LOG).withPrefix("fineract"))
                         
                 // HostPortWaitStrategy still runs an internal port check that requires bash (missing in
                 // apache/fineract images). HTTPS + allowInsecure waits until the app serves actuator.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated periodic purging of expired self-service registration records and authentication tokens (configurable)
  * Optional automatic cleanup of expired two-factor authentication tokens via a separate flag
  * Multi-tenant-aware purge with per-tenant isolation and resilient error handling
  
* **Tests**
  * New unit tests covering scheduler/service behavior and improved integration test logging for container output
<!-- end of auto-generated comment: release notes by coderabbit.ai -->