### PR TITLE
MX-395: Support additional tenant theme colours and custom hex colours

### DIFF
--- a/src/main/java/org/apache/fineract/branding/api/TenantBrandingApiResource.java
+++ b/src/main/java/org/apache/fineract/branding/api/TenantBrandingApiResource.java
@@ -63,7 +63,9 @@ public class TenantBrandingApiResource {
   @Operation(
       summary = "Retrieve Tenant Branding",
       description =
-          "Returns the primary colour for the authenticated tenant.\n\n"
+          "Returns the primary colour for the authenticated tenant, either a supported named colour"
+              + " or a six digit hex colour. A tenant that has never set one, or whose stored value"
+              + " is no longer supported, reads as blue.\n\n"
               + "Example Request:\n\n"
               + "branding")
   @ApiResponse(responseCode = "200", description = "OK")
@@ -84,8 +86,12 @@ public class TenantBrandingApiResource {
   @Operation(
       summary = "Update Tenant Branding",
       description =
-          "Sets the primary colour for the authenticated tenant. Supported colours are blue, green,"
-              + " purple, orange, red and yellow.\n\n"
+          "Sets the primary colour for the authenticated tenant.\n\n"
+              + "The primary colour is either one of the supported named colours - blue, green,"
+              + " purple, orange, red, yellow, pink, light-green and black - or a six digit hex"
+              + " colour such as #3f51b5. Named colours are matched case insensitively and stored"
+              + " in lower case; a hex colour keeps the case it was given. Surrounding whitespace"
+              + " is removed from both. Anything else is rejected.\n\n"
               + "Example Request:\n\n"
               + "branding")
   @ApiResponse(responseCode = "200", description = "OK")

--- a/src/main/java/org/apache/fineract/branding/service/TenantBrandingService.java
+++ b/src/main/java/org/apache/fineract/branding/service/TenantBrandingService.java
@@ -8,6 +8,8 @@ package org.apache.fineract.branding.service;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
+import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
 import org.apache.fineract.branding.data.TenantBrandingData;
 import org.apache.fineract.branding.domain.TenantBranding;
@@ -36,11 +38,26 @@ public class TenantBrandingService {
   public static final String DEFAULT_PRIMARY_COLOR = "blue";
 
   /**
-   * Colours a client application is expected to render. Kept deliberately small: each one has to
-   * carry white label text at WCAG AA in the clients that consume it.
+   * Named colours a client application is expected to render. Each one has to carry white label
+   * text at WCAG AA in the clients that consume it, which is why the named set stays curated rather
+   * than growing to cover every colour a tenant might want; a tenant that wants one of those picks
+   * a hex colour instead.
+   *
+   * <p>Values are stored exactly as listed here, so entries may be added but must not be renamed:
+   * existing rows reference them.
    */
   public static final List<String> SUPPORTED_PRIMARY_COLORS =
-      List.of("blue", "green", "purple", "orange", "red", "yellow");
+      List.of("blue", "green", "purple", "orange", "red", "yellow", "pink", "light-green", "black");
+
+  /**
+   * A six digit hex colour, the only free form value accepted.
+   *
+   * <p>Anchored and limited to hex digits so the colour cannot carry anything but a colour: a
+   * client drops this value straight into a stylesheet, so shapes such as {@code rgb(...)}, {@code
+   * url(...)}, {@code var(...)} or markup must never reach one. Three digit shorthand is rejected
+   * too, keeping one stored form per colour.
+   */
+  private static final Pattern HEX_COLOR_PATTERN = Pattern.compile("^#[0-9A-Fa-f]{6}$");
 
   private final TenantBrandingRepository repository;
 
@@ -61,29 +78,69 @@ public class TenantBrandingService {
   /**
    * Maps a stored colour onto one a client can actually render.
    *
-   * <p>Rows are not only written through {@link #updateCurrentTenantBranding(String)}: the column is
-   * nullable for older rows, and a colour can be retired from {@link #SUPPORTED_PRIMARY_COLORS}
+   * <p>Rows are not only written through {@link #updateCurrentTenantBranding(String)}: the column
+   * is nullable for older rows, and a colour can be retired from {@link #SUPPORTED_PRIMARY_COLORS}
    * while rows still reference it. Reading is therefore defensive, so the endpoint never hands a
    * client a value it cannot use.
+   *
+   * <p>Only an unusable value is replaced. A supported colour - named or hex - is returned as its
+   * canonical form and nothing else, so reading is idempotent: a stored {@code #3f51b5} reads back
+   * as {@code #3f51b5} however many times it is read, rather than drifting towards the default or
+   * towards another shade.
    *
    * @param storedColor colour as held in the database, possibly null
    * @return a supported colour, never null
    */
   private static String normalisedOrDefault(final String storedColor) {
-    final String normalised = storedColor.trim().toLowerCase();
-    return SUPPORTED_PRIMARY_COLORS.contains(normalised) ? normalised : DEFAULT_PRIMARY_COLOR;
+    final String canonical = canonicalPrimaryColor(storedColor);
+    return canonical == null ? DEFAULT_PRIMARY_COLOR : canonical;
+  }
+
+  /**
+   * @param primaryColor colour as supplied by a client or held in the database
+   * @return true when the colour is a supported named colour or a six digit hex colour
+   */
+  public static boolean isSupportedPrimaryColor(final String primaryColor) {
+    return canonicalPrimaryColor(primaryColor) != null;
+  }
+
+  /**
+   * Reduces a colour to the single form it is stored and served in.
+   *
+   * <p>A named colour is matched case insensitively and canonicalised to lower case, which is how
+   * existing rows are held. A hex colour keeps the case it was given: {@code #FFFFFF} and {@code
+   * #ffffff} are the same colour, and rewriting one into the other would change what a client is
+   * handed back for no benefit.
+   *
+   * <p>Case folding is pinned to {@link Locale#ROOT} because the tenant's locale must not decide
+   * whether a colour is recognised - under a Turkish locale the default folding turns the {@code I}
+   * of {@code LIGHT-GREEN} into a dotless {@code ı}, which would match nothing.
+   *
+   * @param primaryColor colour as supplied, possibly null
+   * @return the canonical colour, or null when it is neither a named nor a hex colour
+   */
+  private static String canonicalPrimaryColor(final String primaryColor) {
+    if (primaryColor == null) {
+      return null;
+    }
+    final String trimmed = primaryColor.trim();
+    if (HEX_COLOR_PATTERN.matcher(trimmed).matches()) {
+      return trimmed;
+    }
+    final String named = trimmed.toLowerCase(Locale.ROOT);
+    return SUPPORTED_PRIMARY_COLORS.contains(named) ? named : null;
   }
 
   /**
    * Sets the current tenant's primary colour, creating the row on first use.
    *
-   * @param primaryColor one of {@link #SUPPORTED_PRIMARY_COLORS}
+   * @param primaryColor one of {@link #SUPPORTED_PRIMARY_COLORS}, or a six digit hex colour
    * @return the stored branding
    * @throws PlatformApiDataValidationException if the colour is missing or unsupported
    */
   @Transactional
   public TenantBrandingData updateCurrentTenantBranding(final String primaryColor) {
-    validate(primaryColor);
+    final String canonicalColor = validated(primaryColor);
 
     final String tenantIdentifier = currentTenantIdentifier();
     final TenantBranding branding =
@@ -96,24 +153,48 @@ public class TenantBrandingService {
                   return created;
                 });
 
-    branding.setPrimaryColor(primaryColor.trim().toLowerCase());
+    branding.setPrimaryColor(canonicalColor);
     repository.save(branding);
 
     return new TenantBrandingData(branding.getPrimaryColor());
   }
 
-  private void validate(final String primaryColor) {
+  /**
+   * Checks a colour and reduces it to the form it is stored in.
+   *
+   * <p>The two accepted shapes are alternatives rather than successive constraints, so the check
+   * cannot be expressed as a chain of {@link DataValidatorBuilder} rules - each rule in a chain
+   * adds its own error, and a hex colour would fail the named colour rule. The decision is
+   * therefore taken once, in {@link #canonicalPrimaryColor(String)}, and only its outcome is
+   * reported through the builder, which keeps one definition of what a supported colour is.
+   *
+   * @param primaryColor colour as supplied by the client
+   * @return the canonical colour
+   * @throws PlatformApiDataValidationException if the colour is missing or unsupported
+   */
+  private String validated(final String primaryColor) {
     final List<ApiParameterError> dataValidationErrors = new ArrayList<>();
-    new DataValidatorBuilder(dataValidationErrors)
-        .resource(RESOURCE_NAME)
-        .parameter("primaryColor")
-        .value(primaryColor == null ? null : primaryColor.trim().toLowerCase())
-        .notBlank()
-        .isOneOfTheseStringValues(SUPPORTED_PRIMARY_COLORS);
+    final DataValidatorBuilder validator =
+        new DataValidatorBuilder(dataValidationErrors)
+            .resource(RESOURCE_NAME)
+            .parameter("primaryColor")
+            .value(primaryColor)
+            .notBlank();
+
+    final String canonicalColor = canonicalPrimaryColor(primaryColor);
+    // Reported only when the value is present: a missing colour is already
+    // covered by notBlank, and both errors describe the same one mistake.
+    if (dataValidationErrors.isEmpty() && canonicalColor == null) {
+      validator.failWithCode(
+          "is.not.a.supported.colour",
+          String.join(", ", SUPPORTED_PRIMARY_COLORS),
+          HEX_COLOR_PATTERN.pattern());
+    }
 
     if (!dataValidationErrors.isEmpty()) {
       throw new PlatformApiDataValidationException(dataValidationErrors);
     }
+    return canonicalColor;
   }
 
   private String currentTenantIdentifier() {

--- a/src/test/java/org/apache/fineract/branding/api/TenantBrandingApiResourceTest.java
+++ b/src/test/java/org/apache/fineract/branding/api/TenantBrandingApiResourceTest.java
@@ -7,20 +7,31 @@
 package org.apache.fineract.branding.api;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.Optional;
 import org.apache.fineract.branding.data.TenantBrandingData;
+import org.apache.fineract.branding.domain.TenantBranding;
+import org.apache.fineract.branding.domain.TenantBrandingRepository;
 import org.apache.fineract.branding.service.TenantBrandingService;
+import org.apache.fineract.infrastructure.core.domain.FineractPlatformTenant;
+import org.apache.fineract.infrastructure.core.exception.PlatformApiDataValidationException;
 import org.apache.fineract.infrastructure.core.serialization.DefaultToApiJsonSerializer;
 import org.apache.fineract.infrastructure.core.serialization.FromJsonHelper;
+import org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil;
 import org.apache.fineract.infrastructure.security.service.PlatformSecurityContext;
 import org.apache.fineract.useradministration.domain.AppUser;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
 
 class TenantBrandingApiResourceTest {
 
@@ -50,7 +61,6 @@ class TenantBrandingApiResourceTest {
     when(service.retrieveCurrentTenantBranding()).thenReturn(new TenantBrandingData("blue"));
 
     resource.retrieveBranding();
-
   }
 
   @Test
@@ -102,5 +112,58 @@ class TenantBrandingApiResourceTest {
     resource.updateBranding("{}");
 
     verify(service).updateCurrentTenantBranding(null);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"pink", "light-green", "black", "#3f51b5", "#FFFFFF"})
+  void update_readsTheColoursAddedForTheWebAppFromTheRequestBody(final String colour) {
+    // The hex forms carry a `#`, which has to survive JSON parsing untouched.
+    when(service.updateCurrentTenantBranding(colour)).thenReturn(new TenantBrandingData(colour));
+
+    resource.updateBranding("{\"primaryColor\":\"" + colour + "\"}");
+
+    verify(service).updateCurrentTenantBranding(colour);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"pink", "light-green", "black", "#3f51b5", "#FFFFFF"})
+  void update_storesTheColoursAddedForTheWebApp(final String colour) {
+    // End to end through the real service, so this asserts the endpoint itself
+    // accepts the values rather than only that the resource forwards them.
+    final TenantBrandingRepository repository = mock(TenantBrandingRepository.class);
+    when(repository.findByTenantId("default")).thenReturn(Optional.empty());
+
+    resourceBackedBy(repository).updateBranding("{\"primaryColor\":\"" + colour + "\"}");
+
+    final ArgumentCaptor<TenantBranding> saved = ArgumentCaptor.forClass(TenantBranding.class);
+    verify(repository).save(saved.capture());
+    assertEquals(colour, saved.getValue().getPrimaryColor());
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"foobar", "123456", "#12345", "#GGGGGG", "rgb(1,2,3)", "javascript:x"})
+  void update_rejectsAnInvalidColourEndToEnd(final String colour) {
+    final TenantBrandingRepository repository = mock(TenantBrandingRepository.class);
+    final TenantBrandingApiResource endToEnd = resourceBackedBy(repository);
+
+    assertThrows(
+        PlatformApiDataValidationException.class,
+        () -> endToEnd.updateBranding("{\"primaryColor\":\"" + colour + "\"}"));
+    verify(repository, never()).save(any());
+  }
+
+  /**
+   * @return the resource wired to a real service over the given repository.
+   */
+  private TenantBrandingApiResource resourceBackedBy(final TenantBrandingRepository repository) {
+    ThreadLocalContextUtil.setTenant(
+        FineractPlatformTenant.builder().id(1L).tenantIdentifier("default").build());
+    return new TenantBrandingApiResource(
+        context, new TenantBrandingService(repository), serializer, new FromJsonHelper());
+  }
+
+  @AfterEach
+  void tearDown() {
+    ThreadLocalContextUtil.clearTenant();
   }
 }

--- a/src/test/java/org/apache/fineract/branding/service/TenantBrandingServiceTest.java
+++ b/src/test/java/org/apache/fineract/branding/service/TenantBrandingServiceTest.java
@@ -7,13 +7,16 @@
 package org.apache.fineract.branding.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.List;
 import java.util.Optional;
 import org.apache.fineract.branding.data.TenantBrandingData;
 import org.apache.fineract.branding.domain.TenantBranding;
@@ -24,6 +27,10 @@ import org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 
 class TenantBrandingServiceTest {
@@ -155,14 +162,154 @@ class TenantBrandingServiceTest {
 
   @Test
   void supportedColoursAreLegibleChoicesAndIncludeTheDefault() {
-    // The client renders white label text on these, so the set is deliberately
-    // fixed rather than free form.
+    // The client renders white label text on the named colours, so the set is
+    // deliberately curated rather than free form. Pinned in order: the values
+    // are stored as written, so one may be added but none renamed.
     assertEquals(
-        java.util.List.of("blue", "green", "purple", "orange", "red", "yellow"),
+        List.of(
+            "blue", "green", "purple", "orange", "red", "yellow", "pink", "light-green", "black"),
         TenantBrandingService.SUPPORTED_PRIMARY_COLORS);
-    org.junit.jupiter.api.Assertions.assertTrue(
+    assertTrue(
         TenantBrandingService.SUPPORTED_PRIMARY_COLORS.contains(
             TenantBrandingService.DEFAULT_PRIMARY_COLOR));
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "blue",
+        "green",
+        "purple",
+        "orange",
+        "red",
+        "yellow",
+        "pink",
+        "light-green",
+        "black"
+      })
+  void update_acceptsEverySupportedNamedColour(final String colour) {
+    when(repository.findByTenantId("default")).thenReturn(Optional.empty());
+
+    assertEquals(colour, service.updateCurrentTenantBranding(colour).primaryColor());
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {"#3f51b5", "#FFFFFF", "#000000", "#abcdef", "#ABCDEF", "#FF0000", "#00FF00"})
+  void update_acceptsASixDigitHexColour(final String colour) {
+    // Stored with the case it was given: #FFFFFF and #ffffff are one colour,
+    // and rewriting one into the other would change what a client reads back.
+    when(repository.findByTenantId("default")).thenReturn(Optional.empty());
+
+    assertEquals(colour, service.updateCurrentTenantBranding(colour).primaryColor());
+  }
+
+  @ParameterizedTest
+  @NullSource
+  @ValueSource(
+      strings = {
+        "",
+        "   ",
+        "foobar",
+        "blue123",
+        "123456",
+        "#123",
+        "#12345",
+        "#1234567",
+        "#GGGGGG",
+        "rgb(1,2,3)",
+        "rgba(1,2,3,1)",
+        "red<script>",
+        "javascript:alert(1)",
+        "url(https://example.invalid/x.png)",
+        "var(--brand)",
+        "expression(alert(1))",
+        "#3f51b5; color: red",
+        "#3f51b5 #ffffff"
+      })
+  void update_rejectsAnythingThatIsNotANamedOrHexColour(final String colour) {
+    // The value is dropped into a stylesheet by the clients that read it, so
+    // nothing but a colour may be stored.
+    assertThrows(
+        PlatformApiDataValidationException.class,
+        () -> service.updateCurrentTenantBranding(colour));
+    verify(repository, never()).save(any());
+  }
+
+  @Test
+  void update_rejectsAHexColourCarryingATrailingLineSeparator() {
+    // U+2028 is a terminator Java's `$` honours and String.trim leaves alone,
+    // so a `$` anchored check alone would accept "#3f51b5<U+2028>payload" as a
+    // colour. Pins that the whole value has to be the colour, and keeps the
+    // character out of the source, where it is invisible.
+    final String lineSeparator = Character.toString(0x2028);
+
+    assertThrows(
+        PlatformApiDataValidationException.class,
+        () -> service.updateCurrentTenantBranding("#3f51b5" + lineSeparator));
+    assertThrows(
+        PlatformApiDataValidationException.class,
+        () -> service.updateCurrentTenantBranding("#3f51b5" + lineSeparator + "color: red"));
+    verify(repository, never()).save(any());
+  }
+
+  @Test
+  void update_normalisesTheCaseOfANamedColourButNotOfAHexColour() {
+    when(repository.findByTenantId("default")).thenReturn(Optional.empty());
+
+    assertEquals(
+        "light-green", service.updateCurrentTenantBranding(" LIGHT-GREEN ").primaryColor());
+    assertEquals("#3F51B5", service.updateCurrentTenantBranding("  #3F51B5  ").primaryColor());
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "blue, blue",
+    "pink, pink",
+    "light-green, light-green",
+    "black, black",
+    "'#3f51b5', '#3f51b5'",
+    "'#FFFFFF', '#FFFFFF'",
+    "'  PINK  ', pink",
+    "'  #3f51b5  ', '#3f51b5'",
+    "chartreuse, blue",
+    "'rgb(1,2,3)', blue",
+    "'#12345', blue"
+  })
+  void retrieve_returnsASupportedColourUnchangedAndReplacesTheRest(
+      final String stored, final String expected) {
+    when(repository.findByTenantId("default")).thenReturn(Optional.of(branding("default", stored)));
+
+    assertEquals(expected, service.retrieveCurrentTenantBranding().primaryColor());
+  }
+
+  @Test
+  void retrieve_doesNotTransformAHexColourOnRepeatedReads() {
+    // Guards the failure the clients would see as branding drifting a shade on
+    // every page load: reading has to be idempotent, so feeding a read back in
+    // as the stored value must settle rather than keep changing it.
+    String colour = "#3f51b5";
+    for (int read = 0; read < 5; read++) {
+      when(repository.findByTenantId("default"))
+          .thenReturn(Optional.of(branding("default", colour)));
+      colour = service.retrieveCurrentTenantBranding().primaryColor();
+    }
+
+    assertEquals("#3f51b5", colour);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"blue", "pink", "light-green", "black", "#3f51b5", "#ABCDEF", " BLUE "})
+  void isSupportedPrimaryColor_acceptsNamedAndHexColours(final String colour) {
+    assertTrue(TenantBrandingService.isSupportedPrimaryColor(colour));
+  }
+
+  @ParameterizedTest
+  @NullSource
+  @ValueSource(
+      strings = {"", "   ", "foobar", "blue123", "123456", "#12345", "#GGGGGG", "rgb(1,2,3)"})
+  void isSupportedPrimaryColor_rejectsAnythingElse(final String colour) {
+    assertFalse(TenantBrandingService.isSupportedPrimaryColor(colour));
   }
 
   private static TenantBranding branding(final String tenantId, final String color) {


### PR DESCRIPTION
Extends the `primaryColor` contract on the tenant branding endpoint so the web app can offer more theme colours and a custom colour picker (WEB-1124).

`primaryColor` now accepts either:
- one of nine named colours — `blue`, `green`, `purple`, `orange`, `red`, `yellow`, `pink`, `light-green`, `black`
- or a six digit hex colour, e.g. `#3f51b5`

Anything else is still rejected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tenant branding now supports additional named colours, including pink, light-green, and black.
  * Six-digit hexadecimal colours are supported.
  * Colour names are handled case-insensitively and stored consistently.
  * Input is safely trimmed before validation.

* **Bug Fixes**
  * Invalid or unsupported colours are rejected with clearer validation.
  * Invalid stored colours safely fall back to blue when retrieved.
  * Valid hexadecimal colour casing is preserved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->