### PR TITLE
MX-262: Handle nullable ExternalNotificationSystemClient across plugin

### DIFF
--- a/src/main/java/org/apache/fineract/selfservice/notification/service/SelfServiceNotificationService.java
+++ b/src/main/java/org/apache/fineract/selfservice/notification/service/SelfServiceNotificationService.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
+import jakarta.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.text.StringEscapeUtils;
 import org.apache.fineract.infrastructure.campaigns.sms.data.SmsProviderData;
@@ -61,7 +62,6 @@ public class SelfServiceNotificationService {
   private final NotificationCooldownCache notificationCooldownCache;
   private final Environment env;
   private final ExternalNotificationSystemClient externalNotificationSystemClient;
-  private NotificationCredentialsData notificationCredentialsData;
 
   /**
    * Guards the one-time WARN log emitted when email delivery fails due to SMTP configuration being
@@ -79,7 +79,7 @@ public class SelfServiceNotificationService {
       SmsCampaignDropdownReadPlatformService smsProviderService,
       NotificationCooldownCache notificationCooldownCache,
       Environment env,
-      ExternalNotificationSystemClient externalNotificationSystemClient) {
+      @Nullable ExternalNotificationSystemClient externalNotificationSystemClient) {
     this.notificationTemplateEngine = notificationTemplateEngine;
     this.notificationMessageSource = notificationMessageSource;
     this.emailService = emailService;
@@ -182,18 +182,21 @@ public class SelfServiceNotificationService {
   private void sendEmailNotification(
       SelfServiceNotificationEvent event, String subject, Context context) {
 
-    notificationCredentialsData = externalNotificationSystemClient.resolveNotificationCredentials();
+    NotificationCredentialsData notificationCredentials = null;
+    if (externalNotificationSystemClient != null) {
+      notificationCredentials = externalNotificationSystemClient.resolveNotificationCredentials();
+    }
     String templateName = "html/" + event.getType().getTemplatePrefix();
     String htmlBody = notificationTemplateEngine.process(templateName, context);
 
-    if (notificationCredentialsData.isEnabled()) {
+    if (notificationCredentials != null && notificationCredentials.isEnabled()) {
 
       NotificationMessage notificationMessage = new NotificationMessage();
 
       notificationMessage.setEmail(event.getEmail());
       notificationMessage.setMobile(event.getMobileNumber());
 
-      if (notificationCredentialsData.isWhatsapp() || notificationCredentialsData.isSms()) {
+      if (notificationCredentials.isWhatsapp() || notificationCredentials.isSms()) {
         // 1. Remove all HTML tags using regex
         String noTags = htmlBody.replaceAll("<[^>]*>", "");
 
@@ -207,7 +210,7 @@ public class SelfServiceNotificationService {
         notificationMessage.setText(result);
       }
 
-      if (notificationCredentialsData.isEmail()) {
+      if (notificationCredentials.isEmail()) {
         notificationMessage.setText(htmlBody);
       }
 

--- a/src/main/java/org/apache/fineract/selfservice/registration/starter/SelfRegistrationConfiguration.java
+++ b/src/main/java/org/apache/fineract/selfservice/registration/starter/SelfRegistrationConfiguration.java
@@ -39,6 +39,7 @@ import org.apache.fineract.useradministration.domain.AppUserRepository;
 import org.apache.fineract.useradministration.domain.PasswordValidationPolicyRepository;
 import org.apache.fineract.useradministration.domain.RoleRepository;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import jakarta.annotation.Nullable;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.MessageSource;
 import org.springframework.context.annotation.Bean;
@@ -119,7 +120,7 @@ public class SelfRegistrationConfiguration {
       AppSelfServiceUserRepository appSelfServiceUserRepository,
       SelfServiceAuthorizationTokenService selfServiceAuthorizationTokenService,
       ApplicationEventPublisher applicationEventPublisher,
-      ExternalNotificationSystemClient externalNotificationSystemClient) {
+      @Nullable ExternalNotificationSystemClient externalNotificationSystemClient) {
     return new SelfServiceRegistrationWritePlatformServiceImpl(
         selfServiceRegistrationRepository,
         fromApiJsonHelper,

--- a/src/test/java/org/apache/fineract/selfservice/notification/SelfServiceSmtpFallbackIntegrationTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/notification/SelfServiceSmtpFallbackIntegrationTest.java
@@ -280,7 +280,8 @@ public class SelfServiceSmtpFallbackIntegrationTest {
         SelfServicePluginEmailService emailService,
         NotificationCooldownCache cooldownCache,
         Environment env,
-        ExternalNotificationSystemClient externalNotificationSystemClient) {
+        @jakarta.annotation.Nullable
+            ExternalNotificationSystemClient externalNotificationSystemClient) {
       return new SelfServiceNotificationService(
           notificationTemplateEngine,
           notificationMessageSource,

--- a/src/test/java/org/apache/fineract/selfservice/notification/service/SelfServiceNotificationServiceTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/notification/service/SelfServiceNotificationServiceTest.java
@@ -43,6 +43,7 @@ import org.apache.fineract.infrastructure.core.domain.FineractPlatformTenant;
 import org.apache.fineract.infrastructure.core.service.SelfServicePluginEmailService;
 import org.apache.fineract.infrastructure.core.service.SmtpConfigurationUnavailableException;
 import org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil;
+import org.apache.fineract.infrastructure.configuration.data.NotificationCredentialsData;
 import org.apache.fineract.infrastructure.sms.domain.SmsMessage;
 import org.apache.fineract.infrastructure.sms.domain.SmsMessageRepository;
 import org.apache.fineract.infrastructure.sms.scheduler.SmsMessageScheduledJobService;
@@ -157,11 +158,18 @@ class SelfServiceNotificationServiceTest {
         .thenReturn(true);
   }
 
+  private void stubExternalNotificationDisabled() {
+    NotificationCredentialsData creds = new NotificationCredentialsData();
+    creds.setEnabled(false);
+    when(externalNotificationSystemClient.resolveNotificationCredentials()).thenReturn(creds);
+  }
+
   // ---- Email happy path ----
 
   @Test
   void handleNotification_EmailMode_SendsEmail() {
     stubNotificationEnabled();
+    stubExternalNotificationDisabled();
     when(cooldownCache.tryAcquire(any())).thenReturn(true);
     when(templateEngine.process(eq("html/login-success"), any())).thenReturn("<html>body</html>");
     when(messageSource.getMessage(
@@ -254,6 +262,7 @@ class SelfServiceNotificationServiceTest {
   @Test
   void handleNotification_EmailMode_SkipsWhenBlankEmail() {
     stubNotificationEnabled();
+    stubExternalNotificationDisabled();
     when(cooldownCache.tryAcquire(any())).thenReturn(true);
     when(messageSource.getMessage(
             eq("subject.login-success"), eq(null), eq("subject.login-success"), any(Locale.class)))
@@ -291,6 +300,7 @@ class SelfServiceNotificationServiceTest {
   @Test
   void handleNotification_EmailMode_ReleaseCooldownOnConfigError() {
     stubNotificationEnabled();
+    stubExternalNotificationDisabled();
     when(cooldownCache.tryAcquire(any())).thenReturn(true);
     when(templateEngine.process(eq("html/login-success"), any())).thenReturn("<html>body</html>");
     when(messageSource.getMessage(
@@ -312,6 +322,7 @@ class SelfServiceNotificationServiceTest {
   @Test
   void handleNotification_EmailMode_LogsWarnOnFirstConfigError_ThenDebug() {
     stubNotificationEnabled();
+    stubExternalNotificationDisabled();
     when(cooldownCache.tryAcquire(any())).thenReturn(true);
     when(templateEngine.process(eq("html/login-success"), any())).thenReturn("<html>body</html>");
     when(messageSource.getMessage(
@@ -348,6 +359,7 @@ class SelfServiceNotificationServiceTest {
   @Test
   void handleNotification_EmailMode_ReleaseCooldownOnGeneralError() {
     stubNotificationEnabled();
+    stubExternalNotificationDisabled();
     when(cooldownCache.tryAcquire(any())).thenReturn(true);
     when(templateEngine.process(eq("html/login-success"), any())).thenReturn("<html>body</html>");
     when(messageSource.getMessage(

--- a/src/test/java/org/apache/fineract/selfservice/savings/api/SelfSavingsAccountApiResourceTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/savings/api/SelfSavingsAccountApiResourceTest.java
@@ -11,6 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -131,7 +132,7 @@ class SelfSavingsAccountApiResourceTest {
     mockSavingsMapped();
     SavingsAccountData data = createDefaultSavingsAccountData();
     when(savingsAccountsApiResource.retrieveOne(
-            eq(ACCOUNT_ID), eq(false), eq("all"), eq(""), eq(uriInfo)))
+            eq(ACCOUNT_ID), eq(false), eq("all"), isNull(), eq(uriInfo)))
         .thenReturn(data);
 
     SavingsAccountData result = resource.retrieveSavings(ACCOUNT_ID, "all", null, null, null, uriInfo);


### PR DESCRIPTION
ExternalNotificationSystemClient is conditional on mifos.self.service.external.sms.system.enabled=true and will not be present in most deployments. Guard all call sites against a null reference.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced system resilience by making external notification service optional, allowing graceful fallback when unavailable.

* **Tests**
  * Updated test suite to verify notification fallback behavior functions correctly without external notification service.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openMF/selfservice-plugin/pull/168?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->