### PR TITLE
fix(MX-384): update enrollment and transfer test setup

### DIFF
--- a/src/test/java/org/apache/fineract/selfservice/account/service/SelfAccountTransferWritePlatformServiceImplTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/account/service/SelfAccountTransferWritePlatformServiceImplTest.java
@@ -12,6 +12,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
@@ -31,9 +32,13 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.fineract.infrastructure.configuration.domain.ConfigurationDomainService;
 import org.apache.fineract.infrastructure.core.domain.ExternalId;
+import org.apache.fineract.infrastructure.core.domain.FineractPlatformTenant;
 import org.apache.fineract.infrastructure.core.exception.PlatformApiDataValidationException;
 import org.apache.fineract.infrastructure.core.serialization.FromJsonHelper;
 import org.apache.fineract.infrastructure.core.service.ExternalIdFactory;
+import org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil;
+import org.apache.fineract.infrastructure.core.service.TransactionDateManagementService;
+import org.apache.fineract.infrastructure.core.util.TransactionDateUtil;
 import org.apache.fineract.organisation.office.domain.Office;
 import org.apache.fineract.organisation.office.service.OfficeReadPlatformService;
 import org.apache.fineract.portfolio.account.service.AccountTransfersReadPlatformService;
@@ -65,6 +70,7 @@ import org.apache.fineract.selfservice.registration.domain.SelfServiceRequestTyp
 import org.apache.fineract.selfservice.security.service.PlatformSelfServiceSecurityContext;
 import org.apache.fineract.selfservice.useradministration.domain.AppSelfServiceUser;
 import org.apache.fineract.selfservice.useradministration.domain.AppSelfServiceUserClientMapping;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -90,6 +96,8 @@ class SelfAccountTransferWritePlatformServiceImplTest {
   private static final Long SAVINGS_ID = 11L;
   private static final String OTP = "123456";
   private static final String IBAN = "CR05015202001026284066";
+  private static final LocalDateTime TEST_NOW = LocalDateTime.of(2026, 1, 2, 10, 0, 0);
+  private static final String TEST_FINERACT_DATE = "02 January 2026";
 
   @Mock private PlatformSelfServiceSecurityContext context;
   @Mock private AccountTransferQuoteService quoteService;
@@ -118,6 +126,8 @@ class SelfAccountTransferWritePlatformServiceImplTest {
   @Mock private SelfServiceAccountTransferRepository selfServiceAccountTransferRepository;
   @Mock private SelfServiceTransferAuditRepository transferAuditRepository;
   @Mock private SelfServiceFeeCollectionService feeCollectionService;
+  @Mock private TransactionDateUtil transactionDateUtil;
+  @Mock private TransactionDateManagementService transactionDateManagementService;
   @Mock private HttpServletRequest httpRequest;
 
   @InjectMocks private SelfAccountTransferWritePlatformServiceImpl service;
@@ -143,6 +153,17 @@ class SelfAccountTransferWritePlatformServiceImplTest {
     Set<AppSelfServiceUserClientMapping> defaultMappings = mappings(ownClient);
     lenient().when(user.getAppUserClientMappings()).thenReturn(defaultMappings);
     lenient().when(httpRequest.getRemoteAddr()).thenReturn("127.0.0.1");
+    lenient().when(transactionDateUtil.getCurrentTenantLocalDateTime()).thenReturn(TEST_NOW);
+    lenient()
+        .when(transactionDateUtil.getCurrentDateForFineract(anyString(), anyString()))
+        .thenReturn(TEST_FINERACT_DATE);
+    ThreadLocalContextUtil.setTenant(
+        new FineractPlatformTenant(1L, "default", "Default", "UTC", null));
+  }
+
+  @AfterEach
+  void tearDown() {
+    ThreadLocalContextUtil.reset();
   }
 
   @Test

--- a/src/test/java/org/apache/fineract/selfservice/registration/domain/SelfServiceRegistrationTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/registration/domain/SelfServiceRegistrationTest.java
@@ -10,10 +10,25 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 
 import java.time.LocalDateTime;
+import org.apache.fineract.infrastructure.core.domain.FineractPlatformTenant;
+import org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil;
 import org.apache.fineract.portfolio.client.domain.Client;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class SelfServiceRegistrationTest {
+
+  @BeforeEach
+  void setUp() {
+    ThreadLocalContextUtil.setTenant(
+        new FineractPlatformTenant(1L, "default", "Default", "UTC", null));
+  }
+
+  @AfterEach
+  void tearDown() {
+    ThreadLocalContextUtil.reset();
+  }
 
   @Test
   void instance_shouldCreateRegistrationWithAllFields() {

--- a/src/test/java/org/apache/fineract/selfservice/registration/service/ExpiredTokenPurgeServiceTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/registration/service/ExpiredTokenPurgeServiceTest.java
@@ -16,6 +16,7 @@ package org.apache.fineract.selfservice.registration.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -41,12 +42,17 @@ class ExpiredTokenPurgeServiceTest {
   @Captor private ArgumentCaptor<String> sqlCaptor;
 
   private ExpiredTokenPurgeService service;
-  
-  private TransactionDateUtil transactionDateUtil;
+
+  @Mock private TransactionDateUtil transactionDateUtil;
 
   @BeforeEach
   void setUp() {
-    service = new ExpiredTokenPurgeService(selfServiceRegistrationRepository, jdbcTemplate, transactionDateUtil);
+    lenient()
+        .when(transactionDateUtil.getCurrentTenantLocalDateTime())
+        .thenAnswer(invocation -> LocalDateTime.now());
+    service =
+        new ExpiredTokenPurgeService(
+            selfServiceRegistrationRepository, jdbcTemplate, transactionDateUtil);
   }
 
   // ── Self-service token purge ──────────────────────────────────────────────

--- a/src/test/java/org/apache/fineract/selfservice/registration/service/SelfServiceForgotPasswordWritePlatformServiceImplTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/registration/service/SelfServiceForgotPasswordWritePlatformServiceImplTest.java
@@ -31,7 +31,9 @@ import java.time.LocalDateTime;
 import java.util.HashSet;
 import java.util.Set;
 import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
+import org.apache.fineract.infrastructure.core.domain.FineractPlatformTenant;
 import org.apache.fineract.infrastructure.core.serialization.FromJsonHelper;
+import org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil;
 import org.apache.fineract.infrastructure.core.util.TransactionDateUtil;
 import org.apache.fineract.infrastructure.security.service.PlatformPasswordEncoder;
 import org.apache.fineract.portfolio.client.domain.Client;
@@ -45,6 +47,7 @@ import org.apache.fineract.selfservice.useradministration.domain.AppSelfServiceU
 import org.apache.fineract.selfservice.useradministration.domain.AppSelfServiceUserRepository;
 import org.apache.fineract.useradministration.domain.PasswordValidationPolicy;
 import org.apache.fineract.useradministration.domain.PasswordValidationPolicyRepository;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -72,7 +75,7 @@ class SelfServiceForgotPasswordWritePlatformServiceImplTest {
   @Mock private Environment env;
 
   private SelfServiceForgotPasswordWritePlatformServiceImpl service;
-  
+
   @Mock private TransactionDateUtil transactionDateUtil;
 
   @BeforeEach
@@ -86,8 +89,15 @@ class SelfServiceForgotPasswordWritePlatformServiceImplTest {
             platformPasswordEncoder,
             selfServiceAuthorizationTokenService,
             applicationEventPublisher,
-            env, 
+            env,
             transactionDateUtil);
+    ThreadLocalContextUtil.setTenant(
+        new FineractPlatformTenant(1L, "default", "Default", "UTC", null));
+  }
+
+  @AfterEach
+  void tearDown() {
+    ThreadLocalContextUtil.reset();
   }
 
   @Test
@@ -97,7 +107,9 @@ class SelfServiceForgotPasswordWritePlatformServiceImplTest {
             eq(SelfServiceApiConstants.usernameParamName), any(JsonElement.class)))
         .thenReturn("jdoe");
     when(selfServiceAuthorizationTokenService.generateToken()).thenReturn("123456");
+    LocalDateTime createdAt = LocalDateTime.of(2026, 4, 13, 12, 0, 0);
     LocalDateTime expectedExpiry = LocalDateTime.of(2026, 4, 13, 12, 0, 30);
+    when(transactionDateUtil.getCurrentTenantLocalDateTime()).thenReturn(createdAt);
     when(selfServiceAuthorizationTokenService.calculateExpiry(any())).thenReturn(expectedExpiry);
 
     AppSelfServiceUser appUser = mock(AppSelfServiceUser.class);

--- a/src/test/java/org/apache/fineract/selfservice/registration/service/SelfServiceRegistrationWritePlatformServiceImplTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/registration/service/SelfServiceRegistrationWritePlatformServiceImplTest.java
@@ -17,6 +17,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.HashMap;
 import org.apache.fineract.infrastructure.businessdate.domain.BusinessDateType;
 import org.apache.fineract.infrastructure.core.domain.FineractPlatformTenant;
@@ -125,6 +126,8 @@ class SelfServiceRegistrationWritePlatformServiceImplTest {
     businessDates.put(BusinessDateType.BUSINESS_DATE, businessDate);
     businessDates.put(BusinessDateType.COB_DATE, businessDate.minusDays(1));
     ThreadLocalContextUtil.setBusinessDates(businessDates);
+    ThreadLocalContextUtil.setTenant(
+        new FineractPlatformTenant(1L, "default", "Default", "UTC", null));
   }
 
   @AfterEach
@@ -224,9 +227,10 @@ class SelfServiceRegistrationWritePlatformServiceImplTest {
     Client client = mock(Client.class);
     when(clientRepository.getClientByAccountNumber("12345")).thenReturn(client);
     when(selfServiceAuthorizationTokenService.generateToken()).thenReturn("123456");
-    when(selfServiceAuthorizationTokenService.calculateExpiry(any()))
-        .thenAnswer(
-            invocation -> ((java.time.LocalDateTime) invocation.getArgument(0)).plusSeconds(30));
+    LocalDateTime createdAt = LocalDateTime.of(2026, 1, 2, 10, 0, 0);
+    LocalDateTime expectedExpiry = LocalDateTime.of(2026, 1, 2, 10, 0, 30);
+    when(transactionDateUtil.getCurrentTenantLocalDateTime()).thenReturn(createdAt);
+    when(selfServiceAuthorizationTokenService.calculateExpiry(any())).thenReturn(expectedExpiry);
     when(platformPasswordEncoder.encode(any())).thenReturn("encoded-password");
 
     SelfServiceRegistration result = service.createRegistrationRequest("{}");


### PR DESCRIPTION
## Summary
- Add missing date utility mocks/stubs for self account transfer tests
- Stub tenant-aware registration time and fixed expiry in registration tests
- Keep MX-384 scoped to test setup only

## Tests
- ./mvnw -Dtest=SelfAccountTransferWritePlatformServiceImplTest test (selected tests pass; JaCoCo gate fails due targeted coverage)
- ./mvnw -Dtest=SelfServiceRegistrationWritePlatformServiceImplTest test (selected tests pass; JaCoCo gate fails due targeted coverage)
- ./mvnw -Dtest=SelfAccountTransferWritePlatformServiceImplTest,SelfServiceRegistrationWritePlatformServiceImplTest test (34 selected tests pass; JaCoCo gate fails due targeted coverage)
- ./mvnw -Dtest=SelfAccountTransferWritePlatformServiceImplTest,SelfServiceRegistrationWritePlatformServiceImplTest -Djacoco.skip=true test (pass)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by using deterministic transaction and registration timestamps.
  * Added consistent tenant-context setup and cleanup across service tests.
  * Stabilized token-expiry verification with fixed expected values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->