### PR TITLE
MX-391: Give tenant branding its own security filter chain

### DIFF
--- a/src/main/java/org/apache/fineract/branding/starter/TenantBrandingSecurityConfiguration.java
+++ b/src/main/java/org/apache/fineract/branding/starter/TenantBrandingSecurityConfiguration.java
@@ -1,0 +1,203 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.apache.fineract.branding.starter;
+
+import org.apache.fineract.infrastructure.businessdate.service.BusinessDateReadPlatformService;
+import org.apache.fineract.infrastructure.cache.service.CacheWritePlatformService;
+import org.apache.fineract.infrastructure.configuration.domain.ConfigurationDomainService;
+import org.apache.fineract.infrastructure.core.config.FineractProperties;
+import org.apache.fineract.infrastructure.core.serialization.ToApiJsonSerializer;
+import org.apache.fineract.infrastructure.security.data.PlatformRequestLog;
+import org.apache.fineract.infrastructure.security.filter.TenantAwareBasicAuthenticationFilter;
+import org.apache.fineract.infrastructure.security.service.AuthTenantDetailsService;
+import org.apache.fineract.notification.service.UserNotificationService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.ProviderManager;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.www.BasicAuthenticationEntryPoint;
+import org.springframework.security.web.context.SecurityContextHolderFilter;
+import org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher;
+import org.springframework.security.web.util.matcher.OrRequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+/**
+ * Security for the tenant branding endpoint.
+ *
+ * <p>Branding needs its own chain because it is the one resource in this plugin outside the {@code
+ * /v1/self/} prefix, and so belongs to neither of the two chains that would otherwise claim it:
+ *
+ * <ul>
+ *   <li>{@code SelfServiceSecurityConfiguration} authenticates against the self-service user store.
+ *       A platform user does not exist there, so if that chain claims a branding request the caller
+ *       is rejected with 401 despite presenting valid platform credentials - and the rejection
+ *       happens in the filter chain, so nothing the resource does about its own authentication can
+ *       prevent it.
+ *   <li>Fineract's main chain claims {@code /api/**}, which covers branding only where the
+ *       deployment resolves it under that prefix. A client resolving a bare {@code /v1/branding}
+ *       reaches a path no chain claims, which skips authentication and - because {@code
+ *       TenantAwareBasicAuthenticationFilter} is also what resolves the tenant - leaves the tenant
+ *       null, so every tenant silently reads the default colour.
+ * </ul>
+ *
+ * <p>Ordered ahead of the self-service chain so that neither outcome depends on which prefix a
+ * deployment happens to use. Both spellings are claimed here, explicitly.
+ *
+ * <p>Reads are anonymous: the colour is not sensitive, every client needs it to render, and the
+ * login screen has to paint the tenant's brand before anyone has authenticated. Writes still
+ * require a platform user, and the resource additionally requires {@code UPDATE_CONFIGURATION} - a
+ * Fineract permission check belongs with the handler rather than here.
+ *
+ * <p>The authentication manager is built explicitly from the platform provider rather than left to
+ * {@code httpBasic()} to resolve. An implicitly resolved manager takes whichever {@code
+ * UserDetailsService} the context offers, which in this application is ambiguous - and picking the
+ * self-service one is precisely the failure this chain exists to prevent.
+ */
+@Configuration
+public class TenantBrandingSecurityConfiguration {
+
+  private static final PathPatternRequestMatcher.Builder API_MATCHER =
+      PathPatternRequestMatcher.withDefaults();
+
+  /** Branding as resolved by a client that includes the API prefix. */
+  private static final String PREFIXED_BRANDING_PATH = "/api/v1/branding";
+
+  /** Branding as resolved by a client that does not, mirroring the self-service chain. */
+  private static final String BRANDING_PATH = "/v1/branding";
+
+  @Autowired
+  @Qualifier("customAuthenticationProvider") private DaoAuthenticationProvider platformAuthenticationProvider;
+
+  @Autowired
+  @Qualifier("basicAuthenticationEntryPoint") private BasicAuthenticationEntryPoint platformAuthenticationEntryPoint;
+
+  @Autowired private ToApiJsonSerializer<PlatformRequestLog> toApiJsonSerializer;
+  @Autowired private ConfigurationDomainService configurationDomainService;
+  @Autowired private CacheWritePlatformService cacheWritePlatformService;
+  @Autowired private UserNotificationService userNotificationService;
+  @Autowired private AuthTenantDetailsService basicAuthTenantDetailsService;
+  @Autowired private BusinessDateReadPlatformService businessDateReadPlatformService;
+  @Autowired private FineractProperties fineractProperties;
+
+  /**
+   * The order belongs on the bean method rather than the class: a class level {@code @Order} does
+   * not reach the {@code SecurityFilterChain} beans a configuration produces, so declaring it there
+   * leaves the chain sorted by default precedence and silently claiming nothing.
+   *
+   * @param http security builder for this chain
+   * @return chain claiming both spellings of the branding path
+   * @throws Exception if the chain cannot be built
+   */
+  @Bean
+  @Order(0)
+  public SecurityFilterChain tenantBrandingSecurityFilterChain(final HttpSecurity http)
+      throws Exception {
+
+    http.securityMatcher(brandingRequestMatcher())
+        .csrf(AbstractHttpConfigurer::disable)
+        .sessionManagement(smc -> smc.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+
+        // Resolves the tenant from the Fineract-Platform-TenantId header and authenticates
+        // any credentials that are present. Anonymous requests pass through with the tenant
+        // already set, which is what lets a read answer the right colour without a user.
+        .addFilterBefore(brandingAuthenticationFilter(), SecurityContextHolderFilter.class)
+        .authorizeHttpRequests(
+            auth ->
+                auth
+                    // Preflight carries no credentials.
+                    .requestMatchers(
+                        API_MATCHER.matcher(HttpMethod.OPTIONS, PREFIXED_BRANDING_PATH),
+                        API_MATCHER.matcher(HttpMethod.OPTIONS, BRANDING_PATH))
+                    .permitAll()
+                    .requestMatchers(
+                        API_MATCHER.matcher(HttpMethod.GET, PREFIXED_BRANDING_PATH),
+                        API_MATCHER.matcher(HttpMethod.GET, BRANDING_PATH))
+                    .permitAll()
+                    // Writes, and anything else that reaches this path.
+                    .anyRequest()
+                    .authenticated())
+
+        // Answers an unauthenticated write with the platform realm, so a branding 401 names
+        // the chain that produced it.
+        .exceptionHandling(eh -> eh.authenticationEntryPoint(platformAuthenticationEntryPoint));
+
+    if (fineractProperties.getSecurity().getCors().isEnabled()) {
+      http.cors(cors -> cors.configurationSource(brandingCorsConfigurationSource()));
+    }
+
+    return http.build();
+  }
+
+  /**
+   * @return matcher claiming branding under both prefixes
+   */
+  private RequestMatcher brandingRequestMatcher() {
+    return new OrRequestMatcher(
+        API_MATCHER.matcher(PREFIXED_BRANDING_PATH), API_MATCHER.matcher(BRANDING_PATH));
+  }
+
+  /**
+   * Authenticates against the platform user store, not the self-service one.
+   *
+   * @return tenant resolving basic authentication filter scoped to branding
+   */
+  private TenantAwareBasicAuthenticationFilter brandingAuthenticationFilter() {
+    final TenantAwareBasicAuthenticationFilter filter =
+        new TenantAwareBasicAuthenticationFilter(
+            platformAuthenticationManager(),
+            platformAuthenticationEntryPoint,
+            toApiJsonSerializer,
+            configurationDomainService,
+            cacheWritePlatformService,
+            userNotificationService,
+            basicAuthTenantDetailsService,
+            businessDateReadPlatformService);
+
+    filter.setRequestMatcher(brandingRequestMatcher());
+    return filter;
+  }
+
+  /**
+   * @return manager backed solely by the platform authentication provider
+   */
+  private AuthenticationManager platformAuthenticationManager() {
+    return new ProviderManager(platformAuthenticationProvider);
+  }
+
+  /**
+   * Mirrors the CORS configuration of the other chains, so a browser client is not blocked on a
+   * response this chain produced.
+   *
+   * @return CORS source for branding requests
+   */
+  private CorsConfigurationSource brandingCorsConfigurationSource() {
+    final CorsConfiguration config = new CorsConfiguration();
+    final FineractProperties.CorsProperties corsConfiguration =
+        fineractProperties.getSecurity().getCors();
+    config.setAllowedOriginPatterns(corsConfiguration.getAllowedOriginPatterns());
+    config.setAllowedMethods(corsConfiguration.getAllowedMethods());
+    config.setAllowedHeaders(corsConfiguration.getAllowedHeaders());
+    config.setExposedHeaders(corsConfiguration.getExposedHeaders());
+    config.setAllowCredentials(corsConfiguration.isAllowCredentials());
+
+    final UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+    source.registerCorsConfiguration("/**", config);
+    return source;
+  }
+}

--- a/src/test/java/org/apache/fineract/branding/security/TenantBrandingSecurityFilterChainIntegrationTest.java
+++ b/src/test/java/org/apache/fineract/branding/security/TenantBrandingSecurityFilterChainIntegrationTest.java
@@ -1,0 +1,258 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.apache.fineract.branding.security;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.List;
+import org.apache.fineract.selfservice.security.service.SelfServiceAuthenticationTokenService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultMatcher;
+import org.springframework.web.util.ServletRequestPathUtils;
+
+/**
+ * Guards the security wiring of the tenant branding endpoint.
+ *
+ * <p>Branding is the one resource in this plugin outside the {@code /v1/self/} prefix, which left
+ * it belonging to neither of the chains that would otherwise claim it. Two failures followed, and
+ * both are invisible from the resource itself because they happen in the filter chain before it
+ * runs:
+ *
+ * <ul>
+ *   <li>the self-service chain claiming the request and authenticating a platform user against the
+ *       self-service user store, where that user does not exist - 401 despite valid credentials
+ *   <li>no chain claiming it at all, which skips authentication and, because the same filter
+ *       resolves the tenant, leaves the tenant null so every tenant reads the default colour
+ * </ul>
+ *
+ * <p>{@code TenantBrandingSecurityConfiguration} claims both spellings ahead of both chains. These
+ * tests hold it there.
+ *
+ * <p>Chains are interrogated directly where the question is which one claims a path, because the
+ * resource is JAX-RS and is not registered with the Spring MVC dispatcher: under MockMvc every path
+ * answers 404 regardless of which filters ran. Authorization is asserted through MockMvc, which
+ * does work, because Spring Security decides before the dispatcher is reached - so a rejected
+ * request answers 401 while a permitted one falls through to the dispatcher's 404.
+ */
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.MOCK,
+    classes = TenantBrandingSecurityTestConfig.class,
+    properties = "spring.main.allow-bean-definition-overriding=true")
+@ActiveProfiles("test")
+@TestPropertySource("classpath:application-test.properties")
+@AutoConfigureMockMvc
+class TenantBrandingSecurityFilterChainIntegrationTest {
+
+  private static final String BRANDING_PATH = "/v1/branding";
+  private static final String PREFIXED_BRANDING_PATH = "/api/v1/branding";
+  private static final String PREFIXED_SELF_PATH = "/api/v1/self/clients";
+  private static final String BARE_SELF_PATH = "/v1/self/clients";
+  private static final String TENANT_HEADER = "Fineract-Platform-TenantId";
+
+  @Autowired private MockMvc mockMvc;
+  @Autowired private List<SecurityFilterChain> filterChains;
+
+  @Autowired
+  @Qualifier("selfServiceSecurityFilterChain") private SecurityFilterChain selfServiceFilterChain;
+
+  @Autowired
+  @Qualifier("tenantBrandingSecurityFilterChain") private SecurityFilterChain brandingFilterChain;
+
+  @MockitoBean private SelfServiceAuthenticationTokenService selfServiceAuthenticationTokenService;
+
+  @Test
+  @DisplayName("branding is claimed under both spellings, so protection does not depend on prefix")
+  void brandingPaths_areClaimedUnderBothSpellings() {
+    assertTrue(
+        isClaimedByAnyChain(PREFIXED_BRANDING_PATH),
+        () -> PREFIXED_BRANDING_PATH + " is claimed by no SecurityFilterChain");
+    assertTrue(
+        isClaimedByAnyChain(BRANDING_PATH),
+        () ->
+            BRANDING_PATH
+                + " is claimed by no SecurityFilterChain, so a client resolving branding without"
+                + " the /api prefix reaches it with neither authentication nor a tenant.");
+  }
+
+  /**
+   * Ordering is the whole point: the self-service chain would otherwise claim these paths first in
+   * deployments where its matchers resolve differently, and reject platform users.
+   */
+  @Test
+  @DisplayName("the branding chain, not the self-service chain, claims branding first")
+  void brandingChain_winsAheadOfTheSelfServiceChain() {
+    assertSame(
+        brandingFilterChain,
+        firstChainClaiming(PREFIXED_BRANDING_PATH),
+        "the branding chain must be evaluated before any other chain claiming "
+            + PREFIXED_BRANDING_PATH);
+    assertSame(
+        brandingFilterChain,
+        firstChainClaiming(BRANDING_PATH),
+        "the branding chain must be evaluated before any other chain claiming " + BRANDING_PATH);
+  }
+
+  /**
+   * The self-service chain authenticates against the self-service user store, so a platform user
+   * can never satisfy it.
+   *
+   * <p>The chains name themselves in the challenge they emit: the self-service chain answers {@code
+   * WWW-Authenticate: Basic realm="Fineract Self Service API"}, the platform entry point used here
+   * and by Fineract's main chain answers {@code realm="Fineract Platform API"}. A branding 401
+   * carrying the former is the self-service chain having claimed the request.
+   */
+  @Test
+  @DisplayName("branding is not claimed by the self-service chain, which uses the wrong user store")
+  void brandingPaths_areNotClaimedByTheSelfServiceChain() {
+    assertFalse(
+        selfServiceFilterChain.matches(requestFor(PREFIXED_BRANDING_PATH)),
+        () ->
+            PREFIXED_BRANDING_PATH
+                + " is claimed by the self-service chain, which authenticates against the"
+                + " self-service user store. Platform users do not exist there, so every branding"
+                + " read is rejected with 401 before reaching the resource.");
+    assertFalse(
+        selfServiceFilterChain.matches(requestFor(BRANDING_PATH)),
+        () -> BRANDING_PATH + " is claimed by the self-service chain");
+  }
+
+  /**
+   * Claiming branding must not widen into anything else. Asserted as "the branding chain does not
+   * claim self-service paths" rather than "the self-service chain claims them", because which chain
+   * wins for {@code /api/v1/self/**} is decided by ordering this change does not touch.
+   */
+  @Test
+  @DisplayName("the branding chain claims nothing beyond branding")
+  void brandingChain_doesNotClaimAnythingElse() {
+    assertFalse(
+        brandingFilterChain.matches(requestFor(PREFIXED_SELF_PATH)),
+        () -> "the branding chain claims " + PREFIXED_SELF_PATH);
+    assertFalse(
+        brandingFilterChain.matches(requestFor(BARE_SELF_PATH)),
+        () -> "the branding chain claims " + BARE_SELF_PATH);
+    assertFalse(
+        brandingFilterChain.matches(requestFor("/api/v1/offices")),
+        "the branding chain claims unrelated platform paths");
+  }
+
+  /**
+   * Victor's requirement, asserted where it is actually decided. A permitted request is not
+   * rejected by security; it reaches the dispatcher, which has no JAX-RS handler registered and
+   * answers 404.
+   */
+  @Test
+  @DisplayName("an anonymous read is permitted under both spellings")
+  void anonymousRead_isPermitted() throws Exception {
+    mockMvc
+        .perform(get(PREFIXED_BRANDING_PATH).header(TENANT_HEADER, "default"))
+        .andExpect(notRejected(PREFIXED_BRANDING_PATH));
+    mockMvc
+        .perform(get(BRANDING_PATH).header(TENANT_HEADER, "default"))
+        .andExpect(notRejected(BRANDING_PATH));
+  }
+
+  /** The colour is tenant configuration: reading it is open, changing it is not. */
+  @Test
+  @DisplayName("an anonymous write is rejected under both spellings")
+  void anonymousWrite_isRejected() throws Exception {
+    mockMvc
+        .perform(
+            put(PREFIXED_BRANDING_PATH)
+                .header(TENANT_HEADER, "default")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"primaryColor\":\"green\"}"))
+        .andExpect(rejected(PREFIXED_BRANDING_PATH));
+    mockMvc
+        .perform(
+            put(BRANDING_PATH)
+                .header(TENANT_HEADER, "default")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"primaryColor\":\"green\"}"))
+        .andExpect(rejected(BRANDING_PATH));
+  }
+
+  /**
+   * @param path path being exercised, for the failure message
+   * @return matcher asserting security let the request through
+   */
+  private static ResultMatcher notRejected(final String path) {
+    return result -> {
+      final int status = result.getResponse().getStatus();
+      if (status == 401 || status == 403) {
+        throw new AssertionError(
+            "An anonymous read of " + path + " was rejected with " + status + ".");
+      }
+    };
+  }
+
+  /**
+   * @param path path being exercised, for the failure message
+   * @return matcher asserting security rejected the request
+   */
+  private static ResultMatcher rejected(final String path) {
+    return result -> {
+      final int status = result.getResponse().getStatus();
+      if (status != 401 && status != 403) {
+        throw new AssertionError(
+            "An anonymous write to "
+                + path
+                + " was answered with "
+                + status
+                + " rather than being rejected.");
+      }
+    };
+  }
+
+  /**
+   * @param path servlet relative path to test
+   * @return whether any configured chain claims the path
+   */
+  private boolean isClaimedByAnyChain(final String path) {
+    return firstChainClaiming(path) != null;
+  }
+
+  /**
+   * @param path servlet relative path to test
+   * @return the chain Spring Security would use, which is the first one matching
+   */
+  private SecurityFilterChain firstChainClaiming(final String path) {
+    final HttpServletRequest request = requestFor(path);
+    return filterChains.stream().filter(chain -> chain.matches(request)).findFirst().orElse(null);
+  }
+
+  /**
+   * Builds a request the path matchers can evaluate. {@code PathPatternRequestMatcher} reads the
+   * parsed {@code RequestPath} rather than the raw URI, so it has to be cached on the request
+   * first.
+   *
+   * @param path servlet relative path
+   * @return request positioned at that path
+   */
+  private static HttpServletRequest requestFor(final String path) {
+    final MockHttpServletRequest request = new MockHttpServletRequest("GET", path);
+    request.setServletPath(path);
+    ServletRequestPathUtils.parseAndCache(request);
+    return request;
+  }
+}

--- a/src/test/java/org/apache/fineract/branding/security/TenantBrandingSecurityTestConfig.java
+++ b/src/test/java/org/apache/fineract/branding/security/TenantBrandingSecurityTestConfig.java
@@ -1,0 +1,23 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.apache.fineract.branding.security;
+
+import org.apache.fineract.branding.starter.TenantBrandingSecurityConfiguration;
+import org.apache.fineract.selfservice.security.SelfServiceSecurityTestConfig;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+/**
+ * Stands all three chains up together, which is the only arrangement in which the branding chain's
+ * ordering can be asserted: on its own it would claim branding trivially.
+ *
+ * <p>Reuses {@link SelfServiceSecurityTestConfig} for the mocked collaborators rather than
+ * duplicating them, and adds the branding chain on top.
+ */
+@Configuration
+@Import({SelfServiceSecurityTestConfig.class, TenantBrandingSecurityConfiguration.class})
+public class TenantBrandingSecurityTestConfig {}

--- a/src/test/java/org/apache/fineract/branding/service/TenantBrandingServiceTest.java
+++ b/src/test/java/org/apache/fineract/branding/service/TenantBrandingServiceTest.java
@@ -101,6 +101,27 @@ class TenantBrandingServiceTest {
   }
 
   @Test
+  void retrieve_withoutATenantContext_isIndistinguishableFromAnUnconfiguredTenant() {
+    // Pins the failure mode that makes the filter chain wiring worth asserting
+    // (see TenantBrandingSecurityFilterChainIntegrationTest).
+    //
+    // The tenant is read off the request context, and that context is populated
+    // by TenantAwareAuthenticationFilter - a security filter. A request on a
+    // path no filter chain claims therefore arrives with no tenant at all, and
+    // this method answers "blue" rather than failing: exactly what it answers
+    // for a tenant that has never chosen a colour.
+    //
+    // So a server side misconfiguration reads as a legitimate default, and the
+    // client cannot tell either, because blue is also its fallback. Every
+    // tenant silently loses its branding with nothing anywhere reporting it.
+    ThreadLocalContextUtil.clearTenant();
+    when(repository.findByTenantId(null)).thenReturn(Optional.empty());
+
+    assertEquals("blue", service.retrieveCurrentTenantBranding().primaryColor());
+    verify(repository).findByTenantId(null);
+  }
+
+  @Test
   void update_createsTheRowOnFirstUse() {
     when(repository.findByTenantId("default")).thenReturn(Optional.empty());
 


### PR DESCRIPTION
Fixes MX-391

### Problem

`GET /v1/branding` returns 401 for callers sending valid platform credentials.

The 401 carries `WWW-Authenticate: Basic realm="Fineract Self Service API"` — a realm only `SelfServiceSecurityConfiguration` sets, so the self-service chain produced it, and that chain authenticates against the self-service user store where platform users don't exist. The body is Spring Boot's default error shape rather than Fineract's, so the request never reached the resource.

That means removing `context.authenticatedUser()` from `retrieveBranding()` cannot fix this — the rejection happens in the filter chain, before the resource runs.

### Cause

Branding is the only resource outside `/v1/self/`, so it belongs to neither chain that can claim it. Where the self-service chain claims it, platform users are rejected. Where no chain claims it, the request skips authentication *and* tenant resolution — `TenantAwareBasicAuthenticationFilter` is what sets the tenant — so every tenant silently reads the default colour.

### Change

A dedicated chain for branding, ordered ahead of the others:

- claims both `/api/v1/branding` and `/v1/branding`, so protection doesn't depend on the deployment's API prefix
- keeps the tenant filter, so the tenant always resolves
- `permitAll` on GET - the colour isn't sensitive and the login screen needs it before anyone authenticates
- authentication required for writes; `UPDATE_CONFIGURATION` stays in the resource

The order is on the `@Bean` method: a class-level `@Order` doesn't reach the `SecurityFilterChain` beans a configuration produces.

### Tests

6 new chain tests (both spellings claimed, branding chain wins first, self-service chain claims neither, anonymous read permitted, anonymous write rejected) plus one pinning the null-tenant read. No regressions in the existing self-service security suites.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tenant-aware security for branding endpoints.
  * Anonymous users can view branding with GET requests, while write operations require authentication.
  * Supports both `/api/v1/branding` and `/v1/branding` URL formats.
  * Branding requests without a tenant context now return the default blue branding.

* **Tests**
  * Added coverage for endpoint security, request routing, authentication rules, and default branding behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->