### PR TITLE
MX-251: Fix allowPartialPeriodInterestCalculation typo in API docs

### DIFF
--- a/src/main/java/org/apache/fineract/selfservice/loanaccount/api/SelfLoansApiResource.java
+++ b/src/main/java/org/apache/fineract/selfservice/loanaccount/api/SelfLoansApiResource.java
@@ -302,7 +302,7 @@ public class SelfLoansApiResource {
               + "Additional Mandatory Fields if interest recalculation is enabled for product and Rest frequency not same as repayment period: recalculationRestFrequencyDate\n\n"
               + "Additional Mandatory Fields if interest recalculation with interest/fee compounding is enabled for product and compounding frequency not same as repayment period: recalculationCompoundingFrequencyDate\n\n"
               + "Additional Mandatory Field if Entity-Datatable Check is enabled for the entity of type loan: datatables\n\n"
-              + "Optional Fields: graceOnPrincipalPayment, graceOnInterestPayment, graceOnInterestCharged, linkAccountId, allowPartialPeriodInterestCalcualtion, fixedEmiAmount, maxOutstandingLoanBalance, disbursementData, graceOnArrearsAgeing, createStandingInstructionAtDisbursement (requires linkedAccountId if set to true)\n\n"
+              + "Optional Fields: graceOnPrincipalPayment, graceOnInterestPayment, graceOnInterestCharged, linkAccountId, allowPartialPeriodInterestCalculation, fixedEmiAmount, maxOutstandingLoanBalance, disbursementData, graceOnArrearsAgeing, createStandingInstructionAtDisbursement (requires linkedAccountId if set to true)\n\n"
               + "Showing request/response for 'Submit a new Loan Application'")
   @RequestBody(
       required = true,

--- a/src/main/java/org/apache/fineract/selfservice/products/api/SelfLoanProductsApiResource.java
+++ b/src/main/java/org/apache/fineract/selfservice/products/api/SelfLoanProductsApiResource.java
@@ -93,7 +93,7 @@ import org.springframework.stereotype.Component;
             + "Example Values: 0=Declining Balance, 1=Flat\n"
             + "interestCalculationPeriodType\n"
             + "Example Values: 0=Daily, 1=Same as repayment period\n"
-            + "allowPartialPeriodInterestCalcualtion\n"
+            + "allowPartialPeriodInterestCalculation\n"
             + "This value will be supported along with interestCalculationPeriodType as Same as repayment period to calculate interest for partial periods. Example: Interest charged from is 5th of April , Principal is 10000 and interest is 1% per month then the interest will be (10000 * 1%)* (25/30) , it calculates for the month first then calculates exact periods between start date and end date(can be a decimal)\n"
             + "inArrearsTolerance\n"
             + "The amount that can be 'waived' at end of all loan payments because it is too small to worry about.\n"


### PR DESCRIPTION
Fixes: [MX-251](https://mifosforge.jira.com/browse/MX-251)

Fixed `allowPartialPeriodInterestCalculation` typo across API docs.

Updated:
`allowPartialPeriodInterestCalcualtion` -> `allowPartialPeriodInterestCalculation`

Changes applied in:
- Loan Repayment Schedule / Loan Application API docs
- Self Loan Products API docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected spelling errors in API documentation for self-service loan and loan product endpoints to improve consistency and clarity.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openMF/selfservice-plugin/pull/164)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MX-251]: https://mifosforge.jira.com/browse/MX-251?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ