### PR TITLE
MX-396 Implement Rate Limit Configuration in the External System Table for Self Service Plugin

### DIFF
--- a/src/main/java/org/apache/fineract/selfservice/config/SelfServiceRateLimitProperties.java
+++ b/src/main/java/org/apache/fineract/selfservice/config/SelfServiceRateLimitProperties.java
@@ -1,31 +1,65 @@
 package org.apache.fineract.selfservice.config;
 
-import jakarta.validation.constraints.Positive;
-import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.validation.annotation.Validated;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.fineract.infrastructure.configuration.data.ExternalServiceConfigurationData;
+import org.apache.fineract.infrastructure.configuration.service.ExternalServiceConfigurationService;
+import org.springframework.stereotype.Component;
 
 /**
  * Configuration properties for self-service rate limiting.
- * Binds to properties prefixed with "fineract.selfservice.security.rate-limit".
- *
- * @param perResource   Maximum allowed attempts per specific resource (e.g. account ID) within the time window. Fallback is 10.
- * @param global        Maximum allowed total attempts across all resources for the user within the time window. Fallback is 25.
- * @param windowMinutes The rolling time window in minutes for which limits are evaluated. Fallback is 15.
- * @param retentionDays The number of days to retain access audit records before purging. Fallback is 30.
+ * Fetches values dynamically from the c_external_service and c_external_service_properties tables.
  */
-@Validated
-@ConfigurationProperties(prefix = "fineract.selfservice.security.rate-limit")
-public record SelfServiceRateLimitProperties(
-    @Positive int perResource,
-    @Positive int global,
-    @Positive int windowMinutes,
-    @Positive int retentionDays
-) {
-  public SelfServiceRateLimitProperties {
-    // defaults
-    if (perResource <= 0) perResource = 10;
-    if (global <= 0) global = 25;
-    if (windowMinutes <= 0) windowMinutes = 15;
-    if (retentionDays <= 0) retentionDays = 30;
-  }
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class SelfServiceRateLimitProperties {
+
+    private final ExternalServiceConfigurationService externalServiceConfigurationService;
+    private static final String SERVICE_NAME = "SELF_SERVICE_RATE_LIMIT";
+
+    /**
+     * @return Maximum allowed attempts per specific resource (e.g. account ID) within the time window. Fallback is 10.
+     */
+    public int perResource() {
+        return getIntProperty("perResource", 10);
+    }
+
+    /**
+     * @return Maximum allowed total attempts across all resources for the user within the time window. Fallback is 25.
+     */
+    public int global() {
+        return getIntProperty("global", 25);
+    }
+
+    /**
+     * @return The rolling time window in minutes for which limits are evaluated. Fallback is 15.
+     */
+    public int windowMinutes() {
+        return getIntProperty("windowMinutes", 15);
+    }
+
+    /**
+     * @return The number of days to retain access audit records before purging. Fallback is 30.
+     */
+    public int retentionDays() {
+        return getIntProperty("retentionDays", 30);
+    }
+
+    private int getIntProperty(String key, int defaultValue) {
+        try {
+            ExternalServiceConfigurationData config = externalServiceConfigurationService.getConfiguration(SERVICE_NAME);
+            if (config != null && config.getProperties().containsKey(key)) {
+                int parsedValue = Integer.parseInt(config.get(key));
+                if (parsedValue > 0) {
+                    return parsedValue;
+                } else {
+                    log.warn("Rate limit property '{}' must be greater than zero, but was {}. Falling back to default {}", key, parsedValue, defaultValue);
+                }
+            }
+        } catch (Exception e) {
+            log.warn("Failed to fetch or parse rate limit property '{}' from external service configuration, falling back to default {}", key, defaultValue);
+        }
+        return defaultValue;
+    }
 }

--- a/src/main/java/org/apache/fineract/selfservice/security/starter/SelfServiceSecurityConfiguration.java
+++ b/src/main/java/org/apache/fineract/selfservice/security/starter/SelfServiceSecurityConfiguration.java
@@ -64,11 +64,7 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
-import org.apache.fineract.selfservice.config.SelfServiceRateLimitProperties;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
-
 @Configuration
-@EnableConfigurationProperties(SelfServiceRateLimitProperties.class)
 @Order(1) // Very important: Must have higher priority than main security config
 public class SelfServiceSecurityConfiguration {
 

--- a/src/main/resources/db/changelog/tenant/module/selfservice/module-changelog-master.xml
+++ b/src/main/resources/db/changelog/tenant/module/selfservice/module-changelog-master.xml
@@ -86,4 +86,5 @@
   <!-- Security: ownership guard audit table and permissions (from security hardening) -->
   <include file="parts/073-add-access-audit.xml" relativeToChangelogFile="true"/>  
   <include file="parts/074-create-ownership-guard-permissions.xml" relativeToChangelogFile="true"/>
+  <include file="parts/075-add-rate-limit-config.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/tenant/module/selfservice/parts/075-add-rate-limit-config.xml
+++ b/src/main/resources/db/changelog/tenant/module/selfservice/parts/075-add-rate-limit-config.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright since 2026 Mifos Initiative
+ <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+-->
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
+
+    <changeSet id="ss-0075-1-1" author="fineract">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <sqlCheck expectedResult="1">
+                    SELECT COUNT(*) FROM c_external_service WHERE name = 'SELF_SERVICE_RATE_LIMIT'
+                </sqlCheck>
+            </not>
+        </preConditions>
+        
+        <insert tableName="c_external_service">
+            <column name="name" value="SELF_SERVICE_RATE_LIMIT"/>
+        </insert>
+    </changeSet>
+
+    <changeSet id="ss-0075-1-2" author="fineract">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">
+                SELECT COUNT(*) FROM c_external_service_properties esp 
+                WHERE esp.external_service_id = (SELECT id FROM c_external_service WHERE name = 'SELF_SERVICE_RATE_LIMIT')
+            </sqlCheck>
+        </preConditions>
+
+        <!-- perResource: Maximum allowed attempts per specific resource (e.g. account ID) within the time window -->
+        <insert tableName="c_external_service_properties">
+            <column name="external_service_id" valueComputed="(SELECT id FROM c_external_service WHERE name='SELF_SERVICE_RATE_LIMIT')"/>
+            <column name="name" value="perResource"/>
+            <column name="value" value="10"/>
+        </insert>
+        
+        <!-- global: Maximum allowed total attempts across all resources for the user within the time window -->
+        <insert tableName="c_external_service_properties">
+            <column name="external_service_id" valueComputed="(SELECT id FROM c_external_service WHERE name='SELF_SERVICE_RATE_LIMIT')"/>
+            <column name="name" value="global"/>
+            <column name="value" value="25"/>
+        </insert>
+        
+        <!-- windowMinutes: The rolling time window in minutes for which limits are evaluated -->
+        <insert tableName="c_external_service_properties">
+            <column name="external_service_id" valueComputed="(SELECT id FROM c_external_service WHERE name='SELF_SERVICE_RATE_LIMIT')"/>
+            <column name="name" value="windowMinutes"/>
+            <column name="value" value="15"/>
+        </insert>
+        
+        <!-- retentionDays: The number of days to retain access audit records before purging -->
+        <insert tableName="c_external_service_properties">
+            <column name="external_service_id" valueComputed="(SELECT id FROM c_external_service WHERE name='SELF_SERVICE_RATE_LIMIT')"/>
+            <column name="name" value="retentionDays"/>
+            <column name="value" value="30"/>
+        </insert>
+    </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
# Description

This PR moves the self-service rate limit configuration from static application properties to the database. This makes the configuration dynamic and allows different tenants to have their own rate limits without needing a server restart.

## Key Changes

- Added `075-add-rate-limit-config.xml` to create the `SELF_SERVICE_RATE_LIMIT` configuration with default values for `perResource`, `global`, `windowMinutes`, and `retentionDays`.
- Changed `SelfServiceRateLimitProperties` from a properties record to a Spring `@Component`.
- Added `ExternalServiceConfigurationService` to fetch the rate limit values at runtime.
- Kept fallback default values in place so the rate limiter still works if the database configuration is unavailable.

## Verification

- Ran `./mvnw clean compile test-compile` successfully.
- Verified that the Spring application context starts correctly and the configuration bindings work after removing `@EnableConfigurationProperties`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable self-service rate limits for individual resources and overall usage.
  * Introduced a 15-minute evaluation window and 30-day audit retention period.
  * Rate-limit settings now support external configuration with fallback defaults when unavailable or invalid.
* **Bug Fixes**
  * Improved resilience when rate-limit configuration cannot be retrieved or parsed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->