### PR TITLE
feat(MX-394): add self service user admin endpoints

### DIFF
--- a/src/main/java/org/apache/fineract/selfservice/useradministration/api/SelfServiceUserAdminApiResource.java
+++ b/src/main/java/org/apache/fineract/selfservice/useradministration/api/SelfServiceUserAdminApiResource.java
@@ -1,0 +1,142 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.apache.fineract.selfservice.useradministration.api;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import lombok.RequiredArgsConstructor;
+import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
+import org.apache.fineract.infrastructure.core.serialization.ToApiJsonSerializer;
+import org.apache.fineract.infrastructure.security.service.PlatformSecurityContext;
+import org.apache.fineract.selfservice.useradministration.data.AppSelfServiceUserData;
+import org.apache.fineract.selfservice.useradministration.service.AppSelfServiceUserReadPlatformService;
+import org.apache.fineract.selfservice.useradministration.service.SelfServiceUserAdminWritePlatformService;
+import org.springframework.stereotype.Component;
+
+/**
+ * Administrative API for managing self-service users. Each operation requires the corresponding
+ * {@code SELFSERVICEUSER} permission and service-layer office hierarchy checks.
+ */
+@Path("/v1/selfservice/users")
+@Component
+@Tag(name = "Self Service User Administration")
+@RequiredArgsConstructor
+public class SelfServiceUserAdminApiResource {
+
+  private static final String RESOURCE_NAME_FOR_PERMISSIONS = "SELFSERVICEUSER";
+
+  private final PlatformSecurityContext context;
+  private final AppSelfServiceUserReadPlatformService readPlatformService;
+  private final SelfServiceUserAdminWritePlatformService writePlatformService;
+  private final ToApiJsonSerializer<CommandProcessingResult> toApiJsonSerializer;
+
+  /**
+   * Lists self-service users visible to the authenticated administrator.
+   *
+   * @return serialized self-service user list; requires {@code READ_SELFSERVICEUSER}
+   */
+  @GET
+  @Produces({MediaType.APPLICATION_JSON})
+  public String retrieveAll() {
+    context.authenticatedUser().validateHasReadPermission(RESOURCE_NAME_FOR_PERMISSIONS);
+    return toApiJsonSerializer.serialize(readPlatformService.retrieveAllSelfServiceUsersForAdmin());
+  }
+
+  /**
+   * Retrieves one self-service user visible to the authenticated administrator.
+   *
+   * @param userId self-service user identifier
+   * @return serialized self-service user details; requires {@code READ_SELFSERVICEUSER}
+   */
+  @GET
+  @Path("{userId}")
+  @Produces({MediaType.APPLICATION_JSON})
+  public String retrieveOne(@PathParam("userId") Long userId) {
+    context.authenticatedUser().validateHasReadPermission(RESOURCE_NAME_FOR_PERMISSIONS);
+    AppSelfServiceUserData user = readPlatformService.retrieveSelfServiceUserForAdmin(userId);
+    return toApiJsonSerializer.serialize(user);
+  }
+
+  /**
+   * Activates a self-service user visible to the authenticated administrator.
+   *
+   * @param userId self-service user identifier
+   * @return serialized command result; requires {@code UPDATE_SELFSERVICEUSER}
+   */
+  @PUT
+  @Path("{userId}/activate")
+  @Produces({MediaType.APPLICATION_JSON})
+  public String activate(@PathParam("userId") Long userId) {
+    context.authenticatedUser().validateHasUpdatePermission(RESOURCE_NAME_FOR_PERMISSIONS);
+    return toApiJsonSerializer.serialize(writePlatformService.activate(userId));
+  }
+
+  /**
+   * Inactivates a self-service user visible to the authenticated administrator.
+   *
+   * @param userId self-service user identifier
+   * @return serialized command result; requires {@code UPDATE_SELFSERVICEUSER}
+   */
+  @PUT
+  @Path("{userId}/inactivate")
+  @Produces({MediaType.APPLICATION_JSON})
+  public String inactivate(@PathParam("userId") Long userId) {
+    context.authenticatedUser().validateHasUpdatePermission(RESOURCE_NAME_FOR_PERMISSIONS);
+    return toApiJsonSerializer.serialize(writePlatformService.inactivate(userId));
+  }
+
+  /**
+   * Links a visible self-service user to a visible client.
+   *
+   * @param userId self-service user identifier
+   * @param clientId client identifier
+   * @return serialized command result; requires {@code UPDATE_SELFSERVICEUSER}
+   */
+  @PUT
+  @Path("{userId}/clients/{clientId}")
+  @Produces({MediaType.APPLICATION_JSON})
+  public String linkClient(@PathParam("userId") Long userId, @PathParam("clientId") Long clientId) {
+    context.authenticatedUser().validateHasUpdatePermission(RESOURCE_NAME_FOR_PERMISSIONS);
+    return toApiJsonSerializer.serialize(writePlatformService.linkClient(userId, clientId));
+  }
+
+  /**
+   * Removes an existing client link from a visible self-service user.
+   *
+   * @param userId self-service user identifier
+   * @param clientId client identifier
+   * @return serialized command result; requires {@code UPDATE_SELFSERVICEUSER}
+   */
+  @DELETE
+  @Path("{userId}/clients/{clientId}")
+  @Produces({MediaType.APPLICATION_JSON})
+  public String delinkClient(
+      @PathParam("userId") Long userId, @PathParam("clientId") Long clientId) {
+    context.authenticatedUser().validateHasUpdatePermission(RESOURCE_NAME_FOR_PERMISSIONS);
+    return toApiJsonSerializer.serialize(writePlatformService.delinkClient(userId, clientId));
+  }
+
+  /**
+   * Soft-deletes a visible self-service user and releases its unique username.
+   *
+   * @param userId self-service user identifier
+   * @return serialized command result; requires {@code DELETE_SELFSERVICEUSER}
+   */
+  @DELETE
+  @Path("{userId}")
+  @Produces({MediaType.APPLICATION_JSON})
+  public String delete(@PathParam("userId") Long userId) {
+    context.authenticatedUser().validateHasDeletePermission(RESOURCE_NAME_FOR_PERMISSIONS);
+    return toApiJsonSerializer.serialize(writePlatformService.delete(userId));
+  }
+}

--- a/src/main/java/org/apache/fineract/selfservice/useradministration/data/AppSelfServiceUserData.java
+++ b/src/main/java/org/apache/fineract/selfservice/useradministration/data/AppSelfServiceUserData.java
@@ -30,8 +30,11 @@ public final class AppSelfServiceUserData {
   private final Long officeId;
   private final String officeName;
   private final String firstname;
+  private final String middleName;
   private final String lastname;
   private final String email;
+  private final Boolean enabled;
+  private final Boolean deleted;
   private final Boolean passwordNeverExpires;
 
   // import fields
@@ -92,8 +95,11 @@ public final class AppSelfServiceUserData {
     this.officeId = officeId;
     this.officeName = null;
     this.firstname = firstname;
+    this.middleName = null;
     this.lastname = lastname;
     this.email = email;
+    this.enabled = null;
+    this.deleted = null;
     this.passwordNeverExpires = passwordNeverExpires;
     this.roles = roleIds;
     this.sendPasswordToEmail = sendPasswordToEmail;
@@ -121,7 +127,10 @@ public final class AppSelfServiceUserData {
         user.officeId,
         user.officeName,
         user.firstname,
+        user.middleName,
         user.lastname,
+        user.enabled,
+        user.deleted,
         user.availableRoles,
         user.selfServiceRoles,
         user.selectedRoles,
@@ -143,6 +152,9 @@ public final class AppSelfServiceUserData {
         null,
         null,
         null,
+        null,
+        null,
+        null,
         availableRoles,
         selfServiceRoles,
         null,
@@ -154,7 +166,8 @@ public final class AppSelfServiceUserData {
 
   public static AppSelfServiceUserData dropdown(final Long id, final String username) {
     return new AppSelfServiceUserData(
-        id, username, null, null, null, null, null, null, null, null, null, null, null, null);
+        id, username, null, null, null, null, null, null, null, null, null, null, null, null, null,
+        null, null);
   }
 
   public static AppSelfServiceUserData instance(
@@ -178,7 +191,10 @@ public final class AppSelfServiceUserData {
         officeId,
         officeName,
         firstname,
+        null,
         lastname,
+        null,
+        null,
         availableRoles,
         selfServiceRoles,
         selectedRoles,
@@ -195,7 +211,10 @@ public final class AppSelfServiceUserData {
       final Long officeId,
       final String officeName,
       final String firstname,
+      final String middleName,
       final String lastname,
+      final Boolean enabled,
+      final Boolean deleted,
       final Collection<RoleData> availableRoles,
       final Collection<RoleData> selfServiceRoles,
       final Collection<RoleData> selectedRoles,
@@ -208,8 +227,11 @@ public final class AppSelfServiceUserData {
     this.officeId = officeId;
     this.officeName = officeName;
     this.firstname = firstname;
+    this.middleName = middleName;
     this.lastname = lastname;
     this.email = email;
+    this.enabled = enabled;
+    this.deleted = deleted;
     this.allowedOffices = allowedOffices;
     this.availableRoles = availableRoles;
     this.selfServiceRoles = selfServiceRoles;
@@ -219,8 +241,48 @@ public final class AppSelfServiceUserData {
     this.isSelfServiceUser = isSelfServiceUser;
   }
 
+  public static AppSelfServiceUserData adminInstance(
+      final Long id,
+      final String username,
+      final String email,
+      final Long officeId,
+      final String officeName,
+      final String firstname,
+      final String middleName,
+      final String lastname,
+      final Boolean enabled,
+      final Boolean deleted,
+      final Collection<RoleData> availableRoles,
+      final Collection<RoleData> selectedRoles,
+      final StaffData staff,
+      final Boolean passwordNeverExpire,
+      final Boolean isSelfServiceUser) {
+    return new AppSelfServiceUserData(
+        id,
+        username,
+        email,
+        officeId,
+        officeName,
+        firstname,
+        middleName,
+        lastname,
+        enabled,
+        deleted,
+        availableRoles,
+        null,
+        selectedRoles,
+        null,
+        staff,
+        passwordNeverExpire,
+        isSelfServiceUser);
+  }
+
   public boolean hasIdentifyOf(final Long createdById) {
     return this.id.equals(createdById);
+  }
+
+  public Long getId() {
+    return this.id;
   }
 
   public String username() {

--- a/src/main/java/org/apache/fineract/selfservice/useradministration/domain/AppSelfServiceUser.java
+++ b/src/main/java/org/apache/fineract/selfservice/useradministration/domain/AppSelfServiceUser.java
@@ -428,6 +428,10 @@ public class AppSelfServiceUser extends AbstractPersistableCustom<Long>
     this.roles.clear();
   }
 
+  public void disable() {
+    this.enabled = false;
+  }
+
   public boolean isDeleted() {
     return this.deleted;
   }

--- a/src/main/java/org/apache/fineract/selfservice/useradministration/domain/AppSelfServiceUserClientMappingRepository.java
+++ b/src/main/java/org/apache/fineract/selfservice/useradministration/domain/AppSelfServiceUserClientMappingRepository.java
@@ -15,6 +15,7 @@
 package org.apache.fineract.selfservice.useradministration.domain;
 
 import java.util.Optional;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -29,16 +30,22 @@ public interface AppSelfServiceUserClientMappingRepository
 
   @Modifying(clearAutomatically = true)
   @Transactional
+  @CacheEvict(
+      value = {
+        "appSelfServiceUserClientFetchByClientId",
+        "appSelfServiceUserUserClientFetchByAppuserUsername",
+        "appSelfServiceUserUserClientFetchByAppUserId"
+      },
+      allEntries = true)
   @Query(
       value =
           "INSERT INTO m_selfservice_user_client_mapping (appuser_id, client_id) VALUES (?1, ?2)",
       nativeQuery = true)
-  void saveClientUserMapping(
-      @Param("appuserId") Long appuserId, @Param("clientId") Long clientId);
+  void saveClientUserMapping(@Param("appuserId") Long appuserId, @Param("clientId") Long clientId);
 
   /**
-   * Lookup mapping by Fineract client id (backoffice / webhook flows).
-   * Cache key is tenant-scoped for multi-tenant safety.
+   * Lookup mapping by Fineract client id (backoffice / webhook flows). Cache key is tenant-scoped
+   * for multi-tenant safety.
    *
    * @return mapping or {@code null} if none exists
    */
@@ -53,8 +60,8 @@ public interface AppSelfServiceUserClientMappingRepository
   AppSelfServiceUserClientMapping fetchByClientId(@Param("clientId") Long clientId);
 
   /**
-   * Same as {@link #fetchByClientId(Long)} but as {@link Optional} for safer null handling
-   * in onboarding / KYC backoffice APIs.
+   * Same as {@link #fetchByClientId(Long)} but as {@link Optional} for safer null handling in
+   * onboarding / KYC backoffice APIs.
    */
   @Query(
       "SELECT appUserMapping FROM AppSelfServiceUserClientMapping appUserMapping"
@@ -88,11 +95,24 @@ public interface AppSelfServiceUserClientMappingRepository
               + ".getTenant().getTenantIdentifier().concat(#appUserId)")
   AppSelfServiceUserClientMapping fetchByAppUserId(@Param("appUserId") Long appUserId);
 
-  /**
-   * Optional variant of {@link #fetchByAppUserId(Long)}.
-   */
+  /** Optional variant of {@link #fetchByAppUserId(Long)}. */
   @Query(
       "SELECT appUserMapping FROM AppSelfServiceUserClientMapping appUserMapping"
           + " WHERE appUserMapping.appUser.id = :appUserId")
   Optional<AppSelfServiceUserClientMapping> findByAppUserId(@Param("appUserId") Long appUserId);
+
+  boolean existsByAppUserIdAndClientId(Long appUserId, Long clientId);
+
+  boolean existsByClientId(Long clientId);
+
+  @Modifying(clearAutomatically = true)
+  @Transactional
+  @CacheEvict(
+      value = {
+        "appSelfServiceUserClientFetchByClientId",
+        "appSelfServiceUserUserClientFetchByAppuserUsername",
+        "appSelfServiceUserUserClientFetchByAppUserId"
+      },
+      allEntries = true)
+  void deleteByAppUserIdAndClientId(Long appUserId, Long clientId);
 }

--- a/src/main/java/org/apache/fineract/selfservice/useradministration/domain/AppSelfServiceUserRepository.java
+++ b/src/main/java/org/apache/fineract/selfservice/useradministration/domain/AppSelfServiceUserRepository.java
@@ -16,6 +16,7 @@ package org.apache.fineract.selfservice.useradministration.domain;
 
 import java.util.Collection;
 import org.apache.fineract.selfservice.security.domain.PlatformSelfServiceUserRepository;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
@@ -32,4 +33,17 @@ public interface AppSelfServiceUserRepository
   AppSelfServiceUser findAppSelfServiceUserByName(@Param("username") String username);
 
   Collection<AppSelfServiceUser> findByOfficeId(Long officeId);
+
+  @Query(
+      "select appSelfServiceUser from AppSelfServiceUser appSelfServiceUser where"
+          + " appSelfServiceUser.id = :userId and appSelfServiceUser.office.hierarchy like"
+          + " :officeHierarchy")
+  AppSelfServiceUser findByIdAndOfficeHierarchy(
+      @Param("userId") Long userId, @Param("officeHierarchy") String officeHierarchy);
+
+  @EntityGraph(attributePaths = {"appUserClientMappings", "appUserClientMappings.client"})
+  @Query(
+      "select appSelfServiceUser from AppSelfServiceUser appSelfServiceUser where"
+          + " appSelfServiceUser.id in :userIds")
+  Collection<AppSelfServiceUser> findByIdIn(Collection<Long> userIds);
 }

--- a/src/main/java/org/apache/fineract/selfservice/useradministration/service/AppSelfServiceUserReadPlatformService.java
+++ b/src/main/java/org/apache/fineract/selfservice/useradministration/service/AppSelfServiceUserReadPlatformService.java
@@ -16,6 +16,7 @@ package org.apache.fineract.selfservice.useradministration.service;
 
 import java.util.Collection;
 import org.apache.fineract.selfservice.useradministration.data.AppSelfServiceUserData;
+import org.apache.fineract.selfservice.useradministration.domain.AppSelfServiceUser;
 
 public interface AppSelfServiceUserReadPlatformService {
 
@@ -26,6 +27,12 @@ public interface AppSelfServiceUserReadPlatformService {
   AppSelfServiceUserData retrieveNewSelfServiceUserDetails();
 
   AppSelfServiceUserData retrieveSelfServiceUser(Long userId);
+
+  Collection<AppSelfServiceUserData> retrieveAllSelfServiceUsersForAdmin();
+
+  AppSelfServiceUserData retrieveSelfServiceUserForAdmin(Long userId);
+
+  AppSelfServiceUser retrieveSelfServiceUserDomainForAdmin(Long userId);
 
   boolean isUsernameExist(String username);
 }

--- a/src/main/java/org/apache/fineract/selfservice/useradministration/service/AppSelfServiceUserReadPlatformServiceImpl.java
+++ b/src/main/java/org/apache/fineract/selfservice/useradministration/service/AppSelfServiceUserReadPlatformServiceImpl.java
@@ -19,9 +19,13 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.apache.fineract.infrastructure.core.domain.JdbcSupport;
+import org.apache.fineract.infrastructure.security.service.PlatformSecurityContext;
 import org.apache.fineract.organisation.office.data.OfficeData;
 import org.apache.fineract.organisation.office.service.OfficeReadPlatformService;
 import org.apache.fineract.organisation.staff.data.StaffData;
@@ -47,6 +51,7 @@ public class AppSelfServiceUserReadPlatformServiceImpl
     implements AppSelfServiceUserReadPlatformService {
 
   private final PlatformSelfServiceSecurityContext context;
+  private final PlatformSecurityContext platformSecurityContext;
   private final JdbcTemplate jdbcTemplate;
   private final OfficeReadPlatformService officeReadPlatformService;
   private final SelfServiceRoleReadPlatformService roleReadPlatformService;
@@ -68,14 +73,7 @@ public class AppSelfServiceUserReadPlatformServiceImpl
   public Collection<AppSelfServiceUserData> retrieveAllSelfServiceUsers() {
 
     final AppSelfServiceUser currentUser = this.context.authenticatedSelfServiceUser();
-    final String hierarchy = currentUser.getOffice().getHierarchy();
-    final String hierarchySearchString = hierarchy + "%";
-
-    final AppSelfServiceUserMapper mapper =
-        new AppSelfServiceUserMapper(this.roleReadPlatformService, this.staffReadPlatformService);
-    final String sql = "select " + mapper.schema();
-
-    return this.jdbcTemplate.query(sql, mapper, new Object[] {hierarchySearchString}); // NOSONAR
+    return retrieveAllSelfServiceUsers(currentUser.getOffice().getHierarchy(), false);
   }
 
   @Override
@@ -116,6 +114,59 @@ public class AppSelfServiceUserReadPlatformServiceImpl
       throw new UserNotFoundException(userId);
     }
 
+    return toUserData(user, false);
+  }
+
+  @Override
+  public Collection<AppSelfServiceUserData> retrieveAllSelfServiceUsersForAdmin() {
+    final String hierarchy =
+        this.platformSecurityContext.authenticatedUser().getOffice().getHierarchy();
+    return retrieveAllSelfServiceUsers(hierarchy, true);
+  }
+
+  @Override
+  public AppSelfServiceUserData retrieveSelfServiceUserForAdmin(final Long userId) {
+    final AppSelfServiceUser user = retrieveSelfServiceUserDomainForAdmin(userId);
+    return toUserData(user, true);
+  }
+
+  @Override
+  public AppSelfServiceUser retrieveSelfServiceUserDomainForAdmin(final Long userId) {
+    final String hierarchySearchString = this.platformSecurityContext.officeHierarchy() + "%";
+    final AppSelfServiceUser user =
+        this.appUserRepository.findByIdAndOfficeHierarchy(userId, hierarchySearchString);
+    if (user == null || user.isDeleted()) {
+      throw new UserNotFoundException(userId);
+    }
+    return user;
+  }
+
+  private Collection<AppSelfServiceUserData> retrieveAllSelfServiceUsers(
+      final String hierarchy, final boolean includeAdminFields) {
+    final String hierarchySearchString = hierarchy + "%";
+    final AppSelfServiceUserMapper mapper =
+        new AppSelfServiceUserMapper(
+            this.roleReadPlatformService, this.staffReadPlatformService, includeAdminFields);
+    final String sql = "select " + mapper.schema();
+    final Collection<AppSelfServiceUserData> users =
+        this.jdbcTemplate.query(sql, mapper, new Object[] {hierarchySearchString}); // NOSONAR
+    if (includeAdminFields && !users.isEmpty()) {
+      Map<Long, AppSelfServiceUser> usersById =
+          this.appUserRepository
+              .findByIdIn(users.stream().map(AppSelfServiceUserData::getId).toList())
+              .stream()
+              .collect(Collectors.toMap(AppSelfServiceUser::getId, Function.identity()));
+      for (AppSelfServiceUserData userData : users) {
+        AppSelfServiceUser user = usersById.get(userData.getId());
+        if (user != null) {
+          appendClients(userData, user);
+        }
+      }
+    }
+    return users;
+  }
+
+  private AppSelfServiceUserData toUserData(final AppSelfServiceUser user, boolean includeStatus) {
     final Collection<RoleData> availableRoles = this.roleReadPlatformService.retrieveAll();
 
     final Collection<RoleData> selectedUserRoles = new ArrayList<>();
@@ -134,22 +185,28 @@ public class AppSelfServiceUserReadPlatformServiceImpl
     }
 
     AppSelfServiceUserData retUser =
-        AppSelfServiceUserData.instance(
+        AppSelfServiceUserData.adminInstance(
             user.getId(),
             user.getUsername(),
             user.getEmail(),
             user.getOffice().getId(),
             user.getOffice().getName(),
             user.getFirstname(),
-            user.getLastname(),
-            availableRoles,
             null,
+            user.getLastname(),
+            includeStatus ? user.isEnabled() : null,
+            includeStatus ? user.isDeleted() : null,
+            availableRoles,
             selectedUserRoles,
             linkedStaff,
             user.getPasswordNeverExpires(),
             user.isSelfServiceUser());
+    appendClients(retUser, user);
+    return retUser;
+  }
 
-    if (retUser.isSelfServiceUser()) {
+  private void appendClients(AppSelfServiceUserData userData, AppSelfServiceUser user) {
+    if (userData.isSelfServiceUser() && user.getAppUserClientMappings() != null) {
       Set<ClientData> clients = new HashSet<>();
       for (AppSelfServiceUserClientMapping clientMap : user.getAppUserClientMappings()) {
         Client client = clientMap.getClient();
@@ -160,22 +217,23 @@ public class AppSelfServiceUserReadPlatformServiceImpl
                 client.getOffice().getId(),
                 client.getOffice().getName()));
       }
-      retUser.setClients(clients);
+      userData.setClients(clients);
     }
-
-    return retUser;
   }
 
   private static final class AppSelfServiceUserMapper implements RowMapper<AppSelfServiceUserData> {
 
     private final SelfServiceRoleReadPlatformService roleReadPlatformService;
     private final StaffReadService staffReadPlatformService;
+    private final boolean includeAdminFields;
 
     AppSelfServiceUserMapper(
         final SelfServiceRoleReadPlatformService roleReadPlatformService,
-        final StaffReadService staffReadPlatformService) {
+        final StaffReadService staffReadPlatformService,
+        final boolean includeAdminFields) {
       this.roleReadPlatformService = roleReadPlatformService;
       this.staffReadPlatformService = staffReadPlatformService;
+      this.includeAdminFields = includeAdminFields;
     }
 
     @Override
@@ -192,6 +250,8 @@ public class AppSelfServiceUserReadPlatformServiceImpl
       final Long staffId = JdbcSupport.getLong(rs, "staffId");
       final Boolean passwordNeverExpire = rs.getBoolean("passwordNeverExpires");
       final Boolean isSelfServiceUser = rs.getBoolean("isSelfServiceUser");
+      final Boolean enabled = rs.getBoolean("enabled");
+      final Boolean deleted = rs.getBoolean("deleted");
       final Collection<RoleData> selectedRoles =
           this.roleReadPlatformService.retrieveAppUserRoles(id);
 
@@ -201,15 +261,17 @@ public class AppSelfServiceUserReadPlatformServiceImpl
       } else {
         linkedStaff = null;
       }
-      return AppSelfServiceUserData.instance(
+      return AppSelfServiceUserData.adminInstance(
           id,
           username,
           email,
           officeId,
           officeName,
           firstname,
-          lastname,
           null,
+          lastname,
+          includeAdminFields ? enabled : null,
+          includeAdminFields ? deleted : null,
           null,
           selectedRoles,
           linkedStaff,
@@ -221,7 +283,8 @@ public class AppSelfServiceUserReadPlatformServiceImpl
       return " u.id as id, u.username as username, u.firstname as firstname, u.lastname as"
           + " lastname, u.email as email, u.password_never_expires as passwordNeverExpires, "
           + " u.office_id as officeId, o.name as officeName, u.staff_id as staffId,"
-          + " u.is_self_service_user as isSelfServiceUser from m_appselfservice_user u  join"
+          + " u.is_self_service_user as isSelfServiceUser, u.enabled as enabled,"
+          + " u.is_deleted as deleted from m_appselfservice_user u  join"
           + " m_office o on o.id = u.office_id where o.hierarchy like ? and"
           + " u.is_deleted=false order by u.username";
     }

--- a/src/main/java/org/apache/fineract/selfservice/useradministration/service/SelfServiceUserAdminWritePlatformService.java
+++ b/src/main/java/org/apache/fineract/selfservice/useradministration/service/SelfServiceUserAdminWritePlatformService.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.apache.fineract.selfservice.useradministration.service;
+
+import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
+
+public interface SelfServiceUserAdminWritePlatformService {
+
+  CommandProcessingResult activate(Long userId);
+
+  CommandProcessingResult inactivate(Long userId);
+
+  CommandProcessingResult linkClient(Long userId, Long clientId);
+
+  CommandProcessingResult delinkClient(Long userId, Long clientId);
+
+  CommandProcessingResult delete(Long userId);
+}

--- a/src/main/java/org/apache/fineract/selfservice/useradministration/service/SelfServiceUserAdminWritePlatformServiceImpl.java
+++ b/src/main/java/org/apache/fineract/selfservice/useradministration/service/SelfServiceUserAdminWritePlatformServiceImpl.java
@@ -1,0 +1,141 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.apache.fineract.selfservice.useradministration.service;
+
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
+import org.apache.fineract.infrastructure.core.exception.PlatformDataIntegrityException;
+import org.apache.fineract.infrastructure.security.service.PlatformSecurityContext;
+import org.apache.fineract.portfolio.client.domain.ClientRepositoryWrapper;
+import org.apache.fineract.selfservice.useradministration.domain.AppSelfServiceUser;
+import org.apache.fineract.selfservice.useradministration.domain.AppSelfServiceUserClientMappingRepository;
+import org.apache.fineract.selfservice.useradministration.domain.AppSelfServiceUserRepository;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+public class SelfServiceUserAdminWritePlatformServiceImpl
+    implements SelfServiceUserAdminWritePlatformService {
+
+  private static final String USER_CLIENT_MAPPING_UNIQUE_CONSTRAINT = "appuser_id_client_id";
+  private static final String CLIENT_MAPPING_UNIQUE_CONSTRAINT = "unique_self_client";
+
+  private final AppSelfServiceUserRepository userRepository;
+  private final AppSelfServiceUserClientMappingRepository mappingRepository;
+  private final ClientRepositoryWrapper clientRepositoryWrapper;
+  private final AppSelfServiceUserReadPlatformService readPlatformService;
+  private final PlatformSecurityContext context;
+
+  @Override
+  @Transactional
+  public CommandProcessingResult activate(Long userId) {
+    AppSelfServiceUser user = findUser(userId);
+    user.enable();
+    userRepository.saveAndFlush(user);
+    return CommandProcessingResult.withChanges(userId, Map.of("enabled", true));
+  }
+
+  @Override
+  @Transactional
+  public CommandProcessingResult inactivate(Long userId) {
+    AppSelfServiceUser user = findUser(userId);
+    user.disable();
+    userRepository.saveAndFlush(user);
+    return CommandProcessingResult.withChanges(userId, Map.of("enabled", false));
+  }
+
+  @Override
+  @Transactional
+  public CommandProcessingResult linkClient(Long userId, Long clientId) {
+    AppSelfServiceUser user = findUser(userId);
+    clientRepositoryWrapper.getClientByClientIdAndHierarchy(clientId, hierarchySearchString());
+
+    if (mappingRepository.existsByAppUserIdAndClientId(userId, clientId)) {
+      throw duplicateUserClientMapping(userId, clientId);
+    }
+    if (mappingRepository.existsByClientId(clientId)) {
+      throw clientAlreadyLinked(clientId);
+    }
+
+    try {
+      mappingRepository.saveClientUserMapping(user.getId(), clientId);
+    } catch (DataIntegrityViolationException e) {
+      throw translateClientMappingConstraintViolation(userId, clientId, e);
+    }
+    return CommandProcessingResult.withChanges(userId, Map.of("clientId", clientId));
+  }
+
+  @Override
+  @Transactional
+  public CommandProcessingResult delinkClient(Long userId, Long clientId) {
+    findUser(userId);
+    clientRepositoryWrapper.getClientByClientIdAndHierarchy(clientId, hierarchySearchString());
+    if (!mappingRepository.existsByAppUserIdAndClientId(userId, clientId)) {
+      throw new PlatformDataIntegrityException(
+          "error.msg.self.service.user.client.mapping.not.found",
+          "Self-service user " + userId + " is not linked to client " + clientId + ".",
+          "clientId",
+          clientId);
+    }
+    mappingRepository.deleteByAppUserIdAndClientId(userId, clientId);
+    return CommandProcessingResult.withChanges(userId, Map.of("clientId", clientId));
+  }
+
+  @Override
+  @Transactional
+  @CacheEvict(
+      value = {
+        "appSelfServiceUserClientFetchByClientId",
+        "appSelfServiceUserUserClientFetchByAppuserUsername",
+        "appSelfServiceUserUserClientFetchByAppUserId"
+      },
+      allEntries = true)
+  public CommandProcessingResult delete(Long userId) {
+    AppSelfServiceUser user = findUser(userId);
+    user.delete();
+    userRepository.saveAndFlush(user);
+    return CommandProcessingResult.withChanges(userId, Map.of("deleted", true));
+  }
+
+  private AppSelfServiceUser findUser(Long userId) {
+    return readPlatformService.retrieveSelfServiceUserDomainForAdmin(userId);
+  }
+
+  private String hierarchySearchString() {
+    return context.officeHierarchy() + "%";
+  }
+
+  private PlatformDataIntegrityException translateClientMappingConstraintViolation(
+      Long userId, Long clientId, DataIntegrityViolationException exception) {
+    String message = exception.getMostSpecificCause().getMessage();
+    if (message != null && message.contains(USER_CLIENT_MAPPING_UNIQUE_CONSTRAINT)) {
+      return duplicateUserClientMapping(userId, clientId);
+    }
+    if (message != null && message.contains(CLIENT_MAPPING_UNIQUE_CONSTRAINT)) {
+      return clientAlreadyLinked(clientId);
+    }
+    throw exception;
+  }
+
+  private PlatformDataIntegrityException duplicateUserClientMapping(Long userId, Long clientId) {
+    return new PlatformDataIntegrityException(
+        "error.msg.self.service.user.client.mapping.duplicate",
+        "Self-service user " + userId + " is already linked to client " + clientId + ".",
+        "clientId",
+        clientId);
+  }
+
+  private PlatformDataIntegrityException clientAlreadyLinked(Long clientId) {
+    return new PlatformDataIntegrityException(
+        "error.msg.self.service.client.already.linked",
+        "Client " + clientId + " is already linked to a self-service user.",
+        "clientId",
+        clientId);
+  }
+}

--- a/src/main/java/org/apache/fineract/selfservice/useradministration/starter/SelfServiceUserAdministrationConfiguration.java
+++ b/src/main/java/org/apache/fineract/selfservice/useradministration/starter/SelfServiceUserAdministrationConfiguration.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.apache.fineract.selfservice.useradministration.starter;
+
+import org.apache.fineract.infrastructure.security.service.PlatformSecurityContext;
+import org.apache.fineract.portfolio.client.domain.ClientRepositoryWrapper;
+import org.apache.fineract.selfservice.useradministration.domain.AppSelfServiceUserClientMappingRepository;
+import org.apache.fineract.selfservice.useradministration.domain.AppSelfServiceUserRepository;
+import org.apache.fineract.selfservice.useradministration.service.AppSelfServiceUserReadPlatformService;
+import org.apache.fineract.selfservice.useradministration.service.SelfServiceUserAdminWritePlatformService;
+import org.apache.fineract.selfservice.useradministration.service.SelfServiceUserAdminWritePlatformServiceImpl;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SelfServiceUserAdministrationConfiguration {
+
+  @Bean
+  @ConditionalOnMissingBean(SelfServiceUserAdminWritePlatformService.class)
+  public SelfServiceUserAdminWritePlatformService selfServiceUserAdminWritePlatformService(
+      AppSelfServiceUserRepository userRepository,
+      AppSelfServiceUserClientMappingRepository mappingRepository,
+      ClientRepositoryWrapper clientRepositoryWrapper,
+      AppSelfServiceUserReadPlatformService readPlatformService,
+      PlatformSecurityContext context) {
+    return new SelfServiceUserAdminWritePlatformServiceImpl(
+        userRepository, mappingRepository, clientRepositoryWrapper, readPlatformService, context);
+  }
+}

--- a/src/main/resources/db/changelog/tenant/module/selfservice/module-changelog-master.xml
+++ b/src/main/resources/db/changelog/tenant/module/selfservice/module-changelog-master.xml
@@ -82,4 +82,5 @@
   <include file="parts/069-enrich-same-bank-transfer-audit.xml" relativeToChangelogFile="true"/>  
   <include file="parts/070-add-request-audit-table.xml" relativeToChangelogFile="true"/>  
   <include file="parts/071-add-onboarding-grants.xml" relativeToChangelogFile="true"/>
+  <include file="parts/072-add-selfservice-user-admin-permissions.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/tenant/module/selfservice/parts/072-add-selfservice-user-admin-permissions.xml
+++ b/src/main/resources/db/changelog/tenant/module/selfservice/parts/072-add-selfservice-user-admin-permissions.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
+
+  <changeSet author="fineract" id="ss-0058-1-add-selfservice-user-admin-permissions">
+    <preConditions onFail="MARK_RAN">
+      <tableExists tableName="m_permission"/>
+    </preConditions>
+    <sql>
+      INSERT INTO m_permission (grouping, code, entity_name, action_name, can_maker_checker)
+      SELECT 'user administration', 'READ_SELFSERVICEUSER', 'SELFSERVICEUSER', 'READ', false
+      WHERE NOT EXISTS (SELECT 1 FROM m_permission WHERE code = 'READ_SELFSERVICEUSER');
+
+      INSERT INTO m_permission (grouping, code, entity_name, action_name, can_maker_checker)
+      SELECT 'user administration', 'UPDATE_SELFSERVICEUSER', 'SELFSERVICEUSER', 'UPDATE', false
+      WHERE NOT EXISTS (SELECT 1 FROM m_permission WHERE code = 'UPDATE_SELFSERVICEUSER');
+
+      INSERT INTO m_permission (grouping, code, entity_name, action_name, can_maker_checker)
+      SELECT 'user administration', 'DELETE_SELFSERVICEUSER', 'SELFSERVICEUSER', 'DELETE', false
+      WHERE NOT EXISTS (SELECT 1 FROM m_permission WHERE code = 'DELETE_SELFSERVICEUSER');
+    </sql>
+  </changeSet>
+</databaseChangeLog>

--- a/src/test/java/org/apache/fineract/selfservice/security/SelfServiceSecurityFilterChainIntegrationTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/security/SelfServiceSecurityFilterChainIntegrationTest.java
@@ -98,6 +98,21 @@ class SelfServiceSecurityFilterChainIntegrationTest {
   }
 
   @Test
+  void selfServiceUserAdminEndpoint_isNotHandledBySelfServiceSecurityChain() throws Exception {
+    ResultMatcher notHandledBySelfServiceChain =
+        result -> {
+          int status = result.getResponse().getStatus();
+          if (status != 404) {
+            throw new AssertionError("Expected status to be 404, but was " + status);
+          }
+        };
+
+    mockMvc
+        .perform(get("/v1/selfservice/users").header("Fineract-Platform-TenantId", "default"))
+        .andExpect(notHandledBySelfServiceChain);
+  }
+
+  @Test
   void nonSelfEndpoint_isNotAffectedByOurFilterChain() throws Exception {
     ResultMatcher notUnauthorized =
         result -> {

--- a/src/test/java/org/apache/fineract/selfservice/useradministration/api/SelfServiceUserAdminApiResourceIntegrationTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/useradministration/api/SelfServiceUserAdminApiResourceIntegrationTest.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.apache.fineract.selfservice.useradministration.api;
+
+import static io.restassured.RestAssured.given;
+
+import org.apache.fineract.selfservice.testing.support.SelfServiceIntegrationTestBase;
+import org.apache.fineract.selfservice.testing.support.SelfServiceTestUtils;
+import org.junit.jupiter.api.Test;
+
+class SelfServiceUserAdminApiResourceIntegrationTest extends SelfServiceIntegrationTestBase {
+
+  private static final String ADMIN_USERS_PATH =
+      SelfServiceTestUtils.CONTEXT_PATH + "/api/v1/selfservice/users";
+  private static final String PUBLIC_SELF_USERS_PATH =
+      SelfServiceTestUtils.CONTEXT_PATH + "/api/v1/self/users";
+
+  @Test
+  void retrieveAll_shouldRouteAuthenticatedBackofficeRequest() {
+    given(SelfServiceTestUtils.requestSpecWithAuth(getFineractPort(), "mifos", "password"))
+        .when()
+        .get(ADMIN_USERS_PATH)
+        .then()
+        .statusCode(200);
+  }
+
+  @Test
+  void retrieveOne_shouldRouteAuthenticatedBackofficeRequest() {
+    given(SelfServiceTestUtils.requestSpecWithAuth(getFineractPort(), "mifos", "password"))
+        .when()
+        .get(ADMIN_USERS_PATH + "/999999999")
+        .then()
+        .statusCode(404);
+  }
+
+  @Test
+  void retrieveAll_shouldNotBeExposedUnderPublicSelfApi() {
+    given(SelfServiceTestUtils.requestSpec(getFineractPort()))
+        .when()
+        .get(PUBLIC_SELF_USERS_PATH)
+        .then()
+        .statusCode(403);
+  }
+}

--- a/src/test/java/org/apache/fineract/selfservice/useradministration/api/SelfServiceUserAdminApiResourceTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/useradministration/api/SelfServiceUserAdminApiResourceTest.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.apache.fineract.selfservice.useradministration.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
+import org.apache.fineract.infrastructure.core.serialization.ToApiJsonSerializer;
+import org.apache.fineract.infrastructure.security.service.PlatformSecurityContext;
+import org.apache.fineract.selfservice.useradministration.data.AppSelfServiceUserData;
+import org.apache.fineract.selfservice.useradministration.service.AppSelfServiceUserReadPlatformService;
+import org.apache.fineract.selfservice.useradministration.service.SelfServiceUserAdminWritePlatformService;
+import org.apache.fineract.useradministration.domain.AppUser;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class SelfServiceUserAdminApiResourceTest {
+
+  private PlatformSecurityContext context;
+  private AppUser staffUser;
+  private AppSelfServiceUserReadPlatformService readPlatformService;
+  private ToApiJsonSerializer<CommandProcessingResult> serializer;
+  private SelfServiceUserAdminApiResource resource;
+
+  @BeforeEach
+  void setUp() {
+    context = mock(PlatformSecurityContext.class);
+    staffUser = mock(AppUser.class);
+    readPlatformService = mock(AppSelfServiceUserReadPlatformService.class);
+    SelfServiceUserAdminWritePlatformService writePlatformService =
+        mock(SelfServiceUserAdminWritePlatformService.class);
+    serializer = mock(ToApiJsonSerializer.class);
+    when(context.authenticatedUser()).thenReturn(staffUser);
+    resource =
+        new SelfServiceUserAdminApiResource(
+            context, readPlatformService, writePlatformService, serializer);
+  }
+
+  @Test
+  void retrieveAll_shouldRequireReadPermissionAndSerializeUsers() {
+    List<AppSelfServiceUserData> users =
+        List.of(
+            AppSelfServiceUserData.adminInstance(
+                10L, "reader", null, null, null, null, null, null, true, false, null, null, null,
+                null, true));
+    when(readPlatformService.retrieveAllSelfServiceUsersForAdmin()).thenReturn(users);
+    when(serializer.serialize(users)).thenReturn("users-json");
+
+    String result = resource.retrieveAll();
+
+    assertEquals("users-json", result);
+    verify(staffUser).validateHasReadPermission("SELFSERVICEUSER");
+    verify(readPlatformService).retrieveAllSelfServiceUsersForAdmin();
+  }
+
+  @Test
+  void retrieveOne_shouldRequireReadPermissionAndSerializeUser() {
+    AppSelfServiceUserData user =
+        AppSelfServiceUserData.adminInstance(
+            10L, "reader", null, null, null, null, null, null, true, false, null, null, null, null,
+            true);
+    when(readPlatformService.retrieveSelfServiceUserForAdmin(10L)).thenReturn(user);
+    when(serializer.serialize(user)).thenReturn("user-json");
+
+    String result = resource.retrieveOne(10L);
+
+    assertEquals("user-json", result);
+    verify(staffUser).validateHasReadPermission("SELFSERVICEUSER");
+    verify(readPlatformService).retrieveSelfServiceUserForAdmin(10L);
+  }
+}

--- a/src/test/java/org/apache/fineract/selfservice/useradministration/domain/AppSelfServiceUserTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/useradministration/domain/AppSelfServiceUserTest.java
@@ -95,12 +95,23 @@ class AppSelfServiceUserTest {
   @Test
   void delete_shouldSoftDelete() {
     AppSelfServiceUser user = createUser(new HashSet<>());
+    setId(user, 99L);
     user.delete();
 
     assertTrue(user.isDeleted());
     assertFalse(user.isEnabled());
     assertFalse(user.isAccountNonExpired());
-    assertTrue(user.getUsername().contains("DELETED"));
+    assertEquals("99_DELETED_testuser", user.getUsername());
+  }
+
+  @Test
+  void disable_shouldInactivateWithoutDeletingOrRenamingUsername() {
+    AppSelfServiceUser user = createUser(new HashSet<>());
+    user.disable();
+
+    assertFalse(user.isEnabled());
+    assertFalse(user.isDeleted());
+    assertEquals("testuser", user.getUsername());
   }
 
   @Test
@@ -195,5 +206,15 @@ class AppSelfServiceUserTest {
     AppSelfServiceUser user = createUser(new HashSet<>());
     assertNull(user.getStaffId());
     assertNull(user.getStaff());
+  }
+
+  private void setId(AppSelfServiceUser user, Long id) {
+    try {
+      var idField = AppSelfServiceUser.class.getSuperclass().getDeclaredField("id");
+      idField.setAccessible(true);
+      idField.set(user, id);
+    } catch (ReflectiveOperationException e) {
+      throw new IllegalStateException(e);
+    }
   }
 }

--- a/src/test/java/org/apache/fineract/selfservice/useradministration/service/AppSelfServiceUserReadPlatformServiceImplTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/useradministration/service/AppSelfServiceUserReadPlatformServiceImplTest.java
@@ -1,0 +1,247 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.apache.fineract.selfservice.useradministration.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.apache.fineract.infrastructure.businessdate.domain.BusinessDateType;
+import org.apache.fineract.infrastructure.core.domain.FineractPlatformTenant;
+import org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil;
+import org.apache.fineract.infrastructure.security.service.PlatformSecurityContext;
+import org.apache.fineract.organisation.office.domain.Office;
+import org.apache.fineract.organisation.office.service.OfficeReadPlatformService;
+import org.apache.fineract.organisation.staff.service.StaffReadService;
+import org.apache.fineract.portfolio.client.domain.Client;
+import org.apache.fineract.selfservice.security.service.PlatformSelfServiceSecurityContext;
+import org.apache.fineract.selfservice.useradministration.data.AppSelfServiceUserData;
+import org.apache.fineract.selfservice.useradministration.domain.AppSelfServiceUser;
+import org.apache.fineract.selfservice.useradministration.domain.AppSelfServiceUserRepository;
+import org.apache.fineract.useradministration.domain.AppUser;
+import org.apache.fineract.useradministration.exception.UserNotFoundException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+
+class AppSelfServiceUserReadPlatformServiceImplTest {
+
+  private PlatformSecurityContext platformSecurityContext;
+  private JdbcTemplate jdbcTemplate;
+  private AppSelfServiceUserRepository userRepository;
+  private SelfServiceRoleReadPlatformService roleReadPlatformService;
+  private AppSelfServiceUserReadPlatformServiceImpl service;
+
+  @BeforeEach
+  void setUp() {
+    FineractPlatformTenant tenant =
+        new FineractPlatformTenant(1L, "default", "Default Tenant", "UTC", null);
+    ThreadLocalContextUtil.setTenant(tenant);
+    HashMap<BusinessDateType, LocalDate> businessDates = new HashMap<>();
+    businessDates.put(BusinessDateType.BUSINESS_DATE, LocalDate.now());
+    businessDates.put(BusinessDateType.COB_DATE, LocalDate.now().minusDays(1));
+    ThreadLocalContextUtil.setBusinessDates(businessDates);
+
+    PlatformSelfServiceSecurityContext selfServiceContext =
+        mock(PlatformSelfServiceSecurityContext.class);
+    platformSecurityContext = mock(PlatformSecurityContext.class);
+    jdbcTemplate = mock(JdbcTemplate.class);
+    OfficeReadPlatformService officeReadPlatformService = mock(OfficeReadPlatformService.class);
+    roleReadPlatformService = mock(SelfServiceRoleReadPlatformService.class);
+    userRepository = mock(AppSelfServiceUserRepository.class);
+    StaffReadService staffReadPlatformService = mock(StaffReadService.class);
+    service =
+        new AppSelfServiceUserReadPlatformServiceImpl(
+            selfServiceContext,
+            platformSecurityContext,
+            jdbcTemplate,
+            officeReadPlatformService,
+            roleReadPlatformService,
+            userRepository,
+            staffReadPlatformService);
+    when(roleReadPlatformService.retrieveAll()).thenReturn(new ArrayList<>());
+  }
+
+  @AfterEach
+  void tearDown() {
+    ThreadLocalContextUtil.clearTenant();
+  }
+
+  @Test
+  void retrieveSelfServiceUserForAdmin_shouldReturnStatusAndLinkedClients() throws Exception {
+    AppSelfServiceUser user = user(10L, "reader", true, client(20L, "Client One"));
+    when(platformSecurityContext.officeHierarchy()).thenReturn(".");
+    when(userRepository.findByIdAndOfficeHierarchy(10L, ".%")).thenReturn(user);
+
+    AppSelfServiceUserData result = service.retrieveSelfServiceUserForAdmin(10L);
+
+    assertEquals(10L, result.getId());
+    assertEquals("reader", field(result, "username"));
+    assertTrue((Boolean) field(result, "enabled"));
+    assertFalse((Boolean) field(result, "deleted"));
+    Set<?> clients = (Set<?>) field(result, "clients");
+    assertEquals(1, clients.size());
+    Object client = clients.iterator().next();
+    assertEquals(20L, field(client, "id"));
+    assertEquals("Client One", field(client, "displayName"));
+  }
+
+  @Test
+  void retrieveSelfServiceUserForAdmin_shouldReturnInactiveStatus() throws Exception {
+    AppSelfServiceUser user = user(10L, "inactive", true);
+    user.disable();
+    when(platformSecurityContext.officeHierarchy()).thenReturn(".");
+    when(userRepository.findByIdAndOfficeHierarchy(10L, ".%")).thenReturn(user);
+
+    AppSelfServiceUserData result = service.retrieveSelfServiceUserForAdmin(10L);
+
+    assertFalse((Boolean) field(result, "enabled"));
+    assertFalse((Boolean) field(result, "deleted"));
+  }
+
+  @Test
+  void retrieveSelfServiceUserForAdmin_shouldPreserveDeletedUserBehavior() {
+    AppSelfServiceUser user = user(10L, "deleted", true);
+    user.delete();
+    when(platformSecurityContext.officeHierarchy()).thenReturn(".");
+    when(userRepository.findByIdAndOfficeHierarchy(10L, ".%")).thenReturn(user);
+
+    assertThrows(UserNotFoundException.class, () -> service.retrieveSelfServiceUserForAdmin(10L));
+  }
+
+  @Test
+  void retrieveSelfServiceUserForAdmin_shouldRejectUserOutsideHierarchy() {
+    when(platformSecurityContext.officeHierarchy()).thenReturn(".");
+    when(userRepository.findByIdAndOfficeHierarchy(10L, ".%")).thenReturn(null);
+
+    assertThrows(UserNotFoundException.class, () -> service.retrieveSelfServiceUserForAdmin(10L));
+    verify(userRepository).findByIdAndOfficeHierarchy(10L, ".%");
+  }
+
+  @Test
+  void retrieveAllSelfServiceUsersForAdmin_shouldUseAdminHierarchyAndAppendClients()
+      throws Exception {
+    AppUser admin = mock(AppUser.class);
+    Office office = mock(Office.class);
+    when(office.getHierarchy()).thenReturn(".");
+    when(admin.getOffice()).thenReturn(office);
+    when(platformSecurityContext.authenticatedUser()).thenReturn(admin);
+
+    AppSelfServiceUserData row =
+        AppSelfServiceUserData.adminInstance(
+            10L,
+            "reader",
+            null,
+            1L,
+            "Head Office",
+            "Read",
+            null,
+            "User",
+            true,
+            false,
+            null,
+            null,
+            null,
+            true,
+            true);
+    when(jdbcTemplate.query(anyString(), any(RowMapper.class), eq(new Object[] {".%"})))
+        .thenReturn(List.of(row));
+    AppSelfServiceUser linkedUser = user(10L, "reader", true, client(20L, "Client One"));
+    when(userRepository.findByIdIn(List.of(10L))).thenReturn(List.of(linkedUser));
+
+    Collection<AppSelfServiceUserData> result = service.retrieveAllSelfServiceUsersForAdmin();
+
+    AppSelfServiceUserData user = result.iterator().next();
+    assertEquals(10L, user.getId());
+    assertTrue((Boolean) field(user, "enabled"));
+    assertFalse((Boolean) field(user, "deleted"));
+    assertEquals(1, ((Set<?>) field(user, "clients")).size());
+    verify(platformSecurityContext).authenticatedUser();
+    verify(userRepository).findByIdIn(List.of(10L));
+  }
+
+  private AppSelfServiceUser user(
+      Long id, String username, boolean selfService, Client... clients) {
+    Office office = mock(Office.class);
+    when(office.getId()).thenReturn(1L);
+    when(office.getName()).thenReturn("Head Office");
+    List<SimpleGrantedAuthority> authorities = List.of(new SimpleGrantedAuthority("DUMMY"));
+    AppSelfServiceUser user =
+        new AppSelfServiceUser(
+            office,
+            new User(username, "password", authorities),
+            new HashSet<>(),
+            username + "@example.com",
+            "Test",
+            "User",
+            null,
+            true,
+            selfService,
+            List.of(clients),
+            false);
+    setId(user, id);
+    return user;
+  }
+
+  private Client client(Long id, String displayName) {
+    Office office = mock(Office.class);
+    when(office.getId()).thenReturn(1L);
+    when(office.getName()).thenReturn("Head Office");
+    Client client = mock(Client.class);
+    when(client.getId()).thenReturn(id);
+    when(client.getDisplayName()).thenReturn(displayName);
+    when(client.getOffice()).thenReturn(office);
+    return client;
+  }
+
+  private void setId(AppSelfServiceUser user, Long id) {
+    try {
+      Field idField = AppSelfServiceUser.class.getSuperclass().getDeclaredField("id");
+      idField.setAccessible(true);
+      idField.set(user, id);
+    } catch (ReflectiveOperationException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  private Object field(Object target, String fieldName) throws Exception {
+    Field field = findField(target.getClass(), fieldName);
+    field.setAccessible(true);
+    return field.get(target);
+  }
+
+  private Field findField(Class<?> type, String fieldName) throws NoSuchFieldException {
+    Class<?> current = type;
+    while (current != null) {
+      try {
+        return current.getDeclaredField(fieldName);
+      } catch (NoSuchFieldException e) {
+        current = current.getSuperclass();
+      }
+    }
+    throw new NoSuchFieldException(fieldName);
+  }
+}

--- a/src/test/java/org/apache/fineract/selfservice/useradministration/service/SelfServiceUserAdminWritePlatformServiceImplTest.java
+++ b/src/test/java/org/apache/fineract/selfservice/useradministration/service/SelfServiceUserAdminWritePlatformServiceImplTest.java
@@ -1,0 +1,306 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.apache.fineract.selfservice.useradministration.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import org.apache.fineract.infrastructure.businessdate.domain.BusinessDateType;
+import org.apache.fineract.infrastructure.core.domain.FineractPlatformTenant;
+import org.apache.fineract.infrastructure.core.exception.PlatformDataIntegrityException;
+import org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil;
+import org.apache.fineract.infrastructure.security.service.PlatformSecurityContext;
+import org.apache.fineract.organisation.office.domain.Office;
+import org.apache.fineract.portfolio.client.domain.Client;
+import org.apache.fineract.portfolio.client.domain.ClientRepositoryWrapper;
+import org.apache.fineract.selfservice.useradministration.domain.AppSelfServiceUser;
+import org.apache.fineract.selfservice.useradministration.domain.AppSelfServiceUserClientMappingRepository;
+import org.apache.fineract.selfservice.useradministration.domain.AppSelfServiceUserRepository;
+import org.apache.fineract.useradministration.exception.UserNotFoundException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+
+class SelfServiceUserAdminWritePlatformServiceImplTest {
+
+  private AppSelfServiceUserRepository userRepository;
+  private AppSelfServiceUserClientMappingRepository mappingRepository;
+  private ClientRepositoryWrapper clientRepositoryWrapper;
+  private AppSelfServiceUserReadPlatformService readPlatformService;
+  private PlatformSecurityContext context;
+  private SelfServiceUserAdminWritePlatformServiceImpl service;
+
+  @BeforeEach
+  void setUp() {
+    FineractPlatformTenant tenant =
+        new FineractPlatformTenant(1L, "default", "Default Tenant", "UTC", null);
+    ThreadLocalContextUtil.setTenant(tenant);
+    HashMap<BusinessDateType, LocalDate> businessDates = new HashMap<>();
+    businessDates.put(BusinessDateType.BUSINESS_DATE, LocalDate.now());
+    businessDates.put(BusinessDateType.COB_DATE, LocalDate.now().minusDays(1));
+    ThreadLocalContextUtil.setBusinessDates(businessDates);
+
+    userRepository = mock(AppSelfServiceUserRepository.class);
+    mappingRepository = mock(AppSelfServiceUserClientMappingRepository.class);
+    clientRepositoryWrapper = mock(ClientRepositoryWrapper.class);
+    readPlatformService = mock(AppSelfServiceUserReadPlatformService.class);
+    context = mock(PlatformSecurityContext.class);
+    when(context.officeHierarchy()).thenReturn(".");
+    service =
+        new SelfServiceUserAdminWritePlatformServiceImpl(
+            userRepository,
+            mappingRepository,
+            clientRepositoryWrapper,
+            readPlatformService,
+            context);
+  }
+
+  @AfterEach
+  void tearDown() {
+    ThreadLocalContextUtil.clearTenant();
+  }
+
+  @Test
+  void activate_shouldEnableExistingUser() {
+    AppSelfServiceUser user = user(10L);
+    user.disable();
+    when(readPlatformService.retrieveSelfServiceUserDomainForAdmin(10L)).thenReturn(user);
+
+    service.activate(10L);
+
+    assertTrue(user.isEnabled());
+    verify(userRepository).saveAndFlush(user);
+  }
+
+  @Test
+  void inactivate_shouldDisableExistingUser() {
+    AppSelfServiceUser user = user(10L);
+    when(readPlatformService.retrieveSelfServiceUserDomainForAdmin(10L)).thenReturn(user);
+
+    service.inactivate(10L);
+
+    assertFalse(user.isEnabled());
+    assertFalse(user.isDeleted());
+    verify(userRepository).saveAndFlush(user);
+  }
+
+  @Test
+  void linkClient_shouldRejectDuplicateUserClientLink() {
+    AppSelfServiceUser user = user(10L);
+    when(readPlatformService.retrieveSelfServiceUserDomainForAdmin(10L)).thenReturn(user);
+    when(clientRepositoryWrapper.getClientByClientIdAndHierarchy(20L, ".%"))
+        .thenReturn(mock(Client.class));
+    when(mappingRepository.existsByAppUserIdAndClientId(10L, 20L)).thenReturn(true);
+
+    assertThrows(PlatformDataIntegrityException.class, () -> service.linkClient(10L, 20L));
+    verify(mappingRepository).existsByAppUserIdAndClientId(10L, 20L);
+    verifyNoMoreInteractions(mappingRepository);
+  }
+
+  @Test
+  void linkClient_shouldRejectClientAlreadyLinkedToAnotherUser() {
+    AppSelfServiceUser user = user(10L);
+    when(readPlatformService.retrieveSelfServiceUserDomainForAdmin(10L)).thenReturn(user);
+    when(clientRepositoryWrapper.getClientByClientIdAndHierarchy(20L, ".%"))
+        .thenReturn(mock(Client.class));
+    when(mappingRepository.existsByAppUserIdAndClientId(10L, 20L)).thenReturn(false);
+    when(mappingRepository.existsByClientId(20L)).thenReturn(true);
+
+    assertThrows(PlatformDataIntegrityException.class, () -> service.linkClient(10L, 20L));
+  }
+
+  @Test
+  void linkClient_shouldCreateMappingWhenValid() {
+    AppSelfServiceUser user = user(10L);
+    when(readPlatformService.retrieveSelfServiceUserDomainForAdmin(10L)).thenReturn(user);
+    when(clientRepositoryWrapper.getClientByClientIdAndHierarchy(20L, ".%"))
+        .thenReturn(mock(Client.class));
+    when(mappingRepository.existsByAppUserIdAndClientId(10L, 20L)).thenReturn(false);
+    when(mappingRepository.existsByClientId(20L)).thenReturn(false);
+
+    service.linkClient(10L, 20L);
+
+    verify(clientRepositoryWrapper).getClientByClientIdAndHierarchy(20L, ".%");
+    verify(mappingRepository).saveClientUserMapping(10L, 20L);
+  }
+
+  @Test
+  void linkClient_shouldTranslateDuplicateUserClientConstraintViolation() {
+    AppSelfServiceUser user = user(10L);
+    when(readPlatformService.retrieveSelfServiceUserDomainForAdmin(10L)).thenReturn(user);
+    when(clientRepositoryWrapper.getClientByClientIdAndHierarchy(20L, ".%"))
+        .thenReturn(mock(Client.class));
+    when(mappingRepository.existsByAppUserIdAndClientId(10L, 20L)).thenReturn(false);
+    when(mappingRepository.existsByClientId(20L)).thenReturn(false);
+    whenSaveMappingFails("Duplicate entry for key 'appuser_id_client_id'");
+
+    assertThrows(PlatformDataIntegrityException.class, () -> service.linkClient(10L, 20L));
+  }
+
+  @Test
+  void linkClient_shouldTranslateClientAlreadyLinkedConstraintViolation() {
+    AppSelfServiceUser user = user(10L);
+    when(readPlatformService.retrieveSelfServiceUserDomainForAdmin(10L)).thenReturn(user);
+    when(clientRepositoryWrapper.getClientByClientIdAndHierarchy(20L, ".%"))
+        .thenReturn(mock(Client.class));
+    when(mappingRepository.existsByAppUserIdAndClientId(10L, 20L)).thenReturn(false);
+    when(mappingRepository.existsByClientId(20L)).thenReturn(false);
+    whenSaveMappingFails("Duplicate entry for key 'unique_self_client'");
+
+    assertThrows(PlatformDataIntegrityException.class, () -> service.linkClient(10L, 20L));
+  }
+
+  @Test
+  void delinkClient_shouldRejectMissingMapping() {
+    AppSelfServiceUser user = user(10L);
+    when(readPlatformService.retrieveSelfServiceUserDomainForAdmin(10L)).thenReturn(user);
+    when(clientRepositoryWrapper.getClientByClientIdAndHierarchy(20L, ".%"))
+        .thenReturn(mock(Client.class));
+    when(mappingRepository.existsByAppUserIdAndClientId(10L, 20L)).thenReturn(false);
+
+    assertThrows(PlatformDataIntegrityException.class, () -> service.delinkClient(10L, 20L));
+  }
+
+  @Test
+  void delinkClient_shouldDeleteExistingMapping() {
+    AppSelfServiceUser user = user(10L);
+    when(readPlatformService.retrieveSelfServiceUserDomainForAdmin(10L)).thenReturn(user);
+    when(clientRepositoryWrapper.getClientByClientIdAndHierarchy(20L, ".%"))
+        .thenReturn(mock(Client.class));
+    when(mappingRepository.existsByAppUserIdAndClientId(10L, 20L)).thenReturn(true);
+
+    service.delinkClient(10L, 20L);
+
+    verify(clientRepositoryWrapper).getClientByClientIdAndHierarchy(20L, ".%");
+    verify(mappingRepository).deleteByAppUserIdAndClientId(10L, 20L);
+  }
+
+  @Test
+  void delete_shouldSoftDeleteAndReleaseUsername() {
+    AppSelfServiceUser user = user(10L);
+    when(readPlatformService.retrieveSelfServiceUserDomainForAdmin(10L)).thenReturn(user);
+
+    service.delete(10L);
+
+    assertTrue(user.isDeleted());
+    assertFalse(user.isEnabled());
+    assertEquals("10_DELETED_testuser", user.getUsername());
+    verify(userRepository).saveAndFlush(user);
+  }
+
+  @Test
+  void activate_shouldRejectUserOutsideHierarchy() {
+    when(readPlatformService.retrieveSelfServiceUserDomainForAdmin(10L))
+        .thenThrow(new UserNotFoundException(10L));
+
+    assertThrows(UserNotFoundException.class, () -> service.activate(10L));
+    verifyNoInteractions(userRepository);
+  }
+
+  @Test
+  void inactivate_shouldRejectUserOutsideHierarchy() {
+    when(readPlatformService.retrieveSelfServiceUserDomainForAdmin(10L))
+        .thenThrow(new UserNotFoundException(10L));
+
+    assertThrows(UserNotFoundException.class, () -> service.inactivate(10L));
+    verifyNoInteractions(userRepository);
+  }
+
+  @Test
+  void linkClient_shouldRejectUserOutsideHierarchyBeforeClientLookup() {
+    when(readPlatformService.retrieveSelfServiceUserDomainForAdmin(10L))
+        .thenThrow(new UserNotFoundException(10L));
+
+    assertThrows(UserNotFoundException.class, () -> service.linkClient(10L, 20L));
+    verifyNoInteractions(clientRepositoryWrapper, mappingRepository);
+  }
+
+  @Test
+  void delinkClient_shouldRejectUserOutsideHierarchyBeforeClientLookup() {
+    when(readPlatformService.retrieveSelfServiceUserDomainForAdmin(10L))
+        .thenThrow(new UserNotFoundException(10L));
+
+    assertThrows(UserNotFoundException.class, () -> service.delinkClient(10L, 20L));
+    verifyNoInteractions(clientRepositoryWrapper, mappingRepository);
+  }
+
+  @Test
+  void delete_shouldRejectUserOutsideHierarchy() {
+    when(readPlatformService.retrieveSelfServiceUserDomainForAdmin(10L))
+        .thenThrow(new UserNotFoundException(10L));
+
+    assertThrows(UserNotFoundException.class, () -> service.delete(10L));
+    verifyNoInteractions(userRepository);
+  }
+
+  @Test
+  void delete_shouldRejectRepeatedDeleteWithoutRenamingAgain() {
+    AppSelfServiceUser user = user(10L);
+    when(readPlatformService.retrieveSelfServiceUserDomainForAdmin(10L))
+        .thenReturn(user)
+        .thenThrow(new UserNotFoundException(10L));
+
+    service.delete(10L);
+    String deletedUsername = user.getUsername();
+
+    assertThrows(UserNotFoundException.class, () -> service.delete(10L));
+    assertEquals(deletedUsername, user.getUsername());
+    verify(userRepository).saveAndFlush(user);
+  }
+
+  private AppSelfServiceUser user(Long id) {
+    Office office = mock(Office.class);
+    ArrayList<SimpleGrantedAuthority> authorities = new ArrayList<>();
+    authorities.add(new SimpleGrantedAuthority("DUMMY"));
+    AppSelfServiceUser user =
+        new AppSelfServiceUser(
+            office,
+            new User("testuser", "password", authorities),
+            new HashSet<>(),
+            "test@example.com",
+            "Test",
+            "User",
+            null,
+            true,
+            true,
+            new ArrayList<>(),
+            false);
+    setId(user, id);
+    return user;
+  }
+
+  private void setId(AppSelfServiceUser user, Long id) {
+    try {
+      Field idField = AppSelfServiceUser.class.getSuperclass().getDeclaredField("id");
+      idField.setAccessible(true);
+      idField.set(user, id);
+    } catch (ReflectiveOperationException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  private void whenSaveMappingFails(String message) {
+    org.mockito.Mockito.doThrow(new DataIntegrityViolationException(message))
+        .when(mappingRepository)
+        .saveClientUserMapping(10L, 20L);
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added administrator APIs to list and view self-service users.
  - Added controls to activate, deactivate, soft-delete, link, and unlink clients from users.
  - Added visibility of user status and linked clients.
  - Added hierarchy-based access restrictions and permission controls.
  - Added permissions for reading, updating, and deleting self-service users.

- **Tests**
  - Added comprehensive unit and integration coverage for administration, security, status changes, client mappings, and access restrictions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->