### PR TITLE
MX-388: Add tenant branding endpoint for client applications

### DIFF
--- a/src/main/java/org/apache/fineract/branding/api/TenantBrandingApiResource.java
+++ b/src/main/java/org/apache/fineract/branding/api/TenantBrandingApiResource.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.apache.fineract.branding.api;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import lombok.RequiredArgsConstructor;
+import org.apache.fineract.branding.data.TenantBrandingData;
+import org.apache.fineract.branding.service.TenantBrandingService;
+import org.apache.fineract.infrastructure.core.serialization.DefaultToApiJsonSerializer;
+import org.apache.fineract.infrastructure.core.serialization.FromJsonHelper;
+import org.apache.fineract.infrastructure.security.service.PlatformSecurityContext;
+import org.springframework.stereotype.Component;
+
+/**
+ * JAX-RS resource exposing the current tenant's branding under {@code /v1/branding}.
+ *
+ * <p>Deliberately not under {@code /v1/self}: that prefix is matched by the self-service security
+ * chain and authenticates self-service users only, whereas branding is consumed by staff facing
+ * clients such as the web app. Sitting outside that prefix leaves the endpoint on Fineract's main
+ * security chain, so ordinary platform credentials apply.
+ *
+ * <p>Reading requires nothing beyond an authenticated user, since the colour is not sensitive and
+ * every client needs it to render. Updating requires {@code UPDATE_CONFIGURATION}, matching the
+ * permission a user would need to change comparable tenant wide settings.
+ */
+@Path("/v1/branding")
+@Component
+@Tag(
+    name = "Tenant Branding",
+    description =
+        "Branding applied by client applications for the authenticated tenant. The value is tenant"
+            + " scoped, so every user of a tenant sees the same branding on every device.")
+@RequiredArgsConstructor
+public class TenantBrandingApiResource {
+
+  private static final String UPDATE_PERMISSION = "UPDATE_CONFIGURATION";
+
+  private final PlatformSecurityContext context;
+  private final TenantBrandingService tenantBrandingService;
+  private final DefaultToApiJsonSerializer<TenantBrandingData> toApiJsonSerializer;
+  private final FromJsonHelper fromApiJsonHelper;
+
+  /**
+   * Retrieves the branding of the tenant the caller authenticated against.
+   *
+   * @return JSON representation of the branding, defaulted when the tenant has never set one
+   */
+  @GET
+  @Produces({MediaType.APPLICATION_JSON})
+  @Operation(
+      summary = "Retrieve Tenant Branding",
+      description =
+          "Returns the primary colour for the authenticated tenant.\n\n"
+              + "Example Request:\n\n"
+              + "branding")
+  @ApiResponse(responseCode = "200", description = "OK")
+  public String retrieveBranding() {
+    context.authenticatedUser();
+    final TenantBrandingData branding = tenantBrandingService.retrieveCurrentTenantBranding();
+    return toApiJsonSerializer.serialize(branding);
+  }
+
+  /**
+   * Updates the branding of the tenant the caller authenticated against.
+   *
+   * @param apiRequestBodyAsJson request body carrying {@code primaryColor}
+   * @return JSON representation of the stored branding
+   */
+  @PUT
+  @Consumes({MediaType.APPLICATION_JSON})
+  @Produces({MediaType.APPLICATION_JSON})
+  @Operation(
+      summary = "Update Tenant Branding",
+      description =
+          "Sets the primary colour for the authenticated tenant. Supported colours are blue, green,"
+              + " purple, orange, red and yellow.\n\n"
+              + "Example Request:\n\n"
+              + "branding")
+  @ApiResponse(responseCode = "200", description = "OK")
+  public String updateBranding(@Parameter(hidden = true) final String apiRequestBodyAsJson) {
+    context.authenticatedUser().validateHasPermissionTo(UPDATE_PERMISSION);
+
+    // Parsed through FromJsonHelper rather than JsonCommand.from(String): that
+    // factory leaves the command's own helper null, so reading a parameter off
+    // it throws a NullPointerException.
+    final String primaryColor =
+        fromApiJsonHelper.extractStringNamed(
+            "primaryColor", fromApiJsonHelper.parse(apiRequestBodyAsJson));
+    final TenantBrandingData branding =
+        tenantBrandingService.updateCurrentTenantBranding(primaryColor);
+
+    return toApiJsonSerializer.serialize(branding);
+  }
+}

--- a/src/main/java/org/apache/fineract/branding/data/TenantBrandingData.java
+++ b/src/main/java/org/apache/fineract/branding/data/TenantBrandingData.java
@@ -1,0 +1,14 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.apache.fineract.branding.data;
+
+/**
+ * Branding returned to client applications.
+ *
+ * @param primaryColor identifier of the tenant's primary colour, never null
+ */
+public record TenantBrandingData(String primaryColor) {}

--- a/src/main/java/org/apache/fineract/branding/domain/TenantBranding.java
+++ b/src/main/java/org/apache/fineract/branding/domain/TenantBranding.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.apache.fineract.branding.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import java.time.OffsetDateTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Branding applied by client applications for a single tenant.
+ *
+ * <p>The row is tenant scoped rather than user scoped, so every user of a tenant sees the same
+ * branding on every device. Tenants without a row fall back to the default colour.
+ */
+@Entity
+@Table(name = "m_selfservice_tenant_branding")
+@Getter
+@Setter
+@NoArgsConstructor
+public class TenantBranding {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(name = "tenant_id", nullable = false, unique = true)
+  private String tenantId;
+
+  @Column(name = "primary_color", length = 20)
+  private String primaryColor = "blue";
+
+  @Column(name = "created_at")
+  private OffsetDateTime createdAt;
+
+  @Column(name = "updated_at")
+  private OffsetDateTime updatedAt;
+
+  @PrePersist
+  protected void onCreate() {
+    OffsetDateTime now = OffsetDateTime.now();
+    this.createdAt = now;
+    this.updatedAt = now;
+  }
+
+  @PreUpdate
+  protected void onUpdate() {
+    this.updatedAt = OffsetDateTime.now();
+  }
+}

--- a/src/main/java/org/apache/fineract/branding/domain/TenantBrandingRepository.java
+++ b/src/main/java/org/apache/fineract/branding/domain/TenantBrandingRepository.java
@@ -1,0 +1,17 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.apache.fineract.branding.domain;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TenantBrandingRepository extends JpaRepository<TenantBranding, Long> {
+
+  Optional<TenantBranding> findByTenantId(String tenantId);
+}

--- a/src/main/java/org/apache/fineract/branding/service/TenantBrandingService.java
+++ b/src/main/java/org/apache/fineract/branding/service/TenantBrandingService.java
@@ -1,0 +1,123 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.apache.fineract.branding.service;
+
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.apache.fineract.branding.data.TenantBrandingData;
+import org.apache.fineract.branding.domain.TenantBranding;
+import org.apache.fineract.branding.domain.TenantBrandingRepository;
+import org.apache.fineract.infrastructure.core.data.ApiParameterError;
+import org.apache.fineract.infrastructure.core.data.DataValidatorBuilder;
+import org.apache.fineract.infrastructure.core.domain.FineractPlatformTenant;
+import org.apache.fineract.infrastructure.core.exception.PlatformApiDataValidationException;
+import org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Reads and updates the current tenant's branding.
+ *
+ * <p>The tenant is taken from the request context rather than a parameter, so a caller can only
+ * ever read or change the branding of the tenant it authenticated against.
+ */
+@Service
+@RequiredArgsConstructor
+public class TenantBrandingService {
+
+  private static final String RESOURCE_NAME = "tenantbranding";
+
+  /** Applied when a tenant has no row, or has one the client cannot interpret. */
+  public static final String DEFAULT_PRIMARY_COLOR = "blue";
+
+  /**
+   * Colours a client application is expected to render. Kept deliberately small: each one has to
+   * carry white label text at WCAG AA in the clients that consume it.
+   */
+  public static final List<String> SUPPORTED_PRIMARY_COLORS =
+      List.of("blue", "green", "purple", "orange", "red", "yellow");
+
+  private final TenantBrandingRepository repository;
+
+  /**
+   * @return the current tenant's branding, falling back to the default colour when the tenant has
+   *     no row, the stored colour is null, or it is no longer one of the supported colours
+   */
+  @Transactional(readOnly = true)
+  public TenantBrandingData retrieveCurrentTenantBranding() {
+    return new TenantBrandingData(
+        repository
+            .findByTenantId(currentTenantIdentifier())
+            .map(TenantBranding::getPrimaryColor)
+            .map(TenantBrandingService::normalisedOrDefault)
+            .orElse(DEFAULT_PRIMARY_COLOR));
+  }
+
+  /**
+   * Maps a stored colour onto one a client can actually render.
+   *
+   * <p>Rows are not only written through {@link #updateCurrentTenantBranding(String)}: the column is
+   * nullable for older rows, and a colour can be retired from {@link #SUPPORTED_PRIMARY_COLORS}
+   * while rows still reference it. Reading is therefore defensive, so the endpoint never hands a
+   * client a value it cannot use.
+   *
+   * @param storedColor colour as held in the database, possibly null
+   * @return a supported colour, never null
+   */
+  private static String normalisedOrDefault(final String storedColor) {
+    final String normalised = storedColor.trim().toLowerCase();
+    return SUPPORTED_PRIMARY_COLORS.contains(normalised) ? normalised : DEFAULT_PRIMARY_COLOR;
+  }
+
+  /**
+   * Sets the current tenant's primary colour, creating the row on first use.
+   *
+   * @param primaryColor one of {@link #SUPPORTED_PRIMARY_COLORS}
+   * @return the stored branding
+   * @throws PlatformApiDataValidationException if the colour is missing or unsupported
+   */
+  @Transactional
+  public TenantBrandingData updateCurrentTenantBranding(final String primaryColor) {
+    validate(primaryColor);
+
+    final String tenantIdentifier = currentTenantIdentifier();
+    final TenantBranding branding =
+        repository
+            .findByTenantId(tenantIdentifier)
+            .orElseGet(
+                () -> {
+                  final TenantBranding created = new TenantBranding();
+                  created.setTenantId(tenantIdentifier);
+                  return created;
+                });
+
+    branding.setPrimaryColor(primaryColor.trim().toLowerCase());
+    repository.save(branding);
+
+    return new TenantBrandingData(branding.getPrimaryColor());
+  }
+
+  private void validate(final String primaryColor) {
+    final List<ApiParameterError> dataValidationErrors = new ArrayList<>();
+    new DataValidatorBuilder(dataValidationErrors)
+        .resource(RESOURCE_NAME)
+        .parameter("primaryColor")
+        .value(primaryColor == null ? null : primaryColor.trim().toLowerCase())
+        .notBlank()
+        .isOneOfTheseStringValues(SUPPORTED_PRIMARY_COLORS);
+
+    if (!dataValidationErrors.isEmpty()) {
+      throw new PlatformApiDataValidationException(dataValidationErrors);
+    }
+  }
+
+  private String currentTenantIdentifier() {
+    final FineractPlatformTenant tenant = ThreadLocalContextUtil.getTenant();
+    return tenant == null ? null : tenant.getTenantIdentifier();
+  }
+}

--- a/src/main/resources/db/changelog/tenant/module/selfservice/module-changelog-master.xml
+++ b/src/main/resources/db/changelog/tenant/module/selfservice/module-changelog-master.xml
@@ -71,5 +71,6 @@
   <include file="parts/059-add-fee-to-paymentlink-audit-table.xml" relativeToChangelogFile="true"/>
   <include file="parts/060-add-extended-features-to-beneficiaries.xml" relativeToChangelogFile="true"/>  
   <include file="parts/061-add-date-time-preferences.xml" relativeToChangelogFile="true"/>
-  <include file="parts/062-fix-beneficiary-unique-constraint.xml" relativeToChangelogFile="true"/>  
+  <include file="parts/062-fix-beneficiary-unique-constraint.xml" relativeToChangelogFile="true"/>
+  <include file="parts/063-add-tenant-branding.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/tenant/module/selfservice/parts/063-add-tenant-branding.xml
+++ b/src/main/resources/db/changelog/tenant/module/selfservice/parts/063-add-tenant-branding.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright since 2026 Mifos Initiative
+ <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+-->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.20.xsd">
+
+    <changeSet author="fineract" id="ss-0063-1">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="m_selfservice_tenant_branding"/>
+            </not>
+        </preConditions>
+        <comment>Create table for per-tenant branding, holding the primary colour applied by client applications</comment>
+        <createTable tableName="m_selfservice_tenant_branding">
+            <column name="id" type="BIGINT" autoIncrement="true">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="tenant_id" type="VARCHAR(50)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+            <column name="primary_color" type="VARCHAR(20)" defaultValue="blue">
+                <constraints nullable="false"/>
+            </column>
+            <column name="created_at" type="TIMESTAMP WITH TIME ZONE"/>
+            <column name="updated_at" type="TIMESTAMP WITH TIME ZONE"/>
+        </createTable>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/org/apache/fineract/branding/api/TenantBrandingApiResourceTest.java
+++ b/src/test/java/org/apache/fineract/branding/api/TenantBrandingApiResourceTest.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.apache.fineract.branding.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.apache.fineract.branding.data.TenantBrandingData;
+import org.apache.fineract.branding.service.TenantBrandingService;
+import org.apache.fineract.infrastructure.core.serialization.DefaultToApiJsonSerializer;
+import org.apache.fineract.infrastructure.core.serialization.FromJsonHelper;
+import org.apache.fineract.infrastructure.security.service.PlatformSecurityContext;
+import org.apache.fineract.useradministration.domain.AppUser;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class TenantBrandingApiResourceTest {
+
+  private static final String UPDATE_PERMISSION = "UPDATE_CONFIGURATION";
+
+  private PlatformSecurityContext context;
+  private TenantBrandingService service;
+  private DefaultToApiJsonSerializer<TenantBrandingData> serializer;
+  private AppUser user;
+  private TenantBrandingApiResource resource;
+
+  @BeforeEach
+  @SuppressWarnings("unchecked")
+  void setUp() {
+    context = mock(PlatformSecurityContext.class);
+    service = mock(TenantBrandingService.class);
+    serializer = mock(DefaultToApiJsonSerializer.class);
+    user = mock(AppUser.class);
+    when(context.authenticatedUser()).thenReturn(user);
+    // A real helper, so the resource's own JSON parsing is exercised rather
+    // than stubbed away.
+    resource = new TenantBrandingApiResource(context, service, serializer, new FromJsonHelper());
+  }
+
+  @Test
+  void retrieve_requiresAnAuthenticatedUser() {
+    when(service.retrieveCurrentTenantBranding()).thenReturn(new TenantBrandingData("blue"));
+
+    resource.retrieveBranding();
+
+    verify(context).authenticatedUser();
+  }
+
+  @Test
+  void retrieve_doesNotRequireAnyPermission() {
+    // The colour is not sensitive and every client needs it to render, so a
+    // read is deliberately open to any authenticated user.
+    when(service.retrieveCurrentTenantBranding()).thenReturn(new TenantBrandingData("blue"));
+
+    resource.retrieveBranding();
+
+    verify(user, never()).validateHasPermissionTo(any());
+  }
+
+  @Test
+  void retrieve_serialisesWhateverTheServiceReturns() {
+    when(service.retrieveCurrentTenantBranding()).thenReturn(new TenantBrandingData("green"));
+    when(serializer.serialize(new TenantBrandingData("green"))).thenReturn("{\"x\":1}");
+
+    assertEquals("{\"x\":1}", resource.retrieveBranding());
+  }
+
+  @Test
+  void update_requiresTheUpdateConfigurationPermission() {
+    when(service.updateCurrentTenantBranding(any())).thenReturn(new TenantBrandingData("green"));
+
+    resource.updateBranding("{\"primaryColor\":\"green\"}");
+
+    verify(user).validateHasPermissionTo(UPDATE_PERMISSION);
+  }
+
+  @Test
+  void update_readsPrimaryColourFromTheRequestBody() {
+    // Regression guard: JsonCommand.from(String) leaves its own JSON helper
+    // null, so reading a parameter off it throws NullPointerException. The
+    // resource must parse through FromJsonHelper instead.
+    when(service.updateCurrentTenantBranding("green")).thenReturn(new TenantBrandingData("green"));
+
+    resource.updateBranding("{\"primaryColor\":\"green\"}");
+
+    verify(service).updateCurrentTenantBranding("green");
+  }
+
+  @Test
+  void update_passesAnAbsentColourThroughForTheServiceToReject() {
+    // Validation lives in one place; the resource must not silently swallow a
+    // malformed body or substitute a default.
+    when(service.updateCurrentTenantBranding(null)).thenReturn(new TenantBrandingData("blue"));
+
+    resource.updateBranding("{}");
+
+    verify(service).updateCurrentTenantBranding(null);
+  }
+}

--- a/src/test/java/org/apache/fineract/branding/domain/TenantBrandingTest.java
+++ b/src/test/java/org/apache/fineract/branding/domain/TenantBrandingTest.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.apache.fineract.branding.domain;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.OffsetDateTime;
+import org.junit.jupiter.api.Test;
+
+class TenantBrandingTest {
+
+  @Test
+  void newRowDefaultsToBlue() {
+    // A tenant that has never chosen a colour still renders.
+    assertEquals("blue", new TenantBranding().getPrimaryColor());
+  }
+
+  @Test
+  void persistStampsBothAuditColumns() {
+    final TenantBranding branding = new TenantBranding();
+
+    branding.onCreate();
+
+    assertNotNull(branding.getCreatedAt());
+    assertNotNull(branding.getUpdatedAt());
+    assertEquals(branding.getCreatedAt(), branding.getUpdatedAt());
+  }
+
+  @Test
+  void updateMovesUpdatedAtAndLeavesCreatedAtAlone() {
+    final TenantBranding branding = new TenantBranding();
+    branding.onCreate();
+    final OffsetDateTime createdAt = branding.getCreatedAt();
+    // Backdate so the new stamp is distinguishable regardless of clock
+    // granularity.
+    branding.setUpdatedAt(createdAt.minusHours(1));
+
+    branding.onUpdate();
+
+    assertEquals(createdAt, branding.getCreatedAt());
+    assertTrue(branding.getUpdatedAt().isAfter(createdAt.minusHours(1)));
+  }
+}

--- a/src/test/java/org/apache/fineract/branding/service/TenantBrandingServiceTest.java
+++ b/src/test/java/org/apache/fineract/branding/service/TenantBrandingServiceTest.java
@@ -1,0 +1,174 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.apache.fineract.branding.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import org.apache.fineract.branding.data.TenantBrandingData;
+import org.apache.fineract.branding.domain.TenantBranding;
+import org.apache.fineract.branding.domain.TenantBrandingRepository;
+import org.apache.fineract.infrastructure.core.domain.FineractPlatformTenant;
+import org.apache.fineract.infrastructure.core.exception.PlatformApiDataValidationException;
+import org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class TenantBrandingServiceTest {
+
+  private TenantBrandingRepository repository;
+  private TenantBrandingService service;
+
+  private static void currentTenant(final String identifier) {
+    ThreadLocalContextUtil.setTenant(
+        FineractPlatformTenant.builder().id(1L).tenantIdentifier(identifier).build());
+  }
+
+  @BeforeEach
+  void setUp() {
+    repository = mock(TenantBrandingRepository.class);
+    service = new TenantBrandingService(repository);
+    currentTenant("default");
+  }
+
+  @AfterEach
+  void tearDown() {
+    ThreadLocalContextUtil.clearTenant();
+  }
+
+  @Test
+  void retrieve_defaultsToBlueWhenTenantHasNoRow() {
+    when(repository.findByTenantId("default")).thenReturn(Optional.empty());
+
+    assertEquals("blue", service.retrieveCurrentTenantBranding().primaryColor());
+  }
+
+  @Test
+  void retrieve_returnsTheStoredColour() {
+    when(repository.findByTenantId("default"))
+        .thenReturn(Optional.of(branding("default", "green")));
+
+    assertEquals("green", service.retrieveCurrentTenantBranding().primaryColor());
+  }
+
+  @Test
+  void retrieve_defaultsWhenTheStoredColourIsNull() {
+    // The column is nullable, and rows can be written outside this service.
+    when(repository.findByTenantId("default")).thenReturn(Optional.of(branding("default", null)));
+
+    assertEquals("blue", service.retrieveCurrentTenantBranding().primaryColor());
+  }
+
+  @Test
+  void retrieve_defaultsWhenTheStoredColourIsNoLongerSupported() {
+    // A colour can be retired while rows still reference it; a client must
+    // never be handed a value it cannot render.
+    when(repository.findByTenantId("default"))
+        .thenReturn(Optional.of(branding("default", "chartreuse")));
+
+    assertEquals("blue", service.retrieveCurrentTenantBranding().primaryColor());
+  }
+
+  @Test
+  void retrieve_normalisesTheStoredColour() {
+    when(repository.findByTenantId("default"))
+        .thenReturn(Optional.of(branding("default", "  GREEN ")));
+
+    assertEquals("green", service.retrieveCurrentTenantBranding().primaryColor());
+  }
+
+  @Test
+  void retrieve_isScopedToTheCurrentTenant() {
+    // Branding is tenant wide, so the row is looked up by the tenant on the
+    // request context and never by a caller supplied identifier.
+    currentTenant("acme");
+    when(repository.findByTenantId("acme")).thenReturn(Optional.of(branding("acme", "purple")));
+
+    assertEquals("purple", service.retrieveCurrentTenantBranding().primaryColor());
+    verify(repository).findByTenantId("acme");
+  }
+
+  @Test
+  void update_createsTheRowOnFirstUse() {
+    when(repository.findByTenantId("default")).thenReturn(Optional.empty());
+
+    final TenantBrandingData result = service.updateCurrentTenantBranding("green");
+
+    final ArgumentCaptor<TenantBranding> saved = ArgumentCaptor.forClass(TenantBranding.class);
+    verify(repository).save(saved.capture());
+    assertEquals("default", saved.getValue().getTenantId());
+    assertEquals("green", saved.getValue().getPrimaryColor());
+    assertEquals("green", result.primaryColor());
+  }
+
+  @Test
+  void update_mutatesTheExistingRowRatherThanAddingAnother() {
+    final TenantBranding existing = branding("default", "blue");
+    when(repository.findByTenantId("default")).thenReturn(Optional.of(existing));
+
+    service.updateCurrentTenantBranding("red");
+
+    assertEquals("red", existing.getPrimaryColor());
+    verify(repository).save(existing);
+  }
+
+  @Test
+  void update_normalisesCaseAndSurroundingWhitespace() {
+    when(repository.findByTenantId("default")).thenReturn(Optional.empty());
+
+    assertEquals("orange", service.updateCurrentTenantBranding("  ORANGE  ").primaryColor());
+  }
+
+  @Test
+  void update_rejectsAnUnsupportedColour() {
+    assertThrows(
+        PlatformApiDataValidationException.class,
+        () -> service.updateCurrentTenantBranding("chartreuse"));
+    verify(repository, never()).save(any());
+  }
+
+  @Test
+  void update_rejectsAMissingColour() {
+    assertThrows(
+        PlatformApiDataValidationException.class, () -> service.updateCurrentTenantBranding(null));
+    verify(repository, never()).save(any());
+  }
+
+  @Test
+  void update_rejectsABlankColour() {
+    assertThrows(
+        PlatformApiDataValidationException.class, () -> service.updateCurrentTenantBranding("   "));
+    verify(repository, never()).save(any());
+  }
+
+  @Test
+  void supportedColoursAreLegibleChoicesAndIncludeTheDefault() {
+    // The client renders white label text on these, so the set is deliberately
+    // fixed rather than free form.
+    assertEquals(
+        java.util.List.of("blue", "green", "purple", "orange", "red", "yellow"),
+        TenantBrandingService.SUPPORTED_PRIMARY_COLORS);
+    org.junit.jupiter.api.Assertions.assertTrue(
+        TenantBrandingService.SUPPORTED_PRIMARY_COLORS.contains(
+            TenantBrandingService.DEFAULT_PRIMARY_COLOR));
+  }
+
+  private static TenantBranding branding(final String tenantId, final String color) {
+    final TenantBranding branding = new TenantBranding();
+    branding.setTenantId(tenantId);
+    branding.setPrimaryColor(color);
+    return branding;
+  }
+}


### PR DESCRIPTION
## What

Adds a tenant scoped primary colour so a single Mifos web app deployment can brand each tenant, exposed as `GET`/`PUT /v1/branding`.

Jira: #MX-388

## Why here rather than in Apache Fineract

This started as a global configuration PR against apache/fineract (apache/fineract#6212, FINERACT-2731). Maintainers declined it: Fineract is a client agnostic core banking backend and should not carry settings that exist to serve one specific frontend. This implementation keeps the data in the plugin's own table, so nothing in Apache Fineract changes.

## Changes

- `063-add-tenant-branding.xml` creates `m_selfservice_tenant_branding`
  (`tenant_id` unique, `primary_color`, timestamps), modelled on
  `061-add-date-time-preferences.xml`. Picked up by the existing
  `SelfServiceLiquibaseConfig`, so it runs per tenant with no new wiring.
- `TenantBranding`, `TenantBrandingRepository`, `TenantBrandingService`,
  `TenantBrandingApiResource`.
- Reading requires only an authenticated user; updating requires
  `UPDATE_CONFIGURATION`.
- Unknown, unset or malformed values fall back to `blue`, so branding can never
  stop a client from rendering.

## Why the endpoint is not under `/v1/self`

`SelfServiceSecurityConfiguration` uses `.securityMatcher("/api/v1/self/**", "/v1/self/**")` and authenticates self-service users only. Branding is read by staff facing clients, so the resource sits at `/v1/branding`, leaving it on Fineract's main security chain where ordinary platform credentials apply. Registration is unaffected: `JerseyConfig` registers every `@Path` bean regardless of path.

## Testing

19 unit tests across the service, resource and entity. Full suite passes (360 tests, 0 failures) with the JaCoCo coverage gate met. Coverage of the new code: `TenantBrandingApiResource` 100%, `TenantBranding` 100%, `TenantBrandingData` 100%, `TenantBrandingService` 98%.

Also verified end to end against Fineract 1.16.0-SNAPSHOT with PostgreSQL 18.3, with both plugin jars mounted on `/app/plugins`:

- changeset runs per tenant and creates the table
- `GET /v1/branding` returns `{"primaryColor":"blue"}` with staff credentials
- `PUT {"primaryColor":"green"}` persists and reads back
- row confirmed in `m_selfservice_tenant_branding`, audit timestamps populated
- unsupported colour returns HTTP 400 with the standard validation envelope
- anonymous request returns 401

## Deployment note

The self-service plugin cannot boot alone: it needs `savings-plugin` on the classpath for `BccrExchangeRateService`, otherwise Fineract fails to start with `NoClassDefFoundError`. Pre-existing and documented in `pom.xml`, but worth knowing if you reproduce the run above.

## Open question

The table is named `m_selfservice_tenant_branding` to follow the repo's `m_selfservice_*` convention and avoid colliding with a future Fineract core table, though branding is not strictly a self-service concern. Happy to rename if you'd prefer something neutral.

## Related

Consumed by openMF/web-app #3784 (#WEB-1084), which degrades to the default colour and reports the feature unavailable when this plugin is not installed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tenant branding support through a new branding API.
  * Authenticated users can retrieve the current primary branding color.
  * Authorized administrators can update the primary color using supported values.
  * New tenants default to a blue primary color, with branding stored per tenant.

* **Tests**
  * Added coverage for authentication, permissions, defaults, validation, tenant isolation, updates, and timestamp behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->